### PR TITLE
Add empty content when history is empty

### DIFF
--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -32,7 +32,7 @@
 			</div>
 			<TaskList
 				class="history--list"
-				:task-type="mySelectedTaskTypeId"
+				:task-type="selectedTaskType"
 				:loading.sync="historyLoading"
 				@try-again="onHistoryTryAgain"
 				@load-task="onHistoryLoadTask" />

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -1,19 +1,32 @@
 <template>
-	<ul
-		class="task-list">
-		<TaskListItem v-for="task in tasks"
-			:key="task.id"
-			class="task-list--item"
-			:task="task"
-			@try-again="$emit('try-again', task)"
-			@load="$emit('load-task', task)"
-			@delete="onTaskDelete(task)"
-			@cancel="onTaskCancel(task)" />
-	</ul>
+	<div>
+		<ul
+			class="task-list">
+			<TaskListItem v-for="task in tasks"
+				:key="task.id"
+				class="task-list--item"
+				:task="task"
+				@try-again="$emit('try-again', task)"
+				@load="$emit('load-task', task)"
+				@delete="onTaskDelete(task)"
+				@cancel="onTaskCancel(task)" />
+		</ul>
+		<NcEmptyContent v-if="!loading && tasks.length === 0"
+			:name="t('assistant', 'Nothing yet')"
+			:description="emptyContentDescription">
+			<template #icon>
+				<HistoryIcon />
+			</template>
+		</NcEmptyContent>
+	</div>
 </template>
 
 <script>
+import HistoryIcon from 'vue-material-design-icons/History.vue'
+
 import TaskListItem from './TaskListItem.vue'
+
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
@@ -24,12 +37,14 @@ export default {
 	name: 'TaskList',
 
 	components: {
+		HistoryIcon,
 		TaskListItem,
+		NcEmptyContent,
 	},
 
 	props: {
 		taskType: {
-			type: [String, null],
+			type: [Object, null],
 			default: null,
 		},
 		loading: {
@@ -50,6 +65,9 @@ export default {
 	},
 
 	computed: {
+		emptyContentDescription() {
+			return t('assistant', 'You have not submitted any "{taskTypeName}" task yet', { taskTypeName: this.taskType?.name })
+		},
 	},
 
 	watch: {
@@ -67,7 +85,7 @@ export default {
 			this.$emit('update:loading', true)
 			const req = {
 				params: {
-					taskType: this.taskType,
+					taskType: this.taskType.id,
 				},
 			}
 			const url = generateOcsUrl('/apps/assistant/api/v1/tasks')


### PR DESCRIPTION
closes #62
The history task list is retrieved after the history button is clicked so we can't hide the button if the history is empty.
But we can show an empty content:

![image](https://github.com/nextcloud/assistant/assets/11291457/984665c1-df7b-4065-8bdf-55fbfd3a7eb8)
