### PR TITLE
Fix navigation icon color

### DIFF
--- a/src/components/AssistantHeaderMenuEntry.vue
+++ b/src/components/AssistantHeaderMenuEntry.vue
@@ -70,7 +70,7 @@ export default {
 			background-color: rgba(0,0,0,0) !important;
 		}
 		.menu-icon {
-			color: var(--color-primary-text) !important;
+			color: var(--color-background-plain-text) !important;
 		}
 	}
 }


### PR DESCRIPTION
It was based on the primary color instead of the background color.
So if the primary color was dark and the background was light, the assistant navigation icon was light and vice versa.