### PR TITLE
Switch to synchronous workflow

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -7,5 +7,6 @@ return [
 		['name' => 'config#setAdminConfig', 'url' => '/admin-config', 'verb' => 'PUT'],
 
 		['name' => 'assistant#getTaskResultPage', 'url' => '/t/{taskId}', 'verb' => 'GET'],
+		['name' => 'assistant#runTask', 'url' => '/run', 'verb' => 'POST'],
 	],
 ];

--- a/lib/Controller/AssistantController.php
+++ b/lib/Controller/AssistantController.php
@@ -61,10 +61,12 @@ class AssistantController extends Controller {
 	#[NoAdminRequired]
 	public function runTask(string $type, string $input, string $appId, string $identifier): DataResponse {
 		try {
-			$output = $this->assistantService->runTask($type, $input, $appId, $this->userId, $identifier);
+			$task = $this->assistantService->runTask($type, $input, $appId, $this->userId, $identifier);
 		} catch (\Exception | \Throwable $e) {
 			return new DataResponse($e->getMessage(), Http::STATUS_BAD_REQUEST);
 		}
-		return new DataResponse($output);
+		return new DataResponse([
+			'task' => $task->jsonSerialize(),
+		]);
 	}
 }

--- a/lib/Controller/AssistantController.php
+++ b/lib/Controller/AssistantController.php
@@ -8,6 +8,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IRequest;
@@ -48,5 +49,22 @@ class AssistantController extends Controller {
 		}
 		$this->initialStateService->provideInitialState('task', $task->jsonSerialize());
 		return new TemplateResponse(Application::APP_ID, 'taskResultPage');
+	}
+
+	/**
+	 * @param string $input
+	 * @param string $type
+	 * @param string $appId
+	 * @param string $identifier
+	 * @return DataResponse
+	 */
+	#[NoAdminRequired]
+	public function runTask(string $type, string $input, string $appId, string $identifier): DataResponse {
+		try {
+			$output = $this->assistantService->runTask($type, $input, $appId, $this->userId, $identifier);
+		} catch (\Exception | \Throwable $e) {
+			return new DataResponse($e->getMessage(), Http::STATUS_BAD_REQUEST);
+		}
+		return new DataResponse($output);
 	}
 }

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -70,11 +70,12 @@ class AssistantService {
 	 * @param string $appId
 	 * @param string|null $userId
 	 * @param string $identifier
-	 * @return string
+	 * @return Task
 	 * @throws PreConditionNotMetException
 	 */
-	public function runTask(string $type, string $input, string $appId, ?string $userId, string $identifier): string {
+	public function runTask(string $type, string $input, string $appId, ?string $userId, string $identifier): Task {
 		$task = new Task($type, $input, $appId, $userId, $identifier);
-		return $this->textProcessingManager->runTask($task);
+		$this->textProcessingManager->runTask($task);
+		return $task;
 	}
 }

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -5,6 +5,7 @@ namespace OCA\TPAssistant\Service;
 use DateTime;
 use OCA\TPAssistant\AppInfo\Application;
 use OCP\Common\Exception\NotFoundException;
+use OCP\PreConditionNotMetException;
 use OCP\TextProcessing\IManager as ITextProcessingManager;
 use OCP\TextProcessing\Task;
 use OCP\Notification\IManager as INotificationManager;
@@ -61,5 +62,19 @@ class AssistantService {
 			return null;
 		}
 		return $task;
+	}
+
+	/**
+	 * @param string $type
+	 * @param string $input
+	 * @param string $appId
+	 * @param string|null $userId
+	 * @param string $identifier
+	 * @return string
+	 * @throws PreConditionNotMetException
+	 */
+	public function runTask(string $type, string $input, string $appId, ?string $userId, string $identifier): string {
+		$task = new Task($type, $input, $appId, $userId, $identifier);
+		return $this->textProcessingManager->runTask($task);
 	}
 }

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -88,7 +88,7 @@ export async function openAssistantForm({ appId, identifier = '', taskType = nul
 				})
 		})
 		view.$on('cancel-sync-n-schedule', () => {
-			window.assistantAbortController.abort()
+			cancelCurrentSyncTask()
 			scheduleTask(appId, identifier, view.selectedTaskTypeId, view.input)
 				.then((response) => {
 					view.showSyncTaskRunning = false
@@ -102,6 +102,10 @@ export async function openAssistantForm({ appId, identifier = '', taskType = nul
 				})
 		})
 	})
