### PR TITLE
Prepare 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 1.0.3 – 2023-12-12
+
+### Changed
+
+- Use new runOrSchedule when trying to run a sync task
+
+### Fixed
+
+- Avoid initially selected task to be hidden in the menu
+- Set default selected task on first use: free prompt
+
 ## 1.0.2 – 2023-11-20
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ include text processing providers to:
 * Get an answer from a free prompt
 * Reformulate (OpenAi/LocalAi only)
 ]]></description>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>TPAssistant</namespace>


### PR DESCRIPTION
### Changed

- Use new runOrSchedule when trying to run a sync task

### Fixed

- Avoid initially selected task to be hidden in the menu
- Set default selected task on first use: free prompt