### PR TITLE
fix(notifier): check if task type is there before getting its name

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -95,8 +95,10 @@ class Notifier implements INotifier {
 				$taskInput = $l->t('Writing style: %1$s; Source material: %2$s', [$params['inputs']['writingStyle'], $params['inputs']['sourceMaterial']]);
 			} else {
 				$availableTaskTypes = $this->taskProcessingManager->getAvailableTaskTypes();
-				$taskType = $availableTaskTypes[$params['taskTypeId']];
-				$taskTypeName = $taskType['name'];
+				if (isset($availableTaskTypes[$params['taskTypeId']])) {
+					$taskType = $availableTaskTypes[$params['taskTypeId']];
+					$taskTypeName = $taskType['name'];
+				}
 			}
 		} catch (\Exception | \Throwable $e) {
 			$this->logger->debug('Impossible to get task type ' . $params['taskTypeId'], ['exception' => $e]);


### PR DESCRIPTION
This can happen if there is a (non-dismissed) notification for a task with a task type that is not available anymore (because the related app has been disabled for example).