### PR TITLE
prepare 1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 1.0.9 – 2024-05-06
+
+### Added
+
+- support RTF files @julien-nc [#66](https://github.com/nextcloud/assistant/pull/66)
+- new assistant standalone page @julien-nc [#72](https://github.com/nextcloud/assistant/pull/72)
+
+### Changed
+
+- use ITempManager instead of manually handling temp files @kyteinksy [#71](https://github.com/nextcloud/assistant/pull/71)
+
+### Fixed
+
+- fix audio transcription smart picker not setting appId and identifier params in the schedule request
+
 ## 1.0.8 – 2024-04-15
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -56,7 +56,7 @@ Known providers:
 * [OpenAi/LocalAI integration](https://apps.nextcloud.com/apps/integration_openai)
 * [Local Whisper Speech-To-Text](https://apps.nextcloud.com/apps/stt_whisper)
 ]]>	</description>
-	<version>1.0.8</version>
+	<version>1.0.9</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Assistant</namespace>


### PR DESCRIPTION
### Added

- support RTF files @julien-nc [#66](https://github.com/nextcloud/assistant/pull/66)
- new assistant standalone page @julien-nc [#72](https://github.com/nextcloud/assistant/pull/72)

### Changed

- use ITempManager instead of manually handling temp files @kyteinksy [#71](https://github.com/nextcloud/assistant/pull/71)

### Fixed

- fix audio transcription smart picker not setting appId and identifier params in the schedule request