### PR TITLE
Display task error message in history

### DIFF
--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -168,6 +168,10 @@ export default {
 					return n('assistant', 'Generation of {n} image is scheduled', 'Generation of {n} images is scheduled', nbImageAsked, { n: nbImageAsked })
 				}
 				return t('assistant', 'This task is scheduled')
+			} else if (this.task.status === TASK_STATUS_STRING.failed) {
+				return this.task.error_message
+					? statusTitles[this.task.status] + ': ' + this.task.error_message
+					: statusTitles[this.task.status]
 			}
 			return statusTitles[this.task.status] ?? t('assistant', 'Unknown status')
 		},


### PR DESCRIPTION
Soft dependency on https://github.com/nextcloud/server/pull/48485
Keep the previous behaviour if no `error_message` key is there in the task objects.