### PR TITLE
Fix polling new chat message when switching sessions

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -24,6 +24,7 @@ return [
 		['name' => 'chattyLLM#getMessages', 'url' => '/chat/messages', 'verb' => 'GET'],
 		['name' => 'chattyLLM#generateForSession', 'url' => '/chat/generate', 'verb' => 'GET'],
 		['name' => 'chattyLLM#regenerateForSession', 'url' => '/chat/regenerate', 'verb' => 'GET'],
+		['name' => 'chattyLLM#checkMessageGenerationSession', 'url' => '/chat/check_session', 'verb' => 'GET'],
 		['name' => 'chattyLLM#checkMessageGenerationTask', 'url' => '/chat/check_generation', 'verb' => 'GET'],
 		['name' => 'chattyLLM#generateTitle', 'url' => '/chat/generate_title', 'verb' => 'GET'],
 		['name' => 'chattyLLM#checkTitleGenerationTask', 'url' => '/chat/check_title_generation', 'verb' => 'GET'],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -4,6 +4,7 @@ namespace OCA\Assistant\AppInfo;
 
 use OCA\Assistant\Capabilities;
 use OCA\Assistant\Listener\BeforeTemplateRenderedListener;
+use OCA\Assistant\Listener\ChattyLLMTaskListener;
 use OCA\Assistant\Listener\CSPListener;
 use OCA\Assistant\Listener\FreePrompt\FreePromptReferenceListener;
 use OCA\Assistant\Listener\SpeechToText\SpeechToTextReferenceListener;
@@ -55,6 +56,7 @@ class Application extends App implements IBootstrap {
 
 		$context->registerEventListener(TaskSuccessfulEvent::class, TaskSuccessfulListener::class);
 		$context->registerEventListener(TaskFailedEvent::class, TaskFailedListener::class);
+		$context->registerEventListener(TaskSuccessfulEvent::class, ChattyLLMTaskListener::class);
 
 		$context->registerNotifierService(Notifier::class);
 

--- a/lib/Listener/ChattyLLMTaskListener.php
+++ b/lib/Listener/ChattyLLMTaskListener.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Assistant\Listener;
+
+use OCA\Assistant\AppInfo\Application;
+use OCA\Assistant\Db\ChattyLLM\Message;
+use OCA\Assistant\Db\ChattyLLM\MessageMapper;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\TaskProcessing\Events\TaskSuccessfulEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @template-implements IEventListener<TaskSuccessfulEvent>
+ */
+class ChattyLLMTaskListener implements IEventListener {
+
+	public function __construct(
+		private MessageMapper $messageMapper,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof TaskSuccessfulEvent)) {
+			return;
+		}
+
+		$task = $event->getTask();
+		$customId = $task->getCustomId();
+		$appId = $task->getAppId();
+		if ($appId !== (Application::APP_ID . ':chatty-llm')
+			|| $customId === null
+			|| !preg_match('/^chatty-llm:(\d+)$/', $customId, $matches)
+		) {
+			return;
+		}
+		$sessionId = (int)$matches[1];
+
+		$message = new Message();
+		$message->setSessionId($sessionId);
+		$message->setRole('assistant');
+		$message->setContent(trim($task->getOutput()['output'] ?? ''));
+		$message->setTimestamp(time());
+		try {
+			$this->messageMapper->insert($message);
+		} catch (\OCP\DB\Exception $e) {
+			$this->logger->error('Message insertion error in chattyllm task listener', ['exception' => $e]);
+		}
+	}
+}

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -219,6 +219,7 @@ export default {
 
 	watch: {
 		async active() {
+			this.loading.llmGeneration = false
 			this.allMessagesLoaded = false
 			this.chatContent = ''
 			this.msgCursor = 0
@@ -226,13 +227,37 @@ export default {
 			this.editingTitle = false
 			this.$refs.inputComponent.focus()
 
-			if (this.active != null && !this.loading.newSession) {
+			if (this.active !== null && !this.loading.newSession) {
 				await this.fetchMessages()
 				this.scrollToBottom()
 			} else {
 				// when no active session or creating a new session
 				this.allMessagesLoaded = true
 				this.loading.newSession = false
+				return
+			}
+			// start polling in case a message is currently being generated
+			try {
+				const checkSessionResponse = await axios.get(getChatURL('/check_session'), { params: { sessionId: this.active.id } })
+				console.debug('check session response:', checkSessionResponse)
+				if (checkSessionResponse.data.taskId === null) {
+					return
+				}
+				try {
+					this.loading.llmGeneration = true
+					const message = await this.pollGenerationTask(checkSessionResponse.data.taskId, this.active.id)
+					console.debug('checkTaskPolling result:', message)
+					this.messages.push(message)
+					this.scrollToBottom()
+				} catch (error) {
+					console.error('checkGenerationTask error:', error)
+					showError(t('assistant', 'Error generating a response'))
+				} finally {
+					this.loading.llmGeneration = false
+				}
+			} catch (error) {
+				console.error('check session error:', error)
+				showError(t('assistant', 'Error checking if the session is thinking'))
 			}
 		},
 	},
@@ -328,7 +353,7 @@ export default {
 			this.messages.push({ role, content, timestamp })
 			this.chatContent = ''
 			this.scrollToBottom()
-			await this.newMessage(role, content, timestamp)
+			await this.newMessage(role, content, timestamp, this.active.id)
 		},
 
 		onLoadOlderMessages() {
@@ -466,13 +491,13 @@ export default {
 			}
 		},
 
-		async newMessage(role, content, timestamp) {
+		async newMessage(role, content, timestamp, sessionId) {
 			try {
 				this.loading.newHumanMessage = true
 				const firstHumanMessage = this.messages.length === 1 && this.messages[0].role === Roles.HUMAN
 
 				const response = await axios.put(getChatURL('/new_message'), {
-					sessionId: this.active.id,
+					sessionId,
 					role,
 					content,
 					timestamp,
@@ -485,11 +510,11 @@ export default {
 				this.messages[this.messages.length - 1] = response.data
 
 				if (firstHumanMessage) {
-					const session = this.sessions.find((session) => session.id === this.active.id)
+					const session = this.sessions.find((session) => session.id === sessionId)
 					session.title = content
 				}
 
-				await this.runGenerationTask()
+				await this.runGenerationTask(sessionId)
 			} catch (error) {
 				this.loading.newHumanMessage = false
 				console.error('newMessage error:', error)
@@ -521,12 +546,12 @@ export default {
 			}
 		},
 
-		async runGenerationTask() {
+		async runGenerationTask(sessionId) {
 			try {
 				this.loading.llmGeneration = true
-				const response = await axios.get(getChatURL('/generate'), { params: { sessionId: this.active.id } })
+				const response = await axios.get(getChatURL('/generate'), { params: { sessionId } })
 				console.debug('scheduleGenerationTask response:', response)
-				const message = await this.pollGenerationTask(response.data.taskId)
+				const message = await this.pollGenerationTask(response.data.taskId, sessionId)
 				console.debug('checkTaskPolling result:', message)
 				this.messages.push(message)
 				this.scrollToBottom()
@@ -540,10 +565,11 @@ export default {
 
 		async runRegenerationTask(messageId) {
 			try {
+				const sessionId = this.active.id
 				this.loading.llmGeneration = true
-				const response = await axios.get(getChatURL('/regenerate'), { params: { messageId, sessionId: this.active.id } })
+				const response = await axios.get(getChatURL('/regenerate'), { params: { messageId, sessionId } })
 				console.debug('scheduleRegenerationTask response:', response)
-				const message = await this.pollGenerationTask(response.data.taskId)
+				const message = await this.pollGenerationTask(response.data.taskId, sessionId)
 				console.debug('checkTaskPolling result:', message)
 				this.messages[this.messages.length - 1] = message
 				this.scrollToBottom()
@@ -555,16 +581,25 @@ export default {
 			}
 		},
 
-		async pollGenerationTask(taskId) {
+		async pollGenerationTask(taskId, sessionId) {
 			return new Promise((resolve, reject) => {
 				this.pollMessageGenerationTimerId = setInterval(() => {
 					axios.get(
 						getChatURL('/check_generation'),
-						{ params: { taskId, sessionId: this.active.id } },
+						{ params: { taskId, sessionId } },
 					).then(response => {
 						clearInterval(this.pollMessageGenerationTimerId)
-						resolve(response.data)
+						if (sessionId === this.active.id) {
+							resolve(response.data)
+						} else {
+							console.debug('Ignoring received a message for session ' + sessionId + ' that is not selected anymore')
+							// should we reject here?
+						}
 					}).catch(error => {
+						if (sessionId !== this.active.id) {
+							console.debug('Stop polling session ' + sessionId + ' because it is not selected anymore')
+							clearInterval(this.pollMessageGenerationTimerId)
+						}
 						// do not reject if response code is Http::STATUS_EXPECTATION_FAILED (417)
 						if (error.response?.status !== 417) {
 							console.error('checkTaskPolling error', error)

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.23.1@8471a896ccea3526b26d082f4461eeea467f10a4">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="lib/Controller/AssistantController.php">
     <TooManyArguments>
       <code><![CDATA[new Task(
@@ -13,7 +13,7 @@
   </file>
   <file src="lib/Controller/ChattyLLMController.php">
     <TooManyArguments>
-      <code><![CDATA[new Task(TextToText::ID, ['input' => $content], Application::APP_ID . ':chatty-llm', $this->userId)]]></code>
+      <code><![CDATA[new Task(TextToText::ID, ['input' => $content], Application::APP_ID . ':chatty-llm', $this->userId, $customId)]]></code>
     </TooManyArguments>
   </file>
   <file src="lib/Service/AssistantService.php">


### PR DESCRIPTION
closes #154
(This replaces it)

Add a new endpoint to check if a session is in a "thinking" state (meaning it currently has a scheduled/running task).
Use this endpoint to know if we should start polling when switching sessions.

Extra changes:

* Prevent scheduling multiple llm tasks for one session
* Fix using incorrect session ID in run/poll methods in the frontend