### PR TITLE
Fix incorrect task type prop set when trying again

### DIFF
--- a/src/assistant.js
+++ b/src/assistant.js
@@ -123,12 +123,13 @@ export async function openAssistantForm({
 			syncSubmit(data.inputs, data.selectedTaskTypeId, customId || identifier)
 		})
 		view.$on('try-again', (task) => {
-			syncSubmit(task.input, task.taskType)
+			console.debug('[assistant] try again', task)
+			syncSubmit(task.input, task.type)
 		})
 		view.$on('load-task', (task) => {
 			if (!view.loading) {
 				console.debug('[assistant] loading task', task)
-				view.selectedTaskTypeId = task.taskType
+				view.selectedTaskTypeId = task.type
 				view.inputs = task.input
 				view.outputs = task.status === TASK_STATUS_STRING.successful ? task.output : null
 				view.selectedTaskId = task.id
@@ -396,11 +397,11 @@ export async function openAssistantTask(task, { isInsideViewer = undefined, acti
 		syncSubmit(data.inputs, data.selectedTaskTypeId, task.identifier ?? '')
 	})
 	view.$on('try-again', (task) => {
-		syncSubmit(task.input, task.taskType)
+		syncSubmit(task.input, task.type)
 	})
 	view.$on('load-task', (task) => {
 		if (!view.loading) {
-			view.selectedTaskTypeId = task.taskType
+			view.selectedTaskTypeId = task.type
 			view.inputs = task.input
 			view.outputs = task.status === TASK_STATUS_STRING.successful ? task.output : null
 			view.selectedTaskId = task.id

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -20,7 +20,7 @@
 					:selected-task-id="task.id"
 					:inputs="task.input"
 					:outputs="task.output"
-					:selected-task-type-id="task.taskType"
+					:selected-task-type-id="task.type"
 					:loading="loading"
 					@sync-submit="onSyncSubmit"
 					@try-again="onTryAgain"
@@ -111,7 +111,7 @@ export default {
 			this.showSyncTaskRunning = true
 			this.progress = null
 			this.task.input = inputs
-			this.task.taskType = taskTypeId
+			this.task.type = taskTypeId
 			scheduleTask('assistant', this.task.identifier, taskTypeId, inputs)
 				.then((response) => {
 					console.debug('Assistant SYNC result', response.data?.ocs?.data)


### PR DESCRIPTION
The "try again" action (in the task history items) was broken. It was using a wrong prop from the task object, resulting in not setting the task type parameter when calling the scheduling endpoint.