### PR TITLE
Integration improvements

### DIFF
--- a/src/assistant.js
+++ b/src/assistant.js
@@ -11,7 +11,21 @@ __webpack_public_path__ = linkTo('assistant', 'js/') // eslint-disable-line
  *  appId: 'my_app_id',
  *  identifier: 'my task identifier',
  *  taskType: 'OCP\\TextProcessing\\FreePromptTaskType',
- *  input: 'count to 3'
+ *  input: 'count to 3',
+ *  actionButtons: [
+ *    {
+ *      label: 'Label 1',
+ *      title: 'Title 1',
+ *      type: 'warning',
+ *      iconSvg: cogSvg,
+ *      onClick: (output) => { console.debug('first button clicked', output) },
+ *    },
+ *    {
+ *      label: 'Label 2',
+ *      title: 'Title 2',
+ *      onClick: (output) => { console.debug('second button clicked', output) },
+ *    },
+ *  ],
  * }).then(r => {console.debug('scheduled task', r.data.ocs.data.task)})
  *
  * @param {object} params parameters for the assistant
@@ -21,11 +35,12 @@ __webpack_public_path__ = linkTo('assistant', 'js/') // eslint-disable-line
  * @param {string} params.input optional initial input text
  * @param {boolean} params.isInsideViewer Should be true if this function is called while the Viewer is displayed
  * @param {boolean} params.closeOnResult If true, the modal will be closed when getting a sync result
+ * @param {Array} params.actionButtons List of extra buttons to show in the assistant result form (only if closeOnResult is false)
  * @return {Promise<unknown>}
  */
 export async function openAssistantForm({
 	appId, identifier = '', taskType = null, input = '',
-	isInsideViewer = undefined, closeOnResult = false,
+	isInsideViewer = undefined, closeOnResult = false, actionButtons = undefined,
 }) {
 	const { default: Vue } = await import(/* webpackChunkName: "vue-lazy" */'vue')
 	const { default: AssistantModal } = await import(/* webpackChunkName: "assistant-modal-lazy" */'./components/AssistantModal.vue')
@@ -48,6 +63,7 @@ export async function openAssistantForm({
 				selectedTaskTypeId,
 				showScheduleConfirmation: false,
 				showSyncTaskRunning: false,
+				actionButtons,
 			},
 		}).$mount(modalElement)
 
@@ -115,6 +131,12 @@ export async function openAssistantForm({
 					console.error('Assistant scheduling error', error)
 					reject(new Error('Assistant scheduling error'))
 				})
+		})
+		view.$on('action-button-clicked', (data) => {
+			if (data.button?.onClick) {
+				data.button.onClick(data.output)
+			}
+			view.$destroy()
 		})
 	})
 }

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -66,6 +66,7 @@ export async function openAssistantForm({
 				actionButtons,
 			},
 		}).$mount(modalElement)
