### PR TITLE
Prepare 1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 1.0.2 – 2023-11-20
+
+### Added
+
+- Input labels and result warning [#8](https://github.com/nextcloud/assistant/pull/8) @julien-nc
+
+### Changed
+
+- Implement synchronous workflow and ability to schedule if it's too long [#13](https://github.com/nextcloud/assistant/pull/13) @julien-nc
+- Use `@nextcloud/vue` 8 @julien-nc
+- Reimplement the task selector with inline buttons and action menu for overflowing ones [#3](https://github.com/nextcloud/assistant/pull/3) @julien-nc
+- Set submit button label to "Submit request" when Free prompt is selected @julien-nc
+
+### Fixed
+
+- Fix top-right menu entry style [#4](https://github.com/nextcloud/assistant/issues/4) @julien-nc
+
 ## 1.0.1 – 2023-08-21
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ include text processing providers to:
 * Get an answer from a free prompt
 * Reformulate (OpenAi/LocalAi only)
 ]]></description>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>TPAssistant</namespace>


### PR DESCRIPTION
### Added

- Input labels and result warning [#8](https://github.com/nextcloud/assistant/pull/8) @julien-nc

### Changed

- Implement synchronous workflow and ability to schedule if it's too long [#13](https://github.com/nextcloud/assistant/pull/13) @julien-nc
- Use `@nextcloud/vue` 8 @julien-nc
- Reimplement the task selector with inline buttons and action menu for overflowing ones [#3](https://github.com/nextcloud/assistant/pull/3) @julien-nc
- Set submit button label to "Submit request" when Free prompt is selected @julien-nc

### Fixed

- Fix top-right menu entry style [#4](https://github.com/nextcloud/assistant/issues/4) @julien-nc