+}
+
+export async function cancelCurrentSyncTask() {
+	window.assistantAbortController?.abort()
 }
 
 export async function runTask(appId, identifier, taskType, input) {

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -66,8 +66,8 @@ export async function openAssistantForm({ appId, identifier = '', taskType = nul
 			view.loading = true
 			runTask(appId, identifier, data.taskTypeId, data.input)
 				.then((response) => {
-					resolve({ output: response.data })
-					view.output = response.data
+					resolve(response.data?.task)
+					view.output = response.data?.task?.output
 				})
 				.catch(error => {
 					view.$destroy()

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -84,7 +84,7 @@ export async function openAssistantForm({ appId, identifier = '', taskType = nul
 export async function runTask(appId, identifier, taskType, input) {
 	const { default: axios } = await import(/* webpackChunkName: "axios-lazy" */'@nextcloud/axios')
 	const { generateUrl } = await import(/* webpackChunkName: "router-gen-lazy" */'@nextcloud/router')
-	const url = generateUrl('/apps/textprocessing_assistant/run')
+	const url = generateUrl('/apps/assistant/run')
 	const params = {
 		input,
 		type: taskType,

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -62,7 +62,36 @@ export async function openAssistantForm({ appId, identifier = '', taskType = nul
 					reject(new Error('Assistant scheduling error'))
 				})
 		})
+		view.$on('sync-submit', (data) => {
+			view.loading = true
+			runTask(appId, identifier, data.taskTypeId, data.input)
+				.then((response) => {
+					resolve({ output: response.data })
+					view.output = response.data
+				})
+				.catch(error => {
+					view.$destroy()
+					console.error('Assistant scheduling error', error)
+					reject(new Error('Assistant scheduling error'))
+				})
+				.then(() => {
+					view.loading = false
+				})
+		})
 	})
+}
+
+export async function runTask(appId, identifier, taskType, input) {
+	const { default: axios } = await import(/* webpackChunkName: "axios-lazy" */'@nextcloud/axios')
+	const { generateUrl } = await import(/* webpackChunkName: "router-gen-lazy" */'@nextcloud/router')
+	const url = generateUrl('/apps/textprocessing_assistant/run')
+	const params = {
+		input,
+		type: taskType,
+		appId,
+		identifier,
+	}
+	return axios.post(url, params)
 }
 
 /**

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -253,6 +253,44 @@ export async function openAssistantResult(task) {
 				showError(t('assistant', 'Failed to schedule the task'))
 			})
 	})
+	view.$on('sync-submit', (data) => {
+		view.loading = true
+		view.showSyncTaskRunning = true
+		view.input = data.input
+		view.selectedTaskTypeId = data.taskTypeId
+		runTask(task.appId, task.identifier, data.taskTypeId, data.input)
+			.then((response) => {
+				// resolve(response.data?.task)
+				view.output = response.data?.task?.output
+				view.loading = false
+				view.showSyncTaskRunning = false
+			})
+			.catch(error => {
+				if (error?.code === 'ERR_CANCELED') {
+					view.output = ''
+				} else {
+					view.$destroy()
+					console.error('Assistant sync run error', error)
+					// reject(new Error('Assistant sync run error'))
+				}
+			})
+			.then(() => {
+			})
+	})
+	view.$on('cancel-sync-n-schedule', () => {
+		cancelCurrentSyncTask()
+		scheduleTask(task.appId, task.identifier, view.selectedTaskTypeId, view.input)
+			.then((response) => {
+				view.showSyncTaskRunning = false
+				view.showScheduleConfirmation = true
+				// resolve(response.data?.ocs?.data?.task)
+			})
+			.catch(error => {
+				view.$destroy()
+				console.error('Assistant scheduling error', error)
+				// reject(new Error('Assistant scheduling error'))
+			})
+	})
 }
 
 export async function addAssistantMenuEntry() {

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -42,6 +42,7 @@ export async function openAssistantForm({ appId, identifier = '', taskType = nul
 				input,
 				selectedTaskTypeId,
 				showScheduleConfirmation: false,
+				showSyncTaskRunning: false,
 			},
 		}).$mount(modalElement)
 
@@ -64,26 +65,50 @@ export async function openAssistantForm({ appId, identifier = '', taskType = nul
 		})
 		view.$on('sync-submit', (data) => {
 			view.loading = true
+			view.showSyncTaskRunning = true
+			view.input = data.input
+			view.selectedTaskTypeId = data.taskTypeId
 			runTask(appId, identifier, data.taskTypeId, data.input)
 				.then((response) => {
 					resolve(response.data?.task)
 					view.output = response.data?.task?.output
+					view.loading = false
+					view.showSyncTaskRunning = false
+				})
+				.catch(error => {
+					if (error?.code === 'ERR_CANCELED') {
+						view.output = ''
+					} else {
+						view.$destroy()
+						console.error('Assistant sync run error', error)
+						reject(new Error('Assistant sync run error'))
+					}
+				})
+				.then(() => {
+				})
+		})
+		view.$on('cancel-sync-n-schedule', () => {
+			window.assistantAbortController.abort()
+			scheduleTask(appId, identifier, view.selectedTaskTypeId, view.input)
+				.then((response) => {
+					view.showSyncTaskRunning = false
+					view.showScheduleConfirmation = true
+					resolve(response.data?.ocs?.data?.task)
 				})
 				.catch(error => {
 					view.$destroy()
 					console.error('Assistant scheduling error', error)
 					reject(new Error('Assistant scheduling error'))
 				})
-				.then(() => {
-					view.loading = false
-				})
 		})
 	})
 }
 
 export async function runTask(appId, identifier, taskType, input) {
+	window.assistantAbortController = new AbortController()
 	const { default: axios } = await import(/* webpackChunkName: "axios-lazy" */'@nextcloud/axios')
 	const { generateUrl } = await import(/* webpackChunkName: "router-gen-lazy" */'@nextcloud/router')
+	saveLastSelectedTaskType(taskType)
 	const url = generateUrl('/apps/assistant/run')
 	const params = {
 		input,
@@ -91,7 +116,7 @@ export async function runTask(appId, identifier, taskType, input) {
 		appId,
 		identifier,
 	}
-	return axios.post(url, params)
+	return axios.post(url, params, { signal: window.assistantAbortController.signal })
 }
 
 /**

--- a/src/components/AssistantForm.vue
+++ b/src/components/AssistantForm.vue
@@ -66,7 +66,7 @@
 					<CreationIcon v-else />
 				</template>
 			</NcButton>
-			<NcButton
+			<!--NcButton
 				v-if="showSubmit"
 				:type="submitButtonType"
 				class="submit-button"
@@ -78,7 +78,7 @@
 				<template #icon>
 					<CreationIcon />
 				</template>
-			</NcButton>
+			</NcButton-->
 			<NcButton
 				v-if="showCopy"
 				type="primary"

--- a/src/components/AssistantForm.vue
+++ b/src/components/AssistantForm.vue
@@ -57,8 +57,22 @@
 				:type="submitButtonType"
 				class="submit-button"
 				:disabled="!canSubmit"
-				:aria-label="t('assistant', 'Submit assistant task')"
-				:title="t('assistant', 'Submit')"
+				:aria-label="t('textprocessing_assistant', 'Run an assistant task')"
+				:title="t('textprocessing_assistant', 'Run')"
+				@click="onSyncSubmit">
+				{{ syncSubmitButtonLabel }}
+				<template #icon>
+					<NcLoadingIcon v-if="loading" />
+					<CreationIcon v-else />
+				</template>
+			</NcButton>
+			<NcButton
+				v-if="showSubmit"
+				:type="submitButtonType"
+				class="submit-button"
+				:disabled="!canSubmit"
+				:aria-label="t('textprocessing_assistant', 'Schedule an assistant task')"
+				:title="t('textprocessing_assistant', 'Schedule')"
 				@click="onSubmit">
 				{{ submitButtonLabel }}
 				<template #icon>
@@ -87,6 +101,7 @@ import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 import ClipboardCheckOutlineIcon from 'vue-material-design-icons/ClipboardCheckOutline.vue'
 import CreationIcon from 'vue-material-design-icons/Creation.vue'
 
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContenteditable.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
@@ -107,12 +122,17 @@ export default {
 		TaskTypeSelect,
 		NcButton,
 		NcRichContenteditable,
+		NcLoadingIcon,
 		CreationIcon,
 		ContentCopyIcon,
 		ClipboardCheckOutlineIcon,
 		NcNoteCard,
 	},
 	props: {
+		loading: {
+			type: Boolean,
+			default: false,
+		},
 		input: {
 			type: String,
 			default: '',
@@ -134,7 +154,6 @@ export default {
 		return {
 			myInput: this.input,
 			myOutput: this.output,
-			loading: false,
 			taskTypes: [],
 			mySelectedTaskTypeId: this.selectedTaskTypeId,
 			copied: false,
@@ -163,8 +182,16 @@ export default {
 					? t('assistant', 'Send request')
 					: this.selectedTaskType.name
 		},
+		syncSubmitButtonLabel() {
+			return this.myOutput.trim() ? t('textprocessing_assistant', 'Try again') : this.selectedTaskType.name
+		},
 		showCopy() {
 			return !!this.myOutput.trim()
+		},
+	},
+	watch: {
+		output(newVal) {
+			this.myOutput = newVal
 		},
 	},
 	mounted() {
@@ -179,15 +206,15 @@ export default {
 				.catch((error) => {
 					console.error(error)
 				})
-				.then(() => {
-					this.loading = false
-				})
 		},
 		onCancel() {
 			this.$emit('cancel')
 		},
 		onSubmit() {
 			this.$emit('submit', { input: this.myInput.trim(), taskTypeId: this.mySelectedTaskTypeId })
+		},
+		onSyncSubmit() {
+			this.$emit('sync-submit', { input: this.myInput.trim(), taskTypeId: this.mySelectedTaskTypeId })
 		},
 		async onCopy() {
 			try {

--- a/src/components/AssistantForm.vue
+++ b/src/components/AssistantForm.vue
@@ -147,7 +147,7 @@ export default {
 		},
 	},
 	emits: [
-		'cancel',
+		'sync-submit',
 		'submit',
 	],
 	data() {
@@ -206,9 +206,6 @@ export default {
 				.catch((error) => {
 					console.error(error)
 				})
-		},
-		onCancel() {
-			this.$emit('cancel')
 		},
 		onSubmit() {
 			this.$emit('submit', { input: this.myInput.trim(), taskTypeId: this.mySelectedTaskTypeId })

--- a/src/components/AssistantForm.vue
+++ b/src/components/AssistantForm.vue
@@ -261,6 +261,7 @@ export default {
 	}
 
 	.output {
+		width: 100%;
 		display: flex;
 		flex-direction: column;
 		align-items: start;
@@ -307,7 +308,7 @@ export default {
 	}
 
 	.warning-note {
-		width: 100%;
+		align-self: normal;
 	}
 }
 </style>

--- a/src/components/AssistantForm.vue
+++ b/src/components/AssistantForm.vue
@@ -57,8 +57,8 @@
 				:type="submitButtonType"
 				class="submit-button"
 				:disabled="!canSubmit"
-				:aria-label="t('textprocessing_assistant', 'Run an assistant task')"
-				:title="t('textprocessing_assistant', 'Run')"
+				:aria-label="t('assistant', 'Run an assistant task')"
+				:title="t('assistant', 'Run')"
 				@click="onSyncSubmit">
 				{{ syncSubmitButtonLabel }}
 				<template #icon>
@@ -71,8 +71,8 @@
 				:type="submitButtonType"
 				class="submit-button"
 				:disabled="!canSubmit"
-				:aria-label="t('textprocessing_assistant', 'Schedule an assistant task')"
-				:title="t('textprocessing_assistant', 'Schedule')"
+				:aria-label="t('assistant', 'Schedule an assistant task')"
+				:title="t('assistant', 'Schedule')"
 				@click="onSubmit">
 				{{ submitButtonLabel }}
 				<template #icon>
@@ -183,7 +183,7 @@ export default {
 					: this.selectedTaskType.name
 		},
 		syncSubmitButtonLabel() {
-			return this.myOutput.trim() ? t('textprocessing_assistant', 'Try again') : this.selectedTaskType.name
+			return this.myOutput.trim() ? t('assistant', 'Try again') : this.selectedTaskType.name
 		},
 		showCopy() {
 			return !!this.myOutput.trim()

--- a/src/components/AssistantModal.vue
+++ b/src/components/AssistantModal.vue
@@ -17,7 +17,25 @@
 					</template>
 				</NcButton>
 				<NcEmptyContent
-					v-if="showScheduleConfirmation"
+					v-if="showSyncTaskRunning"
+					:title="t('assistant', 'Your task is running')"
+					:name="t('assistant', 'Your task is running')"
+					:description="t('assistant', 'If it takes too long...')">
+					<template #action>
+						<NcButton
+							@click="onCancelNSchedule">
+							<template #icon>
+								<CloseIcon />
+							</template>
+							{{ t('assistant', 'Run in the background') }}
+						</NcButton>
+					</template>
+					<template #icon>
+						<NcLoadingIcon />
+					</template>
+				</NcEmptyContent>
+				<NcEmptyContent
+					v-else-if="showScheduleConfirmation"
 					:title="t('assistant', 'Your task has been scheduled, you will receive a notification when it has finished')"
 					:name="t('assistant', 'Your task has been scheduled, you will receive a notification when it has finished')"
 					:description="shortInput">
@@ -54,6 +72,7 @@ import CloseIcon from 'vue-material-design-icons/Close.vue'
 
 import AssistantIcon from './icons/AssistantIcon.vue'
 
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
@@ -71,6 +90,7 @@ export default {
 		NcButton,
 		NcEmptyContent,
 		CloseIcon,
+		NcLoadingIcon,
 	},
 	props: {
 		/**
@@ -95,6 +115,10 @@ export default {
 		selectedTaskTypeId: {
 			type: [String, null],
 			default: null,
+		},
+		showSyncTaskRunning: {
+			type: Boolean,
+			required: true,
 		},
 		showScheduleConfirmation: {
 			type: Boolean,
@@ -138,6 +162,9 @@ export default {
 		},
 		onSyncSubmit(params) {
 			this.$emit('sync-submit', params)
+		},
+		onCancelNSchedule() {
+			this.$emit('cancel-sync-n-schedule')
 		},
 	},
 }

--- a/src/components/AssistantModal.vue
+++ b/src/components/AssistantModal.vue
@@ -40,8 +40,10 @@
 					:input="input"
 					:output="output"
 					:selected-task-type-id="selectedTaskTypeId"
+					:loading="loading"
 					@cancel="onCancel"
-					@submit="onSubmit" />
+					@submit="onSubmit"
+					@sync-submit="onSyncSubmit" />
 			</div>
 		</div>
 	</NcModal>
@@ -75,6 +77,10 @@ export default {
 		 * If true, add the modal content to the Viewer trap elements via the event-bus
 		 */
 		isInsideViewer: {
+			type: Boolean,
+			default: false,
+		},
+		loading: {
 			type: Boolean,
 			default: false,
 		},
@@ -129,6 +135,9 @@ export default {
 		onSubmit(params) {
 			// this.show = false
 			this.$emit('submit', params)
+		},
+		onSyncSubmit(params) {
+			this.$emit('sync-submit', params)
 		},
 	},
 }

--- a/src/components/AssistantModal.vue
+++ b/src/components/AssistantModal.vue
@@ -16,42 +16,14 @@
 						<CloseIcon />
 					</template>
 				</NcButton>
-				<NcEmptyContent
+				<RunningEmptyContent
 					v-if="showSyncTaskRunning"
-					:title="t('assistant', 'Your task is running')"
-					:name="t('assistant', 'Your task is running')"
-					:description="t('assistant', 'If it takes too long...')">
-					<template #action>
-						<NcButton
-							@click="onCancelNSchedule">
-							<template #icon>
-								<CloseIcon />
-							</template>
-							{{ t('assistant', 'Run in the background') }}
-						</NcButton>
-					</template>
-					<template #icon>
-						<NcLoadingIcon />
-					</template>
-				</NcEmptyContent>
-				<NcEmptyContent
+					@cancel="onCancelNSchedule" />
+				<ScheduledEmptyContent
 					v-else-if="showScheduleConfirmation"
-					:title="t('assistant', 'Your task has been scheduled, you will receive a notification when it has finished')"
-					:name="t('assistant', 'Your task has been scheduled, you will receive a notification when it has finished')"
-					:description="shortInput">
-					<template #action>
-						<NcButton
-							@click="onCancel">
-							<template #icon>
-								<CloseIcon />
-							</template>
-							{{ t('assistant', 'Close') }}
-						</NcButton>
-					</template>
-					<template #icon>
-						<AssistantIcon />
-					</template>
-				</NcEmptyContent>
+					:description="shortInput"
+					:show-close-button="true"
+					@close="onCancel" />
 				<AssistantForm
 					v-else
 					class="form"
@@ -59,7 +31,6 @@
 					:output="output"
 					:selected-task-type-id="selectedTaskTypeId"
 					:loading="loading"
-					@cancel="onCancel"
 					@submit="onSubmit"
 					@sync-submit="onSyncSubmit" />
 			</div>
@@ -70,27 +41,24 @@
 <script>
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 
-import AssistantIcon from './icons/AssistantIcon.vue'
-
-import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 
 import AssistantForm from './AssistantForm.vue'
+import RunningEmptyContent from './RunningEmptyContent.vue'
+import ScheduledEmptyContent from './ScheduledEmptyContent.vue'
 
 import { emit } from '@nextcloud/event-bus'
 
 export default {
 	name: 'AssistantModal',
 	components: {
-		AssistantIcon,
+		ScheduledEmptyContent,
+		RunningEmptyContent,
 		AssistantForm,
 		NcModal,
 		NcButton,
-		NcEmptyContent,
 		CloseIcon,
-		NcLoadingIcon,
 	},
 	props: {
 		/**
@@ -118,7 +86,7 @@ export default {
 		},
 		showSyncTaskRunning: {
 			type: Boolean,
-			required: true,
+			default: false,
 		},
 		showScheduleConfirmation: {
 			type: Boolean,

--- a/src/components/AssistantModal.vue
+++ b/src/components/AssistantModal.vue
@@ -18,6 +18,7 @@
 				</NcButton>
 				<RunningEmptyContent
 					v-if="showSyncTaskRunning"
+					:description="shortInput"
 					@cancel="onCancelNSchedule" />
 				<ScheduledEmptyContent
 					v-else-if="showScheduleConfirmation"

--- a/src/components/RunningEmptyContent.vue
+++ b/src/components/RunningEmptyContent.vue
@@ -1,14 +1,11 @@
 <template>
 	<NcEmptyContent
-		:title="t('assistant', 'Your task is running')"
-		:name="t('assistant', 'Your task is running')"
-		:description="t('assistant', 'If it takes too long...')">
+		:title="t('assistant', 'Getting results…')"
+		:name="t('assistant', 'Getting results…')"
+		:description="description">
 		<template #action>
 			<NcButton
 				@click="$emit('cancel')">
-				<template #icon>
-					<CloseIcon />
-				</template>
 				{{ t('assistant', 'Run in the background') }}
 			</NcButton>
 		</template>
@@ -19,8 +16,6 @@
 </template>
 
 <script>
-import CloseIcon from 'vue-material-design-icons/Close.vue'
-
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
@@ -31,11 +26,14 @@ export default {
 	components: {
 		NcButton,
 		NcEmptyContent,
-		CloseIcon,
 		NcLoadingIcon,
 	},
 
 	props: {
+		description: {
+			type: String,
+			required: true,
+		},
 	},
 
 	emits: [

--- a/src/components/RunningEmptyContent.vue
+++ b/src/components/RunningEmptyContent.vue
@@ -1,0 +1,63 @@
+<template>
+	<NcEmptyContent
+		:title="t('assistant', 'Your task is running')"
+		:name="t('assistant', 'Your task is running')"
+		:description="t('assistant', 'If it takes too long...')">
+		<template #action>
+			<NcButton
+				@click="$emit('cancel')">
+				<template #icon>
+					<CloseIcon />
+				</template>
+				{{ t('assistant', 'Run in the background') }}
+			</NcButton>
+		</template>
+		<template #icon>
+			<NcLoadingIcon />
+		</template>
+	</NcEmptyContent>
+</template>
+
+<script>
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
+
+export default {
+	name: 'RunningEmptyContent',
+
+	components: {
+		NcButton,
+		NcEmptyContent,
+		CloseIcon,
+		NcLoadingIcon,
+	},
+
+	props: {
+	},
+
+	emits: [
+		'cancel',
+	],
+
+	data() {
+		return {
+		}
+	},
+
+	computed: {
+	},
+
+	mounted() {
+	},
+
+	methods: {
+	},
+}
+</script>
+
+<style lang="scss">
+// nothing yet
+</style>

--- a/src/components/ScheduledEmptyContent.vue
+++ b/src/components/ScheduledEmptyContent.vue
@@ -1,0 +1,73 @@
+<template>
+	<NcEmptyContent
+		:title="title"
+		:name="title"
+		:description="description">
+		<template v-if="showCloseButton" #action>
+			<NcButton
+				@click="$emit('close')">
+				<template #icon>
+					<CloseIcon />
+				</template>
+				{{ t('assistant', 'Close') }}
+			</NcButton>
+		</template>
+		<template #icon>
+			<AssistantIcon />
+		</template>
+	</NcEmptyContent>
+</template>
+
+<script>
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+
+import AssistantIcon from './icons/AssistantIcon.vue'
+
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
+
+export default {
+	name: 'ScheduledEmptyContent',
+
+	components: {
+		AssistantIcon,
+		NcButton,
+		NcEmptyContent,
+		CloseIcon,
+	},
+
+	props: {
+		description: {
+			type: String,
+			required: true,
+		},
+		showCloseButton: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: [
+		'cancel',
+	],
+
+	data() {
+		return {
+			title: t('assistant', 'Your task has been scheduled, you will receive a notification when it has finished'),
+		}
+	},
+
+	computed: {
+	},
+
+	mounted() {
+	},
+
+	methods: {
+	},
+}
+</script>
+
+<style lang="scss">
+// nothing yet
+</style>

--- a/src/components/ScheduledEmptyContent.vue
+++ b/src/components/ScheduledEmptyContent.vue
@@ -2,9 +2,10 @@
 	<NcEmptyContent
 		:title="title"
 		:name="title"
-		:description="description">
+		:description="t('assistant', 'You will receive a notification when it has finished')">
 		<template v-if="showCloseButton" #action>
 			<NcButton
+				type="tertiary"
 				@click="$emit('close')">
 				<template #icon>
 					<CloseIcon />
@@ -53,7 +54,7 @@ export default {
 
 	data() {
 		return {
-			title: t('assistant', 'Your task has been scheduled, you will receive a notification when it has finished'),
+			title: t('assistant', 'Your task has been scheduled'),
 		}
 	},
 

--- a/src/views/TaskResultPage.vue
+++ b/src/views/TaskResultPage.vue
@@ -3,15 +3,13 @@
 		<NcAppContent>
 			<div v-if="task?.id"
 				class="assistant-wrapper">
-				<NcEmptyContent
-					v-if="showScheduleConfirmation"
-					:title="t('assistant', 'Your task has been scheduled, you will receive a notification when it has finished')"
-					:name="t('assistant', 'Your task has been scheduled, you will receive a notification when it has finished')"
-					:description="shortInput">
-					<template #icon>
-						<AssistantIcon />
-					</template>
-				</NcEmptyContent>
+				<RunningEmptyContent
+					v-if="showSyncTaskRunning"
+					@cancel="onCancelNSchedule" />
+				<ScheduledEmptyContent
+					v-else-if="showScheduleConfirmation"
+					:description="shortInput"
+					:show-close-button="false" />
 				<AssistantForm
 					v-else
 					class="form"
@@ -27,27 +25,26 @@
 </template>
 
 <script>
-import AssistantIcon from '../components/icons/AssistantIcon.vue'
-
 import NcContent from '@nextcloud/vue/dist/Components/NcContent.js'
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent.js'
-import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 
 import AssistantForm from '../components/AssistantForm.vue'
+import RunningEmptyContent from '../components/RunningEmptyContent.vue'
+import ScheduledEmptyContent from '../components/ScheduledEmptyContent.vue'
 
 import { showError } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
-import { scheduleTask, runTask } from '../assistant.js'
+import { scheduleTask, runTask, cancelCurrentSyncTask } from '../assistant.js'
 
 export default {
 	name: 'TaskResultPage',
 
 	components: {
-		AssistantIcon,
+		ScheduledEmptyContent,
+		RunningEmptyContent,
 		AssistantForm,
 		NcContent,
 		NcAppContent,
-		NcEmptyContent,
 	},
 
 	props: {
@@ -56,6 +53,7 @@ export default {
 	data() {
 		return {
 			task: loadState('assistant', 'task'),
+			showSyncTaskRunning: false,
 			showScheduleConfirmation: false,
 			loading: false,
 		}
@@ -74,6 +72,19 @@ export default {
 	},
 
 	methods: {
+		onCancelNSchedule() {
+			cancelCurrentSyncTask()
+			scheduleTask(this.task.appId, this.task.identifier, this.task.type, this.task.input)
+				.then((response) => {
+					this.showSyncTaskRunning = false
+					this.showScheduleConfirmation = true
+					console.debug('scheduled task', response.data?.ocs?.data?.task)
+				})
+				.catch(error => {
+					console.error('Assistant scheduling error', error)
+					showError(t('assistant', 'Failed to schedule your task'))
+				})
+		},
 		onSubmit(data) {
 			scheduleTask(this.task.appId, this.task.identifier, data.taskTypeId, data.input)
 				.then((response) => {
@@ -87,16 +98,19 @@ export default {
 				})
 		},
 		onSyncSubmit(data) {
-			this.loading = true
+			this.showSyncTaskRunning = true
+			this.task.input = data.input
+			this.task.type = data.taskTypeId
 			runTask(this.task.appId, this.task.identifier, data.taskTypeId, data.input)
 				.then((response) => {
-					this.task.output = response.data
+					this.task.output = response.data?.task?.output ?? ''
+					this.showSyncTaskRunning = false
+					console.debug('Assistant SYNC result', response.data)
 				})
 				.catch(error => {
 					console.error('Assistant scheduling error', error)
 				})
 				.then(() => {
-					this.loading = false
 				})
 		},
 	},
@@ -109,7 +123,7 @@ export default {
 	justify-content: center;
 	margin: 24px 16px 16px 16px;
 	.form {
-		width: 550px;
+		width: 600px;
 	}
 }
 </style>

--- a/src/views/TaskResultPage.vue
+++ b/src/views/TaskResultPage.vue
@@ -18,7 +18,9 @@
 					:input="task.input"
 					:output="task.output ?? ''"
 					:selected-task-type-id="task.type"
-					@submit="onSubmit" />
+					:loading="loading"
+					@submit="onSubmit"
+					@sync-submit="onSyncSubmit" />
 			</div>
 		</NcAppContent>
 	</NcContent>
@@ -35,7 +37,7 @@ import AssistantForm from '../components/AssistantForm.vue'
 
 import { showError } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
-import { scheduleTask } from '../assistant.js'
+import { scheduleTask, runTask } from '../assistant.js'
 
 export default {
 	name: 'TaskResultPage',
@@ -55,6 +57,7 @@ export default {
 		return {
 			task: loadState('assistant', 'task'),
 			showScheduleConfirmation: false,
+			loading: false,
 		}
 	},
 
@@ -81,6 +84,19 @@ export default {
 				.catch(error => {
 					console.error('Assistant scheduling error', error)
 					showError(t('assistant', 'Failed to schedule your task'))
+				})
+		},
+		onSyncSubmit(data) {
+			this.loading = true
+			runTask(this.task.appId, this.task.identifier, data.taskTypeId, data.input)
+				.then((response) => {
+					this.task.output = response.data
+				})
+				.catch(error => {
+					console.error('Assistant scheduling error', error)
+				})
+				.then(() => {
+					this.loading = false
 				})
 		},
 	},

--- a/src/views/TaskResultPage.vue
+++ b/src/views/TaskResultPage.vue
@@ -5,6 +5,7 @@
 				class="assistant-wrapper">
 				<RunningEmptyContent
 					v-if="showSyncTaskRunning"
+					:description="shortInput"
 					@cancel="onCancelNSchedule" />
 				<ScheduledEmptyContent
 					v-else-if="showScheduleConfirmation"


### PR DESCRIPTION
As discussed with @jancborchardt, here is the synchronous workflow:
We always immediately run the task and wait for the result, showing a spinner in the UI. If users are bored to wait, they can click the schedule button which will stop the sync request and schedule the task just like before.

Sync:

https://github.com/nextcloud/assistant/assets/11291457/1e87f387-289c-44b0-b6c6-aa29b4234a01


Bored:

https://github.com/nextcloud/assistant/assets/11291457/52f7e20d-976a-407c-8c98-b0261935871f

