### PR TITLE
Add task history

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -13,6 +13,8 @@ return [
 		['name' => 'assistant#scheduleTextProcessingTask', 'url' => '/task/schedule', 'verb' => 'POST'],
 		['name' => 'assistant#runOrScheduleTextProcessingTask', 'url' => '/task/run-or-schedule', 'verb' => 'POST'],
 		['name' => 'assistant#parseTextFromFile', 'url' => '/parse-file', 'verb' => 'POST'],
+		['name' => 'assistant#deleteTask', 'url' => '/task/{metaTaskId}', 'verb' => 'DELETE'],
+		['name' => 'assistant#cancelTask', 'url' => '/task/cancel/{metaTaskId}', 'verb' => 'PUT'],
 
 		['name' => 'Text2Image#processPrompt', 'url' => '/i/process_prompt', 'verb' => 'POST'],
 		['name' => 'Text2Image#getPromptHistory', 'url' => '/i/prompt_history', 'verb' => 'GET'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -8,6 +8,7 @@ return [
 
 		['name' => 'assistant#getAssistantTaskResultPage', 'url' => '/task/view/{metaTaskId}', 'verb' => 'GET'],
 		['name' => 'assistant#getAssistantTask', 'url' => '/task/{metaTaskId}', 'verb' => 'GET'],
+		['name' => 'assistant#getUserTasks', 'url' => '/tasks', 'verb' => 'GET'],
 		['name' => 'assistant#runTextProcessingTask', 'url' => '/task/run', 'verb' => 'POST'],
 		['name' => 'assistant#scheduleTextProcessingTask', 'url' => '/task/schedule', 'verb' => 'POST'],
 		['name' => 'assistant#runOrScheduleTextProcessingTask', 'url' => '/task/run-or-schedule', 'verb' => 'POST'],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -45,6 +45,12 @@ class Application extends App implements IBootstrap {
 	public const STT_TASK_SUCCESSFUL = 1;
 	public const STT_TASK_FAILED = -1;
 
+	public const STATUS_META_TASK_FAILED = 4;
+	public const STATUS_META_TASK_SUCCESSFUL = 3;
+	public const STATUS_META_TASK_RUNNING = 2;
+	public const STATUS_META_TASK_SCHEDULED = 1;
+	public const STATUS_META_TASK_UNKNOWN = 0;
+
 	public const TASK_CATEGORY_TEXT_GEN = 0;
 	public const TASK_CATEGORY_TEXT_TO_IMAGE = 1;
 	public const TASK_CATEGORY_SPEECH_TO_TEXT = 2;

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -26,6 +26,7 @@ use OCP\SpeechToText\Events\TranscriptionFailedEvent;
 use OCP\SpeechToText\Events\TranscriptionSuccessfulEvent;
 use OCP\TextProcessing\Events\TaskFailedEvent as TextTaskFailedEvent;
 use OCP\TextProcessing\Events\TaskSuccessfulEvent as TextTaskSuccessfulEvent;
+use OCP\TextProcessing\Task as OCPTextprocessingTask;
 use OCP\TextToImage\Events\TaskFailedEvent as TextToImageTaskFailedEvent;
 use OCP\TextToImage\Events\TaskSuccessfulEvent as TextToImageTaskSuccessfulEvent;
 
@@ -45,11 +46,18 @@ class Application extends App implements IBootstrap {
 	public const STT_TASK_SUCCESSFUL = 1;
 	public const STT_TASK_FAILED = -1;
 
-	public const STATUS_META_TASK_FAILED = 4;
-	public const STATUS_META_TASK_SUCCESSFUL = 3;
-	public const STATUS_META_TASK_RUNNING = 2;
-	public const STATUS_META_TASK_SCHEDULED = 1;
 	public const STATUS_META_TASK_UNKNOWN = 0;
+	public const STATUS_META_TASK_SCHEDULED = 1;
+	public const STATUS_META_TASK_RUNNING = 2;
+	public const STATUS_META_TASK_SUCCESSFUL = 3;
+	public const STATUS_META_TASK_FAILED = 4;
+	public const TP_STATUS_TO_META_STATUS = [
+		OCPTextprocessingTask::STATUS_UNKNOWN => self::STATUS_META_TASK_UNKNOWN,
+		OCPTextprocessingTask::STATUS_SCHEDULED => self::STATUS_META_TASK_SCHEDULED,
+		OCPTextprocessingTask::STATUS_RUNNING => self::STATUS_META_TASK_RUNNING,
+		OCPTextprocessingTask::STATUS_SUCCESSFUL => self::STATUS_META_TASK_SUCCESSFUL,
+		OCPTextprocessingTask::STATUS_FAILED => self::STATUS_META_TASK_FAILED,
+	];
 
 	public const TASK_CATEGORY_TEXT_GEN = 0;
 	public const TASK_CATEGORY_TEXT_TO_IMAGE = 1;

--- a/lib/Controller/AssistantController.php
+++ b/lib/Controller/AssistantController.php
@@ -31,6 +31,40 @@ class AssistantController extends Controller {
 
 	/**
 	 * @param int $metaTaskId
+	 * @return DataResponse
+	 */
+	#[NoAdminRequired]
+	public function deleteTask(int $metaTaskId): DataResponse {
+		if ($this->userId !== null) {
+			try {
+				$this->assistantService->deleteAssistantTask($this->userId, $metaTaskId);
+				return new DataResponse('');
+			} catch (\Exception $e) {
+			}
+		}
+
+		return new DataResponse('', Http::STATUS_NOT_FOUND);
+	}
+
+	/**
+	 * @param int $metaTaskId
+	 * @return DataResponse
+	 */
+	#[NoAdminRequired]
+	public function cancelTask(int $metaTaskId): DataResponse {
+		if ($this->userId !== null) {
+			try {
+				$this->assistantService->cancelAssistantTask($this->userId, $metaTaskId);
+				return new DataResponse('');
+			} catch (\Exception $e) {
+			}
+		}
+
+		return new DataResponse('', Http::STATUS_NOT_FOUND);
+	}
+
+	/**
+	 * @param int $metaTaskId
 	 * @return TemplateResponse
 	 */
 	#[NoAdminRequired]
@@ -68,7 +102,7 @@ class AssistantController extends Controller {
 		if ($this->userId !== null) {
 			try {
 				$tasks = $this->metaTaskMapper->getUserMetaTasks($this->userId, $taskType, $category);
-				$serializedTasks = array_map(static function(MetaTask $task) {
+				$serializedTasks = array_map(static function (MetaTask $task) {
 					return $task->jsonSerializeCc();
 				}, $tasks);
 				return new DataResponse(['tasks' => $serializedTasks]);

--- a/lib/Controller/AssistantController.php
+++ b/lib/Controller/AssistantController.php
@@ -3,6 +3,8 @@
 namespace OCA\TpAssistant\Controller;
 
 use OCA\TpAssistant\AppInfo\Application;
+use OCA\TpAssistant\Db\MetaTask;
+use OCA\TpAssistant\Db\MetaTaskMapper;
 use OCA\TpAssistant\Service\AssistantService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -11,16 +13,18 @@ use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\DB\Exception;
 use OCP\IRequest;
 
 class AssistantController extends Controller {
 
 	public function __construct(
-		string                   $appName,
-		IRequest                 $request,
+		string $appName,
+		IRequest $request,
 		private AssistantService $assistantService,
-		private IInitialState    $initialStateService,
-		private ?string          $userId,
+		private MetaTaskMapper $metaTaskMapper,
+		private IInitialState $initialStateService,
+		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -54,6 +58,22 @@ class AssistantController extends Controller {
 				return new DataResponse([
 					'task' => $task->jsonSerializeCc(),
 				]);
+			}
+		}
+		return new DataResponse('', Http::STATUS_NOT_FOUND);
+	}
+
+	#[NoAdminRequired]
+	public function getUserTasks(?string $taskType = null, ?int $category = null): DataResponse {
+		if ($this->userId !== null) {
+			try {
+				$tasks = $this->metaTaskMapper->getUserMetaTasks($this->userId, $taskType, $category);
+				$serializedTasks = array_map(static function(MetaTask $task) {
+					return $task->jsonSerializeCc();
+				}, $tasks);
+				return new DataResponse(['tasks' => $serializedTasks]);
+			} catch (Exception $e) {
+				return new DataResponse(['tasks' => []]);
 			}
 		}
 		return new DataResponse('', Http::STATUS_NOT_FOUND);

--- a/lib/Controller/SpeechToTextController.php
+++ b/lib/Controller/SpeechToTextController.php
@@ -106,7 +106,7 @@ class SpeechToTextController extends Controller {
 	 */
 	private function internalGetTask(int $id): MetaTask {
 		try {
-			$metaTask = $this->metaTaskMapper->getMetaTaskOfUser($id, $this->userId);
+			$metaTask = $this->metaTaskMapper->getUserMetaTask($id, $this->userId);
 
 			if($metaTask->getCategory() !== Application::TASK_CATEGORY_SPEECH_TO_TEXT) {
 				throw new Exception('Task is not a speech to text task.', Http::STATUS_BAD_REQUEST);

--- a/lib/Controller/Text2ImageController.php
+++ b/lib/Controller/Text2ImageController.php
@@ -113,11 +113,13 @@ class Text2ImageController extends Controller {
 		}
 		*/
 
-		return new DataDisplayResponse(
+		$response = new DataDisplayResponse(
 			$result['image'] ?? '',
 			Http::STATUS_OK,
 			['Content-Type' => $result['content-type'] ?? 'image/jpeg']
 		);
+		$response->cacheFor(60 * 60 * 24);
+		return $response;
 	}
 
 	/**

--- a/lib/Db/MetaTaskMapper.php
+++ b/lib/Db/MetaTaskMapper.php
@@ -120,7 +120,7 @@ class MetaTaskMapper extends QBMapper {
 	 * @throws Exception
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getMetaTaskOfUser(int $id, string $userId): MetaTask {
+	public function getUserMetaTask(int $id, string $userId): MetaTask {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('*')
@@ -136,10 +136,12 @@ class MetaTaskMapper extends QBMapper {
 
 	/**
 	 * @param string $userId
+	 * @param string|null $taskType
+	 * @param int|null $category
 	 * @return array
 	 * @throws Exception
 	 */
-	public function getMetaTasksOfUser(string $userId): array {
+	public function getUserMetaTasks(string $userId, ?string $taskType = null, ?int $category = null): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('*')
@@ -147,6 +149,17 @@ class MetaTaskMapper extends QBMapper {
 			->where(
 				$qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR))
 			);
+		if ($taskType !== null) {
+			$qb->andWhere(
+				$qb->expr()->eq('task_type', $qb->createNamedParameter($taskType, IQueryBuilder::PARAM_STR))
+			);
+		}
+		if ($category !== null) {
+			$qb->andWhere(
+				$qb->expr()->eq('category', $qb->createNamedParameter($category, IQueryBuilder::PARAM_INT))
+			);
+		}
+		$qb->orderBy('timestamp', 'DESC');
 
 		return $this->findEntities($qb);
 	}

--- a/lib/Db/Text2Image/ImageGeneration.php
+++ b/lib/Db/Text2Image/ImageGeneration.php
@@ -17,6 +17,10 @@ use OCP\AppFramework\Db\Entity;
  * @method \void setUserId(string $userId)
  * @method \int getTimestamp()
  * @method \void setTimestamp(int $timestamp)
+ * @method \boolean getIsGenerated()
+ * @method \void setIsGenerated(bool $isGenerated)
+ * @method \boolean getFailed()
+ * @method \void setFailed(bool $failed)
  * @method \boolean getNotifyReady()
  * @method \void setNotifyReady(bool $notifyReady)
  * @method \int getExpGenTime()
@@ -66,20 +70,5 @@ class ImageGeneration extends Entity implements \JsonSerializable {
 			'notify_ready' => $this->notifyReady,
 			'exp_gen_time' => $this->expGenTime,
 		];
-	}
-
-	public function setIsGenerated(?bool $isGenerated): void {
-		$this->isGenerated = $isGenerated === true;
-	}
-	public function getIsGenerated(): bool {
-		return $this->isGenerated === true;
-	}
-
-	public function setFailed(?bool $failed): void {
-		$this->failed = $failed === true;
-	}
-
-	public function getFailed(): bool {
-		return $this->failed === true;
 	}
 }

--- a/lib/Listener/SpeechToText/SpeechToTextResultListener.php
+++ b/lib/Listener/SpeechToText/SpeechToTextResultListener.php
@@ -72,7 +72,7 @@ class SpeechToTextResultListener implements IEventListener {
 
 			// Update the meta task with the output and new status
 			$assistantTask->setOutput($transcript);
-			$assistantTask->setStatus(Application::STT_TASK_SUCCESSFUL);
+			$assistantTask->setStatus(Application::STATUS_META_TASK_SUCCESSFUL);
 			$assistantTask = $this->metaTaskMapper->update($assistantTask);
 
 			try {
@@ -104,7 +104,7 @@ class SpeechToTextResultListener implements IEventListener {
 			}
 
 			// Update the meta task with the new status
-			$assistantTask->setStatus(Application::STT_TASK_FAILED);
+			$assistantTask->setStatus(Application::STATUS_META_TASK_FAILED);
 			$assistantTask = $this->metaTaskMapper->update($assistantTask);
 
 			try {

--- a/lib/Listener/SpeechToText/SpeechToTextResultListener.php
+++ b/lib/Listener/SpeechToText/SpeechToTextResultListener.php
@@ -24,7 +24,7 @@ namespace OCA\TpAssistant\Listener\SpeechToText;
 
 use OCA\TpAssistant\AppInfo\Application;
 use OCA\TpAssistant\Db\MetaTaskMapper;
-use OCA\TpAssistant\Service\AssistantService;
+use OCA\TpAssistant\Service\NotificationService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\SpeechToText\Events\AbstractTranscriptionEvent;
@@ -39,7 +39,7 @@ class SpeechToTextResultListener implements IEventListener {
 	public function __construct(
 		private LoggerInterface  $logger,
 		private MetaTaskMapper $metaTaskMapper,
-		private AssistantService $assistantService,
+		private NotificationService $notificationService,
 	) {
 	}
 
@@ -76,13 +76,14 @@ class SpeechToTextResultListener implements IEventListener {
 			$assistantTask = $this->metaTaskMapper->update($assistantTask);
 
 			try {
-				$this->assistantService->sendNotification($assistantTask, null, null, $transcript);
+				$this->notificationService->sendNotification($assistantTask, null, null, $transcript);
 			} catch (\InvalidArgumentException $e) {
 				$this->logger->error('Failed to dispatch notification for successful transcription: ' . $e->getMessage());
 			}
 		}
 
 		if ($event instanceof TranscriptionFailedEvent) {
+			$file = $event->getFile();
 			$this->logger->error('Transcript generation failed: ' . $event->getErrorMessage());
 
 			$metaTasks = $this->metaTaskMapper->getMetaTasksByOcpTaskIdAndCategory($file->getId(), Application::TASK_CATEGORY_SPEECH_TO_TEXT);
@@ -99,16 +100,17 @@ class SpeechToTextResultListener implements IEventListener {
 			}
 
 			if ($assistantTask === null) {
-				$this->logger->error('No assistant task found for speech to text result');
+				$this->logger->error('No assistant task found for speech to text result (task id: ' . $file->getId() . ')');
 				return;
 			}
 
 			// Update the meta task with the new status
 			$assistantTask->setStatus(Application::STATUS_META_TASK_FAILED);
+			$assistantTask->setOutput($event->getErrorMessage());
 			$assistantTask = $this->metaTaskMapper->update($assistantTask);
 
 			try {
-				$this->assistantService->sendNotification($assistantTask);
+				$this->notificationService->sendNotification($assistantTask);
 			} catch (\InvalidArgumentException $e) {
 				$this->logger->error('Failed to dispatch notification for failed transcription: ' . $e->getMessage());
 			}

--- a/lib/Listener/TaskFailedListener.php
+++ b/lib/Listener/TaskFailedListener.php
@@ -5,7 +5,7 @@ namespace OCA\TpAssistant\Listener;
 use OCA\TpAssistant\AppInfo\Application;
 use OCA\TpAssistant\Db\MetaTaskMapper;
 use OCA\TpAssistant\Event\BeforeAssistantNotificationEvent;
-use OCA\TpAssistant\Service\AssistantService;
+use OCA\TpAssistant\Service\NotificationService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -18,7 +18,7 @@ use OCP\TextProcessing\Events\TaskFailedEvent;
 class TaskFailedListener implements IEventListener {
 
 	public function __construct(
-		private AssistantService $assistantService,
+		private NotificationService $notificationService,
 		private IEventDispatcher $eventDispatcher,
 		private MetaTaskMapper $metaTaskMapper,
 	) {
@@ -59,9 +59,9 @@ class TaskFailedListener implements IEventListener {
 
 		// Update task status and output:
 		$assistantTask->setStatus($task->getStatus());
-		$assistantTask->setOutput($task->getOutput());
+		$assistantTask->setOutput($event->getErrorMessage());
 		$assistantTask = $this->metaTaskMapper->update($assistantTask);
 
-		$this->assistantService->sendNotification($assistantTask, $notificationTarget, $notificationActionLabel);
+		$this->notificationService->sendNotification($assistantTask, $notificationTarget, $notificationActionLabel);
 	}
 }

--- a/lib/Listener/TaskFailedListener.php
+++ b/lib/Listener/TaskFailedListener.php
@@ -58,7 +58,7 @@ class TaskFailedListener implements IEventListener {
 		}
 
 		// Update task status and output:
-		$assistantTask->setStatus($task->getStatus());
+		$assistantTask->setStatus(Application::TP_STATUS_TO_META_STATUS[$task->getStatus()]);
 		$assistantTask->setOutput($event->getErrorMessage());
 		$assistantTask = $this->metaTaskMapper->update($assistantTask);
 

--- a/lib/Listener/TaskSuccessfulListener.php
+++ b/lib/Listener/TaskSuccessfulListener.php
@@ -5,7 +5,7 @@ namespace OCA\TpAssistant\Listener;
 use OCA\TpAssistant\AppInfo\Application;
 use OCA\TpAssistant\Db\MetaTaskMapper;
 use OCA\TpAssistant\Event\BeforeAssistantNotificationEvent;
-use OCA\TpAssistant\Service\AssistantService;
+use OCA\TpAssistant\Service\NotificationService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -18,7 +18,7 @@ use OCP\TextProcessing\Events\TaskSuccessfulEvent;
 class TaskSuccessfulListener implements IEventListener {
 
 	public function __construct(
-		private AssistantService $assistantService,
+		private NotificationService $notificationService,
 		private IEventDispatcher $eventDispatcher,
 		private MetaTaskMapper $metaTaskMapper,
 	) {
@@ -62,6 +62,6 @@ class TaskSuccessfulListener implements IEventListener {
 		$assistantTask->setOutput($task->getOutput());
 		$assistantTask = $this->metaTaskMapper->update($assistantTask);
 
-		$this->assistantService->sendNotification($assistantTask, $notificationTarget, $notificationActionLabel);
+		$this->notificationService->sendNotification($assistantTask, $notificationTarget, $notificationActionLabel);
 	}
 }

--- a/lib/Listener/TaskSuccessfulListener.php
+++ b/lib/Listener/TaskSuccessfulListener.php
@@ -58,7 +58,7 @@ class TaskSuccessfulListener implements IEventListener {
 		}
 
 		// Update task status and output:
-		$assistantTask->setStatus($task->getStatus());
+		$assistantTask->setStatus(Application::TP_STATUS_TO_META_STATUS[$task->getStatus()]);
 		$assistantTask->setOutput($task->getOutput());
 		$assistantTask = $this->metaTaskMapper->update($assistantTask);
 

--- a/lib/Listener/Text2Image/Text2ImageResultListener.php
+++ b/lib/Listener/Text2Image/Text2ImageResultListener.php
@@ -57,7 +57,7 @@ class Text2ImageResultListener implements IEventListener {
 
 			$this->text2ImageService->storeImages($images, $imageGenId);
 
-			$assistantTask->setStatus(Task::STATUS_SUCCESSFUL);
+			$assistantTask->setStatus(Application::STATUS_META_TASK_SUCCESSFUL);
 			$assistantTask = $this->metaTaskMapper->update($assistantTask);
 		}
 
@@ -66,7 +66,7 @@ class Text2ImageResultListener implements IEventListener {
 			$this->imageGenerationMapper->setFailed($imageGenId, true);
 
 			// Update the assistant meta task status:
-			$assistantTask->setStatus(Task::STATUS_FAILED);
+			$assistantTask->setStatus(Application::STATUS_META_TASK_FAILED);
 			$assistantTask->setOutput($event->getErrorMessage());
 			$assistantTask = $this->metaTaskMapper->update($assistantTask);
 

--- a/lib/Listener/Text2Image/Text2ImageResultListener.php
+++ b/lib/Listener/Text2Image/Text2ImageResultListener.php
@@ -5,7 +5,7 @@ namespace OCA\TpAssistant\Listener\Text2Image;
 use OCA\TpAssistant\AppInfo\Application;
 use OCA\TpAssistant\Db\MetaTaskMapper;
 use OCA\TpAssistant\Db\Text2Image\ImageGenerationMapper;
-use OCA\TpAssistant\Service\AssistantService;
+use OCA\TpAssistant\Service\NotificationService;
 use OCA\TpAssistant\Service\Text2Image\Text2ImageHelperService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
@@ -24,10 +24,10 @@ class Text2ImageResultListener implements IEventListener {
 
 	public function __construct(
 		private Text2ImageHelperService $text2ImageService,
-		private ImageGenerationMapper   $imageGenerationMapper,
-		private LoggerInterface         $logger,
-		private AssistantService        $assistantService,
-		private MetaTaskMapper          $metaTaskMapper,
+		private ImageGenerationMapper $imageGenerationMapper,
+		private LoggerInterface $logger,
+		private NotificationService $notificationService,
+		private MetaTaskMapper $metaTaskMapper,
 	) {
 	}
 
@@ -67,16 +67,17 @@ class Text2ImageResultListener implements IEventListener {
 
 			// Update the assistant meta task status:
 			$assistantTask->setStatus(Task::STATUS_FAILED);
+			$assistantTask->setOutput($event->getErrorMessage());
 			$assistantTask = $this->metaTaskMapper->update($assistantTask);
 
-			$this->assistantService->sendNotification($assistantTask);
+			$this->notificationService->sendNotification($assistantTask);
 		}
 
 		// Only send the notification if the user enabled them for this task:
 		try {
 			$imageGeneration = $this->imageGenerationMapper->getImageGenerationOfImageGenId($imageGenId);
 			if ($imageGeneration->getNotifyReady()) {
-				$this->assistantService->sendNotification($assistantTask);
+				$this->notificationService->sendNotification($assistantTask);
 			}
 		} catch (\OCP\Db\Exception | DoesNotExistException | MultipleObjectsReturnedException $e) {
 			$this->logger->warning('Could not notify user of a generation (id:' . $imageGenId . ') being ready: ' . $e->getMessage());

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -155,7 +155,7 @@ class AssistantService {
 		}
 	}
 
-	private function cancelOcpTaskOfMetaTask(string $userId, MetaTask $metaTask) {
+	private function cancelOcpTaskOfMetaTask(string $userId, MetaTask $metaTask): void {
 		if ($metaTask->getCategory() === Application::TASK_CATEGORY_TEXT_GEN) {
 			try {
 				$ocpTask = $this->textProcessingManager->getTask($metaTask->getOcpTaskId());
@@ -166,9 +166,23 @@ class AssistantService {
 			$this->text2ImageHelperService->cancelGeneration($metaTask->getOutput(), $userId);
 		} elseif ($metaTask->getCategory() === Application::TASK_CATEGORY_SPEECH_TO_TEXT) {
 			// TODO implement task canceling in stt manager
+			$fileId = $metaTask->getOcpTaskId();
+			$files = $this->storage->getById($fileId);
+			if (count($files) < 1) {
+				return;
+			}
+			$file = array_shift($files);
+			if (!$file instanceof File) {
+				return;
+			}
+			$owner = $file->getOwner();
+			if ($owner === null) {
+				return;
+			}
+			$ownerId = $owner->getUID();
 			$jobArguments = [
-				'fileId' => $metaTask->getOcpTaskId(),
-				'owner' => $userId,
+				'fileId' => $fileId,
+				'owner' => $ownerId,
 				'userId' => $userId,
 				'appId' => Application::APP_ID,
 			];

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -7,8 +7,6 @@ use OCA\TpAssistant\AppInfo\Application;
 use OCA\TpAssistant\Db\MetaTask;
 use OCP\IURLGenerator;
 use OCP\Notification\IManager as INotificationManager;
-use OCP\TextProcessing\Task as TextProcessingTask;
-use OCP\TextToImage\Task as TextToImageTask;
 
 class NotificationService {
 

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -21,49 +21,28 @@ class NotificationService {
 	/**
 	 * Send a success or failure task result notification
 	 *
-	 * @param MetaTask $task
+	 * @param MetaTask $metaTask
 	 * @param string|null $customTarget optional notification link target
 	 * @param string|null $actionLabel optional label for the notification action button
 	 * @param string|null $resultPreview
 	 * @return void
 	 */
-	public function sendNotification(MetaTask $task, ?string $customTarget = null, ?string $actionLabel = null, ?string $resultPreview = null): void {
+	public function sendNotification(MetaTask $metaTask, ?string $customTarget = null, ?string $actionLabel = null, ?string $resultPreview = null): void {
 		$manager = $this->notificationManager;
 		$notification = $manager->createNotification();
 
 		$params = [
-			'appId' => $task->getAppId(),
-			'id' => $task->getId(),
-			'inputs' => $task->getInputsAsArray(),
-			'target' => $customTarget ?? $this->getDefaultTarget($task),
+			'appId' => $metaTask->getAppId(),
+			'id' => $metaTask->getId(),
+			'inputs' => $metaTask->getInputsAsArray(),
+			'target' => $customTarget ?? $this->getDefaultTarget($metaTask),
 			'actionLabel' => $actionLabel,
 			'result' => $resultPreview,
 		];
-		$params['taskTypeClass'] = $task->getTaskType();
-		$params['taskCategory'] = $task->getCategory();
+		$params['taskTypeClass'] = $metaTask->getTaskType();
+		$params['taskCategory'] = $metaTask->getCategory();
 
-		switch ($task->getCategory()) {
-			case Application::TASK_CATEGORY_TEXT_TO_IMAGE:
-				{
-					$taskSuccessful = $task->getStatus() === TextToImageTask::STATUS_SUCCESSFUL;
-					break;
-				}
-			case Application::TASK_CATEGORY_TEXT_GEN:
-				{
-					$taskSuccessful = $task->getStatus() === TextProcessingTask::STATUS_SUCCESSFUL;
-					break;
-				}
-			case Application::TASK_CATEGORY_SPEECH_TO_TEXT:
-				{
-					$taskSuccessful = $task->getStatus() === Application::STT_TASK_SUCCESSFUL;
-					break;
-				}
-			default:
-				{
-					$taskSuccessful = false;
-					break;
-				}
-		}
+		$taskSuccessful = $metaTask->getStatus() === Application::STATUS_META_TASK_SUCCESSFUL;
 
 		$subject = $taskSuccessful
 			? 'success'
@@ -74,9 +53,9 @@ class NotificationService {
 			: 'task-with-custom-target';
 
 		$notification->setApp(Application::APP_ID)
-			->setUser($task->getUserId())
+			->setUser($metaTask->getUserId())
 			->setDateTime(new DateTime())
-			->setObject($objectType, (string) ($task->getId() ?? 0))
+			->setObject($objectType, (string) ($metaTask->getId() ?? 0))
 			->setSubject($subject, $params);
 
 		$manager->notify($notification);

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace OCA\TpAssistant\Service;
+
+use DateTime;
+use OCA\TpAssistant\AppInfo\Application;
+use OCA\TpAssistant\Db\MetaTask;
+use OCP\IURLGenerator;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\TextProcessing\Task as TextProcessingTask;
+use OCP\TextToImage\Task as TextToImageTask;
+
+class NotificationService {
+
+	public function __construct(
+		private INotificationManager $notificationManager,
+		private IURLGenerator $url,
+	) {
+	}
+
+	/**
+	 * Send a success or failure task result notification
+	 *
+	 * @param MetaTask $task
+	 * @param string|null $customTarget optional notification link target
+	 * @param string|null $actionLabel optional label for the notification action button
+	 * @param string|null $resultPreview
+	 * @return void
+	 */
+	public function sendNotification(MetaTask $task, ?string $customTarget = null, ?string $actionLabel = null, ?string $resultPreview = null): void {
+		$manager = $this->notificationManager;
+		$notification = $manager->createNotification();
+
+		$params = [
+			'appId' => $task->getAppId(),
+			'id' => $task->getId(),
+			'inputs' => $task->getInputsAsArray(),
+			'target' => $customTarget ?? $this->getDefaultTarget($task),
+			'actionLabel' => $actionLabel,
+			'result' => $resultPreview,
+		];
+		$params['taskTypeClass'] = $task->getTaskType();
+		$params['taskCategory'] = $task->getCategory();
+
+		switch ($task->getCategory()) {
+			case Application::TASK_CATEGORY_TEXT_TO_IMAGE:
+				{
+					$taskSuccessful = $task->getStatus() === TextToImageTask::STATUS_SUCCESSFUL;
+					break;
+				}
+			case Application::TASK_CATEGORY_TEXT_GEN:
+				{
+					$taskSuccessful = $task->getStatus() === TextProcessingTask::STATUS_SUCCESSFUL;
+					break;
+				}
+			case Application::TASK_CATEGORY_SPEECH_TO_TEXT:
+				{
+					$taskSuccessful = $task->getStatus() === Application::STT_TASK_SUCCESSFUL;
+					break;
+				}
+			default:
+				{
+					$taskSuccessful = false;
+					break;
+				}
+		}
+
+		$subject = $taskSuccessful
+			? 'success'
+			: 'failure';
+
+		$objectType = $customTarget === null
+			? 'task'
+			: 'task-with-custom-target';
+
+		$notification->setApp(Application::APP_ID)
+			->setUser($task->getUserId())
+			->setDateTime(new DateTime())
+			->setObject($objectType, (string) ($task->getId() ?? 0))
+			->setSubject($subject, $params);
+
+		$manager->notify($notification);
+	}
+
+	private function getDefaultTarget(MetaTask $task): string {
+		return $this->url->linkToRouteAbsolute(Application::APP_ID . '.assistant.getAssistantTaskResultPage', ['metaTaskId' => $task->getId()]);
+	}
+}

--- a/lib/Service/SpeechToText/SpeechToTextService.php
+++ b/lib/Service/SpeechToText/SpeechToTextService.php
@@ -40,9 +40,9 @@ class SpeechToTextService {
 
 	public function __construct(
 		private ISpeechToTextManager $speechToTextManager,
-		private IRootFolder          $rootFolder,
-		private IConfig              $config,
-		private MetaTaskMapper       $metaTaskMapper,
+		private IRootFolder $rootFolder,
+		private IConfig $config,
+		private MetaTaskMapper $metaTaskMapper,
 	) {
 	}
 

--- a/lib/Service/SpeechToText/SpeechToTextService.php
+++ b/lib/Service/SpeechToText/SpeechToTextService.php
@@ -77,7 +77,7 @@ class SpeechToTextService {
 			$audioFile->getId(),
 			'speech-to-text',
 			Application::APP_ID,
-			Application::STT_TASK_SCHEDULED,
+			Application::STATUS_META_TASK_SCHEDULED,
 			Application::TASK_CATEGORY_SPEECH_TO_TEXT);
 	}
 
@@ -106,7 +106,7 @@ class SpeechToTextService {
 			$audioFile->getId(),
 			'speech-to-text',
 			Application::APP_ID,
-			Application::STT_TASK_SCHEDULED,
+			Application::STATUS_META_TASK_SCHEDULED,
 			Application::TASK_CATEGORY_SPEECH_TO_TEXT);
 	}
 

--- a/lib/Service/Text2Image/Text2ImageHelperService.php
+++ b/lib/Service/Text2Image/Text2ImageHelperService.php
@@ -17,7 +17,7 @@ use OCA\TpAssistant\Db\Text2Image\ImageGenerationMapper;
 use OCA\TpAssistant\Db\Text2Image\PromptMapper;
 use OCA\TpAssistant\Db\Text2Image\StaleGenerationMapper;
 
-use OCA\TpAssistant\Service\AssistantService;
+use OCA\TpAssistant\Service\NotificationService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http;
@@ -42,17 +42,17 @@ class Text2ImageHelperService {
 	private ?ISimpleFolder $imageDataFolder = null;
 
 	public function __construct(
-		private LoggerInterface       $logger,
-		private IManager              $textToImageManager,
-		private PromptMapper          $promptMapper,
+		private LoggerInterface $logger,
+		private IManager $textToImageManager,
+		private PromptMapper $promptMapper,
 		private ImageGenerationMapper $imageGenerationMapper,
-		private ImageFileNameMapper   $imageFileNameMapper,
+		private ImageFileNameMapper $imageFileNameMapper,
 		private StaleGenerationMapper $staleGenerationMapper,
-		private IAppData              $appData,
-		private IURLGenerator         $urlGenerator,
-		private IL10N                 $l10n,
-		private AssistantService      $assistantService,
-		private MetaTaskMapper        $metaTaskMapper,
+		private IAppData $appData,
+		private IURLGenerator $urlGenerator,
+		private IL10N $l10n,
+		private NotificationService $notificationService,
+		private MetaTaskMapper $metaTaskMapper,
 	) {
 	}
 
@@ -588,7 +588,7 @@ class Text2ImageHelperService {
 			// No need to update the output since it's already set
 			$assistantTask = $this->metaTaskMapper->update($assistantTask);
 
-			$this->assistantService->sendNotification($assistantTask);
+			$this->notificationService->sendNotification($assistantTask);
 		}
 	}
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -49,5 +49,6 @@
 	<stubs>
 		<file name="tests/stubs/oc_core_command_base.php" />
 		<file name="tests/stubs/oc_hooks_emitter.php" />
+		<file name="tests/stubs/oc_transcription.php" />
 	</stubs>
 </psalm>

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -15,7 +15,7 @@ export async function openAssistantForm(params) {
 /**
  * Creates an assistant modal and return a promise which provides the result
  *
- * OCA.TpAssistant.openAssistantTextProcessingForm({
+ * OCA.TPAssistant.openAssistantTextProcessingForm({
  *  appId: 'my_app_id',
  *  identifier: 'my task identifier',
  *  taskType: 'OCP\\TextProcessing\\FreePromptTaskType',

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -191,15 +191,15 @@ export async function runSttTask(inputs) {
 	const { default: axios } = await import(/* webpackChunkName: "axios-lazy" */'@nextcloud/axios')
 	const { generateUrl } = await import(/* webpackChunkName: "router-gen-lazy" */'@nextcloud/router')
 	saveLastSelectedTaskType('speech-to-text')
-	if (inputs.audioData) {
+	if (inputs.sttMode === 'choose') {
+		const url = generateUrl('/apps/assistant/stt/transcribeFile')
+		const params = { path: this.audioFilePath }
+		return axios.post(url, params)
+	} else {
 		const url = generateUrl('/apps/assistant/stt/transcribeAudio')
 		const formData = new FormData()
 		formData.append('audioData', inputs.audioData)
 		return axios.post(url, formData)
-	} else {
-		const url = generateUrl('/apps/assistant/stt/transcribeFile')
-		const params = { path: this.audioFilePath }
-		return axios.post(url, params)
 	}
 }
 

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -193,7 +193,7 @@ export async function runSttTask(inputs) {
 	saveLastSelectedTaskType('speech-to-text')
 	if (inputs.sttMode === 'choose') {
 		const url = generateUrl('/apps/assistant/stt/transcribeFile')
-		const params = { path: this.audioFilePath }
+		const params = { path: inputs.audioFilePath }
 		return axios.post(url, params)
 	} else {
 		const url = generateUrl('/apps/assistant/stt/transcribeAudio')

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -10,6 +10,8 @@ export async function openAssistantForm(params) {
 	return openAssistantTextProcessingForm(params)
 }
 
+// TODO add param to lock on specific task type
+
 /**
  * Creates an assistant modal and return a promise which provides the result
  *

--- a/src/components/AssistantFormInputs.vue
+++ b/src/components/AssistantFormInputs.vue
@@ -150,6 +150,16 @@ export default {
 				this.onUpdate()
 			}
 		},
+		inputs(newVal) {
+			this.writingStyle = this.inputs.writingStyle ?? ''
+			this.sourceMaterial = this.inputs.sourceMaterial ?? this.inputs.prompt ?? ''
+			this.prompt = this.inputs.prompt ?? ''
+			this.sttMode = 'record'
+			this.sttAudioData = null
+			this.sttAudioFilePath = this.inputs.audioFilePath ?? null
+			this.ttiNResults = this.inputs.nResults ?? 1
+			this.ttiDisplayPrompt = this.inputs.displayPrompt ?? false
+		},
 	},
 	mounted() {
 		if (this.selectedTaskTypeId === 'copywriter') {

--- a/src/components/AssistantFormInputs.vue
+++ b/src/components/AssistantFormInputs.vue
@@ -17,7 +17,10 @@
 				<NcButton
 					type="secondary"
 					@click="onChooseFile('writingStyle')">
-					{{ t('assistant','Choose File') }}
+					<template #icon>
+						<FileDocumentIcon />
+					</template>
+					{{ t('assistant','Choose file') }}
 				</NcButton>
 			</div>
 			<NcRichContenteditable
@@ -37,7 +40,10 @@
 				<NcButton
 					type="secondary"
 					@click="onChooseFile('sourceMaterial')">
-					{{ t('assistant','Choose File') }}
+					<template #icon>
+						<FileDocumentIcon />
+					</template>
+					{{ t('assistant','Choose file') }}
 				</NcButton>
 			</div>
 			<NcRichContenteditable
@@ -59,7 +65,10 @@
 				<NcButton
 					type="secondary"
 					@click="onChooseFile('prompt')">
-					{{ t('assistant','Choose File') }}
+					<template #icon>
+						<FileDocumentIcon />
+					</template>
+					{{ t('assistant','Choose file') }}
 				</NcButton>
 			</div>
 			<NcRichContenteditable
@@ -82,6 +91,8 @@
 </template>
 
 <script>
+import FileDocumentIcon from 'vue-material-design-icons/FileDocument.vue'
+
 import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContenteditable.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
@@ -115,6 +126,7 @@ export default {
 		SpeechToTextInputForm,
 		NcRichContenteditable,
 		NcButton,
+		FileDocumentIcon,
 	},
 	props: {
 		inputs: {

--- a/src/components/AssistantFormInputs.vue
+++ b/src/components/AssistantFormInputs.vue
@@ -154,8 +154,8 @@ export default {
 			this.writingStyle = this.inputs.writingStyle ?? ''
 			this.sourceMaterial = this.inputs.sourceMaterial ?? this.inputs.prompt ?? ''
 			this.prompt = this.inputs.prompt ?? ''
-			// this.sttMode = 'record'
-			this.sttAudioData = this.inputs.audioData
+			this.sttMode = this.inputs.sttMode ?? 'record'
+			this.sttAudioData = this.inputs.audioData ?? null
 			this.sttAudioFilePath = this.inputs.audioFilePath ?? null
 			this.ttiNResults = this.inputs.nResults ?? 1
 			this.ttiDisplayPrompt = this.inputs.displayPrompt ?? false
@@ -226,9 +226,11 @@ export default {
 		onUpdateStt() {
 			this.$emit(
 				'update:inputs',
-				this.sttMode === 'record'
-					? { audioData: this.sttAudioData }
-					: { audioFilePath: this.sttAudioFilePath },
+				{
+					sttMode: this.sttMode,
+					audioData: this.sttAudioData,
+					audioFilePath: this.sttAudioFilePath,
+				},
 			)
 		},
 		onUpdateTti() {

--- a/src/components/AssistantFormInputs.vue
+++ b/src/components/AssistantFormInputs.vue
@@ -154,8 +154,8 @@ export default {
 			this.writingStyle = this.inputs.writingStyle ?? ''
 			this.sourceMaterial = this.inputs.sourceMaterial ?? this.inputs.prompt ?? ''
 			this.prompt = this.inputs.prompt ?? ''
-			this.sttMode = 'record'
-			this.sttAudioData = null
+			// this.sttMode = 'record'
+			this.sttAudioData = this.inputs.audioData
 			this.sttAudioFilePath = this.inputs.audioFilePath ?? null
 			this.ttiNResults = this.inputs.nResults ?? 1
 			this.ttiDisplayPrompt = this.inputs.displayPrompt ?? false

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -29,7 +29,7 @@
 			</label>
 			<div v-if="mySelectedTaskTypeId === 'OCP\\TextToImage\\Task'"
 				ref="output">
-				<a :href="formattedOutput">{{ formattedOutput }}</a>
+				<a :href="formattedOutput" class="external">{{ formattedOutput }}</a>
 				<Text2ImageDisplay
 					:image-gen-id="myOutput" />
 			</div>
@@ -99,6 +99,21 @@
 				</NcButton>
 			</div>
 		</div>
+		<div class="history">
+			<NcButton class="advanced-button"
+				type="tertiary"
+				:aria-label="t('assistant', 'Show/hide task history')"
+				@click="showHistory = !showHistory">
+				<template #icon>
+					<ChevronDownIcon v-if="showHistory" />
+					<ChevronRightIcon v-else />
+				</template>
+				{{ t('assistant', 'Task history') }}
+			</NcButton>
+			<TaskList v-if="showHistory"
+				class="history--list"
+				:task-type="mySelectedTaskTypeId" />
+		</div>
 	</div>
 </template>
 
@@ -106,6 +121,8 @@
 import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 import ClipboardCheckOutlineIcon from 'vue-material-design-icons/ClipboardCheckOutline.vue'
 import CreationIcon from 'vue-material-design-icons/Creation.vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
 
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
@@ -116,6 +133,7 @@ import NcIconSvgWrapper from '@nextcloud/vue/dist/Components/NcIconSvgWrapper.js
 import TaskTypeSelect from './TaskTypeSelect.vue'
 import AssistantFormInputs from './AssistantFormInputs.vue'
 import Text2ImageDisplay from './Text2Image/Text2ImageDisplay.vue'
+import TaskList from './TaskList.vue'
 
 import axios from '@nextcloud/axios'
 import { generateOcsUrl, generateUrl } from '@nextcloud/router'
@@ -130,6 +148,7 @@ const FREE_PROMPT_TASK_TYPE_ID = 'OCP\\TextProcessing\\FreePromptTaskType'
 export default {
 	name: 'AssistantTextProcessingForm',
 	components: {
+		TaskList,
 		Text2ImageDisplay,
 		TaskTypeSelect,
 		NcButton,
@@ -139,6 +158,8 @@ export default {
 		CreationIcon,
 		ContentCopyIcon,
 		ClipboardCheckOutlineIcon,
+		ChevronDownIcon,
+		ChevronRightIcon,
 		NcNoteCard,
 		AssistantFormInputs,
 	},
@@ -176,6 +197,7 @@ export default {
 			taskTypes: [],
 			mySelectedTaskTypeId: this.selectedTaskTypeId || FREE_PROMPT_TASK_TYPE_ID,
 			copied: false,
+			showHistory: false,
 		}
 	},
 	computed: {
@@ -384,6 +406,17 @@ export default {
 			flex-wrap: wrap;
 			justify-content: end;
 			gap: 4px;
+		}
+	}
+
+	.history {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: end;
+
+		&--list {
+			width: 100%;
 		}
 	}
 

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -66,7 +66,7 @@
 				<template #icon>
 					<HistoryIcon />
 				</template>
-				{{ t('assistant', 'Previous tasks') }}
+				{{ t('assistant', 'Previous "{taskTypeName}" tasks', { taskTypeName: selectedTaskType.name }) }}
 			</NcButton>
 			<div class="footer--action-buttons">
 				<NcButton

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -59,35 +59,43 @@
 			</NcNoteCard>
 		</div>
 		<div class="footer">
-			<NcButton
-				v-if="showSubmit"
-				:type="submitButtonType"
-				class="submit-button"
-				:disabled="!canSubmit"
-				:title="t('assistant', 'Run a task')"
-				@click="onSyncSubmit">
-				{{ syncSubmitButtonLabel }}
+			<NcButton class="history-button"
+				:type="showHistory ? 'secondary' : 'tertiary'"
+				:aria-label="showHistory ? t('assistant', 'Hide previous tasks') : t('assistant', 'Show previous tasks')"
+				@click="showHistory = !showHistory">
 				<template #icon>
-					<NcLoadingIcon v-if="loading" />
-					<CreationIcon v-else />
+					<HistoryIcon />
 				</template>
+				{{ t('assistant', 'Previous tasks') }}
 			</NcButton>
-			<NcButton
-				v-if="hasOutput"
-				type="primary"
-				class="copy-button"
-				:title="t('assistant', 'Copy output')"
-				@click="onCopy">
-				{{ t('assistant', 'Copy') }}
-				<template #icon>
-					<ClipboardCheckOutlineIcon v-if="copied" />
-					<ContentCopyIcon v-else />
-				</template>
-			</NcButton>
-			<div v-if="hasOutput"
-				class="action-buttons">
+			<div class="footer--action-buttons">
 				<NcButton
-					v-for="(b, i) in actionButtons"
+					v-if="showSubmit"
+					:type="submitButtonType"
+					class="submit-button"
+					:disabled="!canSubmit"
+					:title="t('assistant', 'Run a task')"
+					@click="onSyncSubmit">
+					{{ syncSubmitButtonLabel }}
+					<template #icon>
+						<NcLoadingIcon v-if="loading" />
+						<CreationIcon v-else />
+					</template>
+				</NcButton>
+				<NcButton
+					v-if="hasOutput"
+					type="primary"
+					class="copy-button"
+					:title="t('assistant', 'Copy output')"
+					@click="onCopy">
+					{{ t('assistant', 'Copy') }}
+					<template #icon>
+						<ClipboardCheckOutlineIcon v-if="copied" />
+						<ContentCopyIcon v-else />
+					</template>
+				</NcButton>
+				<NcButton
+					v-for="(b, i) in actionButtonsToShow"
 					:key="i"
 					:type="b.type ?? 'secondary'"
 					:title="b.title"
@@ -100,16 +108,6 @@
 			</div>
 		</div>
 		<div class="history">
-			<NcButton class="advanced-button"
-				type="tertiary"
-				:aria-label="t('assistant', 'Show/hide previous tasks')"
-				@click="showHistory = !showHistory">
-				<template #icon>
-					<ChevronDownIcon v-if="showHistory" />
-					<ChevronRightIcon v-else />
-				</template>
-				{{ t('assistant', 'Previous tasks') }}
-			</NcButton>
 			<TaskList v-if="showHistory"
 				class="history--list"
 				:task-type="mySelectedTaskTypeId"
@@ -123,8 +121,7 @@
 import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 import ClipboardCheckOutlineIcon from 'vue-material-design-icons/ClipboardCheckOutline.vue'
 import CreationIcon from 'vue-material-design-icons/Creation.vue'
-import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
-import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
+import HistoryIcon from 'vue-material-design-icons/History.vue'
 
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
@@ -160,8 +157,7 @@ export default {
 		CreationIcon,
 		ContentCopyIcon,
 		ClipboardCheckOutlineIcon,
-		ChevronDownIcon,
-		ChevronRightIcon,
+		HistoryIcon,
 		NcNoteCard,
 		AssistantFormInputs,
 	},
@@ -259,6 +255,9 @@ export default {
 				return window.location.protocol + '//' + window.location.host + generateUrl('/apps/assistant/i/{imageGenId}', { imageGenId: this.myOutput })
 			}
 			return this.myOutput.trim()
+		},
+		actionButtonsToShow() {
+			return this.hasOutput ? this.actionButtons : []
 		},
 	},
 	watch: {
@@ -406,10 +405,11 @@ export default {
 	.footer {
 		width: 100%;
 		display: flex;
-		flex-wrap: wrap;
-		justify-content: end;
-		gap: 4px;
-		.action-buttons {
+		.history-button {
+			height: 44px;
+		}
+		&--action-buttons {
+			flex-grow: 1;
 			display: flex;
 			flex-wrap: wrap;
 			justify-content: end;

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -7,7 +7,7 @@
 		<TaskTypeSelect
 			:value.sync="mySelectedTaskTypeId"
 			class="task-custom-select"
-			:inline="3"
+			:inline="5"
 			:options="taskTypes" />
 		<h2 v-if="selectedTaskType"
 			class="task-name">
@@ -102,13 +102,13 @@
 		<div class="history">
 			<NcButton class="advanced-button"
 				type="tertiary"
-				:aria-label="t('assistant', 'Show/hide task history')"
+				:aria-label="t('assistant', 'Show/hide previous tasks')"
 				@click="showHistory = !showHistory">
 				<template #icon>
 					<ChevronDownIcon v-if="showHistory" />
 					<ChevronRightIcon v-else />
 				</template>
-				{{ t('assistant', 'Task history') }}
+				{{ t('assistant', 'Previous tasks') }}
 			</NcButton>
 			<TaskList v-if="showHistory"
 				class="history--list"

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -112,7 +112,9 @@
 			</NcButton>
 			<TaskList v-if="showHistory"
 				class="history--list"
-				:task-type="mySelectedTaskTypeId" />
+				:task-type="mySelectedTaskTypeId"
+				@try-again="$emit('try-again', $event)"
+				@load-task="$emit('load-task', $event)" />
 		</div>
 	</div>
 </template>
@@ -189,6 +191,8 @@ export default {
 		'sync-submit',
 		'submit',
 		'action-button-clicked',
+		'try-again',
+		'load-task',
 	],
 	data() {
 		return {

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -218,7 +218,11 @@ export default {
 			return this.selectedTaskType
 		},
 		canSubmit() {
-			// Check that none of the properties of myInputs are empty
+			if (this.selectedTaskType.id === 'speech-to-text') {
+				return (this.myInputs.sttMode === 'record' && this.myInputs.audioData !== null)
+					|| (this.myInputs.sttMode === 'choose' && this.myInputs.audioFilePath !== null)
+			}
+			// otherwise, check that none of the properties of myInputs are empty
 			return Object.values(this.myInputs).every(v => {
 				return (typeof v === 'string' && !!v?.trim())
 					|| (typeof v === 'boolean')

--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -35,7 +35,9 @@
 					:action-buttons="actionButtons"
 					@submit="onSubmit"
 					@sync-submit="onSyncSubmit"
-					@action-button-clicked="onActionButtonClicked" />
+					@action-button-clicked="onActionButtonClicked"
+					@try-again="$emit('try-again', $event)"
+					@load-task="$emit('load-task', $event)" />
 			</div>
 		</div>
 	</NcModal>
@@ -102,7 +104,12 @@ export default {
 	},
 	emits: [
 		'cancel',
+		'cancel-sync-n-schedule',
 		'submit',
+		'sync-submit',
+		'action-button-clicked',
+		'try-again',
+		'load-task',
 	],
 	data() {
 		return {

--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -116,7 +116,7 @@ export default {
 			show: true,
 			closeButtonTitle: t('assistant', 'Close'),
 			closeButtonLabel: t('assistant', 'Close Nextcloud Assistant'),
-			modalSize: 'normal',
+			modalSize: 'large',
 		}
 	},
 	computed: {

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -1,0 +1,88 @@
+<template>
+	<ul class="task-list">
+		<TaskListItem v-for="task in tasks"
+			:key="task.id"
+			class="task-list--item"
+			:task="task" />
+	</ul>
+</template>
+
+<script>
+import TaskListItem from './TaskListItem.vue'
+
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+export default {
+	name: 'TaskList',
+
+	components: {
+		TaskListItem,
+	},
+
+	props: {
+		taskType: {
+			type: [String, null],
+			default: null,
+		},
+	},
+
+	emits: [
+		'load-task',
+	],
+
+	data() {
+		return {
+			tasks: [],
+		}
+	},
+
+	computed: {
+	},
+
+	watch: {
+		taskType() {
+			this.getTasks()
+		},
+	},
+
+	mounted() {
+		this.getTasks()
+	},
+
+	methods: {
+		getTasks() {
+			this.loading = true
+			const req = {
+				params: {
+					taskType: this.taskType,
+				},
+			}
+			const url = generateUrl('/apps/assistant/tasks')
+			axios.get(url, req).then(response => {
+				this.tasks = response.data.tasks
+				console.debug('aaaaa tasks', response.data)
+			}).catch(error => {
+				console.error(error)
+			}).then(() => {
+				this.loading = false
+			})
+		},
+	},
+}
+</script>
+
+<style lang="scss">
+.task-list {
+	//display: flex;
+	//flex-direction: column;
+	//align-items: center;
+	//row-gap: 8px;
+	//column-gap: 6px;
+
+	&--item {
+		//margin: 0 12px 0 12px;
+		width: 99% !important;
+	}
+}
+</style>

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -7,6 +7,8 @@
 			:key="task.id"
 			class="task-list--item"
 			:task="task"
+			@try-again="$emit('try-again', task)"
+			@load="$emit('load-task', task)"
 			@delete="onTaskDelete(task)"
 			@cancel="onTaskCancel(task)" />
 	</ul>
@@ -39,6 +41,7 @@ export default {
 
 	emits: [
 		'load-task',
+		'try-again',
 	],
 
 	data() {
@@ -72,7 +75,6 @@ export default {
 			const url = generateUrl('/apps/assistant/tasks')
 			axios.get(url, req).then(response => {
 				this.tasks = response.data.tasks
-				console.debug('aaaaa tasks', response.data)
 			}).catch(error => {
 				console.error(error)
 			}).then(() => {

--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -5,7 +5,8 @@
 		:title="subName"
 		:bold="false"
 		:active="false"
-		:details="details">
+		:details="details"
+		@click="$emit('load')">
 		<template #icon>
 			<component :is="icon" />
 		</template>
@@ -16,6 +17,12 @@
 			<CheckboxBlankCircle :size="16" fill-color="#fff" />
 		</template-->
 		<template #actions>
+			<NcActionButton @click="$emit('try-again')">
+				<template #icon>
+					<RedoIcon />
+				</template>
+				{{ t('assistant', 'Try again') }}
+			</NcActionButton>
 			<NcActionButton v-if="isScheduled"
 				@click="$emit('cancel')">
 				<template #icon>
@@ -34,6 +41,7 @@
 </template>
 
 <script>
+import RedoIcon from 'vue-material-design-icons/Redo.vue'
 import ProgressQuestionIcon from 'vue-material-design-icons/ProgressQuestion.vue'
 import ProgressCheckIcon from 'vue-material-design-icons/ProgressCheck.vue'
 import ProgressClockIcon from 'vue-material-design-icons/ProgressClock.vue'
@@ -62,6 +70,7 @@ export default {
 		ProgressQuestionIcon,
 		CheckIcon,
 		AlertCircleOutlineIcon,
+		RedoIcon,
 	},
 
 	props: {
@@ -74,6 +83,8 @@ export default {
 	emits: [
 		'delete',
 		'cancel',
+		'try-again',
+		'load',
 	],
 
 	data() {

--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -8,7 +8,9 @@
 		:details="details"
 		@click="$emit('load')">
 		<template #icon>
-			<component :is="icon" :title="statusTitle" />
+			<component :is="icon"
+				style="margin-right: 8px;"
+				:title="statusTitle" />
 		</template>
 		<template #subname>
 			<Text2ImageInlineDisplay v-if="isSuccessful && isText2Image"
@@ -139,7 +141,7 @@ export default {
 				if (this.task.taskType === 'OCP\\TextToImage\\Task') {
 					return n('assistant', '{n} image has been generated', '{n} images have been generated', this.task.inputs.nResults, { n: this.task.inputs.nResults })
 				}
-				return t('assistant', 'Output') + ': ' + this.task.output
+				return t('assistant', 'Result') + ': ' + this.task.output
 			} else if (this.task.status === STATUS.scheduled) {
 				if (this.task.taskType === 'OCP\\TextToImage\\Task') {
 					return n('assistant', 'Generation of {n} image is scheduled', 'Generation of {n} images is scheduled', this.task.inputs.nResults, { n: this.task.inputs.nResults })

--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -1,0 +1,107 @@
+<template>
+	<NcListItem
+		class="task-list-item"
+		:name="name"
+		:bold="false"
+		:active="false"
+		:details="details"
+		:counter-number="counter">
+		<!--template #icon>
+			<NcAvatar disable-menu :size="44" user="janedoe" display-name="Jane Doe" />
+		</template-->
+		<template #subname>
+			{{ subName }}
+		</template>
+		<!--template #indicator>
+			<CheckboxBlankCircle :size="16" fill-color="#fff" />
+		</template-->
+		<template #actions>
+			<NcActionButton @click="cancelTask">
+				<template #icon>
+					<CloseIcon />
+				</template>
+				{{ t('assistant', 'Cancel') }}
+			</NcActionButton>
+			<NcActionButton @click="deleteTask">
+				<template #icon>
+					<DeleteIcon />
+				</template>
+				{{ t('assistant', 'Delete') }}
+			</NcActionButton>
+		</template>
+	</NcListItem>
+</template>
+
+<script>
+import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+
+import NcListItem from '@nextcloud/vue/dist/Components/NcListItem.js'
+import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+
+import { STATUS } from '../constants.js'
+
+export default {
+	name: 'TaskListItem',
+
+	components: {
+		NcListItem,
+		NcActionButton,
+		CloseIcon,
+		DeleteIcon,
+	},
+
+	props: {
+		task: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	emits: [
+		'delete',
+	],
+
+	data() {
+		return {
+		}
+	},
+
+	computed: {
+		name() {
+			if (this.task.taskType === 'copywriter') {
+				return this.task.inputs.sourceMaterial
+			} else if (this.task.taskType === 'speech-to-text') {
+				return t('assistant', 'Audio input')
+			}
+			return this.task.inputs.prompt ?? t('assistant', 'Unknown input')
+		},
+		subName() {
+			if (this.task.status === STATUS.successfull) {
+				if (this.task.taskType === 'OCP\\TextToImage\\Task') {
+					return n('assistant', '{n} image has been generated', '{n} images have been generated', this.task.inputs.nResults, { n: this.task.inputs.nResults })
+				}
+				return t('assistant', 'Output') + ': ' + this.task.output
+			}
+			return '??'
+		},
+	},
+
+	watch: {
+	},
+
+	mounted() {
+	},
+
+	methods: {
+	},
+}
+</script>
+
+<style lang="scss">
+:deep(.task-list-item) {
+	.list-item {
+		width: 99% !important;
+	}
+}
+</style>

--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -17,6 +17,14 @@
 			<CheckboxBlankCircle :size="16" fill-color="#fff" />
 		</template-->
 		<template #actions>
+			<NcActionButton v-if="isSuccessful"
+				:close-after-click="true"
+				@click="onCopyOutput">
+				<template #icon>
+					<ContentCopyIcon />
+				</template>
+				{{ t('assistant', 'Copy result') }}
+			</NcActionButton>
 			<NcActionButton @click="$emit('try-again')">
 				<template #icon>
 					<RedoIcon />
@@ -49,13 +57,20 @@ import AlertCircleOutlineIcon from 'vue-material-design-icons/AlertCircleOutline
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
+import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 
 import NcListItem from '@nextcloud/vue/dist/Components/NcListItem.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 
 import moment from '@nextcloud/moment'
+import { showError, showSuccess } from '@nextcloud/dialogs'
+
+import VueClipboard from 'vue-clipboard2'
+import Vue from 'vue'
 
 import { STATUS } from '../constants.js'
+
+Vue.use(VueClipboard)
 
 export default {
 	name: 'TaskListItem',
@@ -71,6 +86,7 @@ export default {
 		CheckIcon,
 		AlertCircleOutlineIcon,
 		RedoIcon,
+		ContentCopyIcon,
 	},
 
 	props: {
@@ -89,12 +105,16 @@ export default {
 
 	data() {
 		return {
+			copied: false,
 		}
 	},
 
 	computed: {
 		isScheduled() {
 			return this.task.status === STATUS.scheduled
+		},
+		isSuccessful() {
+			return this.task.status === STATUS.successfull
 		},
 		name() {
 			if (this.task.taskType === 'copywriter') {
@@ -158,6 +178,19 @@ export default {
 	},
 
 	methods: {
+		async onCopyOutput() {
+			try {
+				await this.$copyText(this.task.output.trim())
+				this.copied = true
+				setTimeout(() => {
+					this.copied = false
+				}, 5000)
+				showSuccess(t('assistant', 'Task result was copied to clipboard'))
+			} catch (error) {
+				console.error(error)
+				showError(t('assistant', 'Result could not be copied to clipboard'))
+			}
+		},
 	},
 }
 </script>

--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -8,7 +8,7 @@
 		:details="details"
 		@click="$emit('load')">
 		<template #icon>
-			<component :is="icon" />
+			<component :is="icon" :title="statusTitle" />
 		</template>
 		<template #subname>
 			{{ subName }}
@@ -136,6 +136,18 @@ export default {
 				return ProgressClockIcon
 			}
 			return ProgressQuestionIcon
+		},
+		statusTitle() {
+			if (this.task.status === STATUS.successfull) {
+				return t('assistant', 'Succeeded')
+			} else if (this.task.status === STATUS.failed) {
+				return t('assistant', 'Failed')
+			} else if (this.task.status === STATUS.running) {
+				return t('assistant', 'Running')
+			} else if (this.task.status === STATUS.scheduled) {
+				return t('assistant', 'Scheduled')
+			}
+			return t('assistant', 'Unknown status')
 		},
 	},
 

--- a/src/components/Text2Image/Text2ImageDisplay.vue
+++ b/src/components/Text2Image/Text2ImageDisplay.vue
@@ -156,6 +156,26 @@ export default {
 			return generateUrl('/apps/assistant/i/{imageGenId}', { imageGenId: this.imageGenId })
 		},
 	},
+	watch: {
+		imageGenId() {
+			this.prompt = ''
+			this.loadingImages = true
+			this.imgLoadedList = []
+			this.timeUntilCompletion = null
+			this.failed = false
+			this.imageUrls = []
+			this.isOwner = false
+			this.closed = false
+			this.fileVisStatusArray = []
+			this.hoveredIndex = -1
+			this.hovered = false
+			this.editModeEnabled = false
+			this.waitingInBg = false
+
+			this.getImageGenInfo()
+			this.editModeEnabled = this.forceEditMode
+		},
+	},
 	mounted() {
 		this.getImageGenInfo()
 		this.editModeEnabled = this.forceEditMode

--- a/src/components/Text2Image/Text2ImageInlineDisplay.vue
+++ b/src/components/Text2Image/Text2ImageInlineDisplay.vue
@@ -1,0 +1,132 @@
+<template>
+	<div class="display-container">
+		<NcLoadingIcon v-if="loadingInfo"
+			:size="20"
+			class="icon" />
+		<div v-else-if="failed">
+			{{ t('assistant', 'Failed to get images') }}
+		</div>
+		<div v-else
+			class="inline-images">
+			<img v-for="url in imageUrls"
+				:key="url"
+				class="image"
+				:src="url"
+				@error="onError">
+		</div>
+	</div>
+</template>
+
+<script>
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+export default {
+	name: 'Text2ImageInlineDisplay',
+
+	components: {
+		NcLoadingIcon,
+	},
+
+	props: {
+		imageGenId: {
+			type: String,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			loadingInfo: false,
+			failed: false,
+			imageUrls: [],
+		}
+	},
+
+	computed: {
+		infoUrl() {
+			return generateUrl('/apps/assistant/i/info/{imageGenId}', { imageGenId: this.imageGenId })
+		},
+	},
+	watch: {
+		imageGenId() {
+			this.failed = false
+			this.imageUrls = []
+			this.getImageGenInfo()
+		},
+	},
+	mounted() {
+		this.getImageGenInfo()
+	},
+	unmounted() {
+	},
+	methods: {
+		getImageGenInfo() {
+			this.imageUrls = []
+			this.loadingInfo = true
+			axios.get(this.infoUrl)
+				.then((response) => {
+					if (response.status === 200) {
+						if (response.data?.files !== undefined) {
+							if (response.data.files.length === 0) {
+								this.errorMsg = t('assistant', 'This generation has no visible images')
+								this.failed = true
+							} else {
+								this.imageUrls = response.data.files.map(file => {
+									return generateUrl('/apps/assistant/i/{imageGenId}/{fileId}', { imageGenId: this.imageGenId, fileId: file.id })
+								})
+							}
+						} else {
+							this.errorMsg = t('assistant', 'Unexpected server response')
+							this.failed = true
+						}
+					} else {
+						console.error('Unexpected response status: ' + response.status)
+						this.errorMsg = t('assistant', 'Unexpected server response')
+						this.failed = true
+					}
+				})
+				.catch((error) => {
+					this.onError(error)
+				})
+				.then(() => {
+					this.loadingInfo = false
+				})
+		},
+		onError(error) {
+			// If error response status is 429 let the user know that they are being rate limited
+			if (error.response?.status === 429) {
+				this.errorMsg = t('assistant', 'Rate limit reached. Please try again later.')
+				this.failed = true
+			} else if (error.response?.data !== undefined) {
+				this.errorMsg = error.response.data.error
+				this.failed = true
+			} else {
+				console.error('Could not handle response error: ' + error)
+				this.errorMsg = t('assistant', 'Unknown server query error')
+				this.failed = true
+			}
+
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.display-container {
+	display: flex;
+	flex-direction: column;
+	align-items: start;
+	justify-content: center;
+	.inline-images {
+		display: flex;
+		gap: 4px;
+		.image {
+			width: auto;
+			height: 30px;
+			border-radius: var(--border-radius);
+		}
+	}
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -7,12 +7,12 @@ import { subscribe } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 
 /**
- * - Expose OCA.TpAssistant.openTextProcessingModal to let apps use the assistant
+ * - Expose OCA.TPAssistant.openTextProcessingModal to let apps use the assistant
  * - Add a header right menu entry
  * - Listen to notification event
  */
 function init() {
-	if (!OCA.TpAssistant) {
+	if (!OCA.TPAssistant) {
 		/**
 		 * @namespace
 		 */

--- a/tests/stubs/oc_transcription.php
+++ b/tests/stubs/oc_transcription.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OC\SpeechToText {
+
+	use OCP\BackgroundJob\QueuedJob;
+
+	class TranscriptionJob extends QueuedJob
+	{
+		protected function run($argument)
+		{
+		}
+	}
+}

--- a/tests/stubs/oc_transcription.php
+++ b/tests/stubs/oc_transcription.php
@@ -4,10 +4,8 @@ namespace OC\SpeechToText {
 
 	use OCP\BackgroundJob\QueuedJob;
 
-	class TranscriptionJob extends QueuedJob
-	{
-		protected function run($argument)
-		{
+	class TranscriptionJob extends QueuedJob {
+		protected function run($argument) {
 		}
 	}
 }


### PR DESCRIPTION
Add task history as a list that can be toggled at the bottom of the assistant.
The list only contains tasks of the currently selected type.
With the context menu, tasks can be deleted, canceled (when status is scheduled) and repeated (try again if they were successful).
Clicking on a task item loads it in the form (inputs + output) so it can be viewed, edited and launched again.
The task list is visible in the main assistant modal, the one when opening a task result from a notification and in the dedicated assistant page showing a task result.

![image](https://github.com/nextcloud/assistant/assets/11291457/a3912e26-5f35-4153-ad11-5157bff6cf66)

@nimishavijay @jancborchardt I will deploy this on tech-preview soon. Any first feedback?
