### PR TITLE
2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.1.0 – 2024-09-30
+
+### Added
+
+- Add back buttons after launching a task @julien-nc [#131](https://github.com/nextcloud/assistant/pull/131)
+- Close the task history item menu when canceling a task @julien-nc [#131](https://github.com/nextcloud/assistant/pull/131)
+- Render context chat's the referenced source items @kyteinsky [#124](https://github.com/nextcloud/assistant/pull/124)
+
+### Changed
+
+- Migrate to vite build system @julien-nc [#125](https://github.com/nextcloud/assistant/pull/125)
+- Switch audio recorder to extendable-media-recorder @julien-nc [#125](https://github.com/nextcloud/assistant/pull/125)
+
+### Fixed
+
+- Enable submit button without scope in context chat @kyteinsky [#128](https://github.com/nextcloud/assistant/pull/128)
+
 ## 2.0.4 – 2024-09-04
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -58,7 +58,7 @@ Known providers:
 
 More details on how to set this up in the [admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html)
 ]]>	</description>
-	<version>2.0.4</version>
+	<version>2.1.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Assistant</namespace>


### PR DESCRIPTION
## 2.1.0 – 2024-09-30

### Added

- Add back buttons after launching a task @julien-nc [#131](https://github.com/nextcloud/assistant/pull/131)
- Close the task history item menu when canceling a task @julien-nc [#131](https://github.com/nextcloud/assistant/pull/131)
- Render context chat's the referenced source items @kyteinsky [#124](https://github.com/nextcloud/assistant/pull/124)

### Changed

- Migrate to vite build system @julien-nc [#125](https://github.com/nextcloud/assistant/pull/125)
- Switch audio recorder to extendable-media-recorder @julien-nc [#125](https://github.com/nextcloud/assistant/pull/125)

### Fixed

- Enable submit button without scope in context chat @kyteinsky [#128](https://github.com/nextcloud/assistant/pull/128)
