### PR TITLE
Add standalone assistant page

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -11,6 +11,7 @@ return [
 		['name' => 'config#setAdminConfig', 'url' => '/admin-config', 'verb' => 'PUT'],
 
 		['name' => 'assistant#getAssistantTaskResultPage', 'url' => '/task/view/{metaTaskId}', 'verb' => 'GET'],
+		['name' => 'assistant#getAssistantStandalonePage', 'url' => '/', 'verb' => 'GET'],
 
 		['name' => 'Text2Image#showGenerationPage', 'url' => '/i/{imageGenId}', 'verb' => 'GET'],
 		['name' => 'Text2Image#getPromptHistory', 'url' => '/i/data/prompt_history', 'verb' => 'GET'],

--- a/lib/Controller/AssistantController.php
+++ b/lib/Controller/AssistantController.php
@@ -3,6 +3,7 @@
 namespace OCA\Assistant\Controller;
 
 use OCA\Assistant\AppInfo\Application;
+use OCA\Assistant\Db\MetaTask;
 use OCA\Assistant\Service\AssistantService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -11,6 +12,7 @@ use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\IConfig;
 use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
@@ -21,6 +23,7 @@ class AssistantController extends Controller {
 		IRequest $request,
 		private AssistantService $assistantService,
 		private IInitialState $initialStateService,
+		private IConfig $config,
 		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
@@ -37,8 +40,27 @@ class AssistantController extends Controller {
 			$task = $this->assistantService->getAssistantTask($this->userId, $metaTaskId);
 			if ($task !== null) {
 				$this->initialStateService->provideInitialState('task', $task->jsonSerializeCc());
-				return new TemplateResponse(Application::APP_ID, 'taskResultPage');
+				return new TemplateResponse(Application::APP_ID, 'assistantPage');
 			}
+		}
+		return new TemplateResponse('', '403', [], TemplateResponse::RENDER_AS_ERROR, Http::STATUS_FORBIDDEN);
+	}
+
+	/**
+	 * @return TemplateResponse
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function getAssistantStandalonePage(): TemplateResponse {
+		if ($this->userId !== null) {
+			$task = new MetaTask();
+			$task->setTaskType($this->config->getUserValue($this->userId, Application::APP_ID, 'last_task_type'));
+			$task->setUserId($this->userId);
+			$task->setAppId(Application::APP_ID);
+			$task->setInputs('{"prompt":""}');
+			$task->setIdentifier('');
+			$this->initialStateService->provideInitialState('task', $task->jsonSerializeCc());
+			return new TemplateResponse(Application::APP_ID, 'assistantPage');
 		}
 		return new TemplateResponse('', '403', [], TemplateResponse::RENDER_AS_ERROR, Http::STATUS_FORBIDDEN);
 	}

--- a/lib/Db/MetaTask.php
+++ b/lib/Db/MetaTask.php
@@ -103,6 +103,9 @@ class MetaTask extends Entity implements \JsonSerializable {
 	 * @return array
 	 */
 	public function getInputsAsArray(): array {
+		if ($this->inputs === null) {
+			return [];
+		}
 		return json_decode($this->inputs, true) ?? [];
 	}
 }

--- a/src/assistantPage.js
+++ b/src/assistantPage.js
@@ -1,0 +1,6 @@
+import Vue from 'vue'
+import AssistantPage from './views/AssistantPage.vue'
+Vue.mixin({ methods: { t, n } })
+
+const View = Vue.extend(AssistantPage)
+new View().$mount('#content')

--- a/src/taskResultPage.js
+++ b/src/taskResultPage.js
@@ -1,6 +1,0 @@
-import Vue from 'vue'
-import TaskResultPage from './views/TaskResultPage.vue'
-Vue.mixin({ methods: { t, n } })
-
-const View = Vue.extend(TaskResultPage)
-new View().$mount('#content')

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -1,8 +1,7 @@
 <template>
 	<NcContent app-name="assistant">
 		<NcAppContent>
-			<div v-if="task?.id"
-				class="assistant-wrapper">
+			<div class="assistant-wrapper">
 				<RunningEmptyContent
 					v-if="showSyncTaskRunning"
 					:description="shortInput"
@@ -48,7 +47,7 @@ import {
 import { STATUS } from '../constants.js'
 
 export default {
-	name: 'TaskResultPage',
+	name: 'AssistantPage',
 
 	components: {
 		ScheduledEmptyContent,
@@ -81,6 +80,7 @@ export default {
 	},
 
 	mounted() {
+		console.debug('[Assistant] task', this.task)
 	},
 
 	methods: {

--- a/templates/assistantPage.php
+++ b/templates/assistantPage.php
@@ -1,4 +1,4 @@
 <?php
 
 $appId = OCA\Assistant\AppInfo\Application::APP_ID;
-\OCP\Util::addScript($appId, $appId . '-taskResultPage');
+\OCP\Util::addScript($appId, $appId . '-assistantPage');

--- a/webpack.js
+++ b/webpack.js
@@ -23,7 +23,7 @@ webpackConfig.entry = {
 	personalSettings: { import: path.join(__dirname, 'src', 'personalSettings.js'), filename: appId + '-personalSettings.js' },
 	adminSettings: { import: path.join(__dirname, 'src', 'adminSettings.js'), filename: appId + '-adminSettings.js' },
 	main: { import: path.join(__dirname, 'src', 'main.js'), filename: appId + '-main.js' },
-	taskResultPage: { import: path.join(__dirname, 'src', 'taskResultPage.js'), filename: appId + '-taskResultPage.js' },
+	assistantPage: { import: path.join(__dirname, 'src', 'assistantPage.js'), filename: appId + '-assistantPage.js' },
 }
 
 webpackConfig.plugins.push(


### PR DESCRIPTION
This makes the task result page able to show an empty task. It is reachable at `apps/assistant/`. This might be useful for clients that want to open the "raw" assistant in a browser.