### PR TITLE
Fix result display after task type change

### DIFF
--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -11,7 +11,8 @@
 			:value.sync="mySelectedTaskTypeId"
 			class="task-custom-select"
 			:inline="5"
-			:options="taskTypes" />
+			:options="taskTypes"
+			@update:value="onTaskTypeUserChange" />
 		<div v-if="showHistory"
 			class="history">
 			<div class="history--title">
@@ -256,15 +257,8 @@ export default {
 			})
 				&& this.selectedTaskType
 		},
-		submitButtonLabel() {
-			return this.hasOutput
-				? t('assistant', 'Try again')
-				: this.selectedTaskType.id === FREE_PROMPT_TASK_TYPE_ID
-					? t('assistant', 'Send request')
-					: this.selectedTaskType.name
-		},
 		syncSubmitButtonLabel() {
-			return this.output !== null
+			return this.hasOutput
 				? t('assistant', 'Try again')
 				: this.selectedTaskType.id === FREE_PROMPT_TASK_TYPE_ID
 					? t('assistant', 'Send request')
@@ -313,6 +307,9 @@ export default {
 				.then(() => {
 					this.loadingTaskTypes = false
 				})
+		},
+		onTaskTypeUserChange() {
+			this.myOutput = null
 		},
 		onSubmit() {
 			this.$emit('submit', { inputs: this.myInputs, selectedTaskTypeId: this.mySelectedTaskTypeId })

--- a/src/components/TaskTypeSelect.vue
+++ b/src/components/TaskTypeSelect.vue
@@ -106,7 +106,7 @@ export default {
 			// if the initially selected value is in the dropdown, get it out
 			const selectedAction = this.actionTypes.find(a => a.id === this.value)
 			if (this.actionTypes.find(a => a.id === this.value)) {
-				this.onMenuTaskSelected(selectedAction)
+				this.extraButtonType = selectedAction
 			}
 		},
 		getButtonType(taskType) {


### PR DESCRIPTION
* reset the form result if the user selects another task
* fix submit button label (avoid having "try again" after resetting the result)