+		let lastTask = null
 
 		view.$on('cancel', () => {
 			view.$destroy()
@@ -76,7 +77,9 @@ export async function openAssistantForm({
 				.then((response) => {
 					view.input = data.input
 					view.showScheduleConfirmation = true
-					resolve(response.data?.ocs?.data?.task)
+					const task = response.data?.ocs?.data?.task
+					lastTask = task
+					resolve(task)
 				})
 				.catch(error => {
 					view.$destroy()
@@ -92,7 +95,9 @@ export async function openAssistantForm({
 			runOrScheduleTask(appId, identifier, data.taskTypeId, data.input)
 				.then((response) => {
 					const task = response.data?.task
+					lastTask = task
 					resolve(task)
+					view.input = task.input
 					if (task.status === STATUS.successfull) {
 						if (closeOnResult) {
 							view.$destroy()
@@ -100,7 +105,6 @@ export async function openAssistantForm({
 							view.output = task?.output
 						}
 					} else if (task.status === STATUS.scheduled) {
-						view.input = task.input
 						view.showScheduleConfirmation = true
 					}
 					view.loading = false
@@ -124,7 +128,9 @@ export async function openAssistantForm({
 				.then((response) => {
 					view.showSyncTaskRunning = false
 					view.showScheduleConfirmation = true
-					resolve(response.data?.ocs?.data?.task)
+					const task = response.data?.ocs?.data?.task
+					lastTask = task
+					resolve(task)
 				})
 				.catch(error => {
 					view.$destroy()
@@ -134,7 +140,8 @@ export async function openAssistantForm({
 		})
 		view.$on('action-button-clicked', (data) => {
 			if (data.button?.onClick) {
-				data.button.onClick(data.output)
+				lastTask.output = data.output
+				data.button.onClick(lastTask)
 			}
 			view.$destroy()
 		})

--- a/src/components/AssistantForm.vue
+++ b/src/components/AssistantForm.vue
@@ -79,7 +79,7 @@
 				</template>
 			</NcButton-->
 			<NcButton
-				v-if="showCopy"
+				v-if="hasOutput"
 				type="primary"
 				class="copy-button"
 				:title="t('assistant', 'Copy output')"
@@ -90,7 +90,7 @@
 					<ContentCopyIcon v-else />
 				</template>
 			</NcButton>
-			<div v-if="showCopy"
+			<div v-if="hasOutput"
 				class="action-buttons">
 				<NcButton
 					v-for="(b, i) in actionButtons"
@@ -208,7 +208,7 @@ export default {
 					? t('assistant', 'Send request')
 					: this.selectedTaskType.name
 		},
-		showCopy() {
+		hasOutput() {
 			return !!this.myOutput.trim()
 		},
 	},

--- a/src/components/AssistantForm.vue
+++ b/src/components/AssistantForm.vue
@@ -57,8 +57,7 @@
 				:type="submitButtonType"
 				class="submit-button"
 				:disabled="!canSubmit"
-				:aria-label="t('assistant', 'Run an assistant task')"
-				:title="t('assistant', 'Run')"
+				:title="t('assistant', 'Run a task')"
 				@click="onSyncSubmit">
 				{{ syncSubmitButtonLabel }}
 				<template #icon>
@@ -83,8 +82,7 @@
 				v-if="showCopy"
 				type="primary"
 				class="copy-button"
-				:aria-label="t('assistant', 'Copy task output')"
-				:title="t('assistant', 'Copy')"
+				:title="t('assistant', 'Copy output')"
 				@click="onCopy">
 				{{ t('assistant', 'Copy') }}
 				<template #icon>
@@ -92,6 +90,20 @@
 					<ContentCopyIcon v-else />
 				</template>
 			</NcButton>
+			<div v-if="showCopy"
+				class="action-buttons">
+				<NcButton
+					v-for="(b, i) in actionButtons"
+					:key="i"
+					:type="b.type ?? 'secondary'"
+					:title="b.title"
+					@click="onActionButtonClick(b)">
+					{{ b.label }}
+					<template v-if="b.iconSvg" #icon>
+						<NcIconSvgWrapper :svg="b.iconSvg" />
+					</template>
+				</NcButton>
+			</div>
 		</div>
 	</div>
 </template>
@@ -105,6 +117,7 @@ import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContenteditable.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
+import NcIconSvgWrapper from '@nextcloud/vue/dist/Components/NcIconSvgWrapper.js'
 
 import TaskTypeSelect from './TaskTypeSelect.vue'
 
@@ -123,6 +136,7 @@ export default {
 		NcButton,
 		NcRichContenteditable,
 		NcLoadingIcon,
+		NcIconSvgWrapper,
 		CreationIcon,
 		ContentCopyIcon,
 		ClipboardCheckOutlineIcon,
@@ -145,10 +159,15 @@ export default {
 			type: [String, null],
 			default: null,
 		},
+		actionButtons: {
+			type: Array,
+			default: () => [],
+		},
 	},
 	emits: [
 		'sync-submit',
 		'submit',
+		'action-button-clicked',
 	],
 	data() {
 		return {
@@ -230,6 +249,9 @@ export default {
 				showError(t('assistant', 'Result could not be copied to clipboard'))
 			}
 		},
+		onActionButtonClick(button) {
+			this.$emit('action-button-clicked', { button, output: this.myOutput.trim() })
+		},
 	},
 }
 </script>
@@ -303,8 +325,15 @@ export default {
 	.footer {
 		width: 100%;
 		display: flex;
+		flex-wrap: wrap;
 		justify-content: end;
 		gap: 4px;
+		.action-buttons {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: end;
+			gap: 4px;
+		}
 	}
 
 	.success-icon {

--- a/src/components/AssistantModal.vue
+++ b/src/components/AssistantModal.vue
@@ -32,8 +32,10 @@
 					:output="output"
 					:selected-task-type-id="selectedTaskTypeId"
 					:loading="loading"
+					:action-buttons="actionButtons"
 					@submit="onSubmit"
-					@sync-submit="onSyncSubmit" />
+					@sync-submit="onSyncSubmit"
+					@action-button-clicked="onActionButtonClicked" />
 			</div>
 		</div>
 	</NcModal>
@@ -93,6 +95,10 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+		actionButtons: {
+			type: Array,
+			default: () => [],
+		},
 	},
 	emits: [
 		'cancel',
@@ -134,6 +140,9 @@ export default {
 		},
 		onCancelNSchedule() {
 			this.$emit('cancel-sync-n-schedule')
+		},
+		onActionButtonClicked(data) {
+			this.$emit('action-button-clicked', data)
 		},
 	},
 }


### PR DESCRIPTION
refs https://github.com/nextcloud/text/issues/4686

* [x] The main promise always resolves the task with its current status
* [x] Assistant will offer a flag to close the modal after a successful sync task
* [x] There will be a list of action buttons that can be provided


https://github.com/nextcloud/assistant/assets/11291457/5d579c0b-7ee5-4368-97ef-78ff519ff46d

``` js
const params = {
	appId: 'plopApp',
	identifier: 'idid',
	input: 'give me a short summary of a simple settings section about GitHub',
	closeOnResult: false,
	actionButtons: [
		{
			label: 'Put in field 1',
			title: 'Title 1',
			type: 'warning',
			iconSvg: cogSvg,
			onClick: (task) => { this.field1 = task.output },
		},
		{
			label: 'Put in field 2',
			title: 'Title 2',
			onClick: (task) => { this.field2 = task.output },
		},
	],
}
OCA.TPAssistant.openAssistantForm(params)
```

Is it enough to get the task output as parameter of button callbacks? I could refactor a bit and make it possible to get the task itself if necessary.