### PR TITLE
Fix config value types for some bools and ints we store

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -62,7 +62,7 @@ Known providers:
 
 More details on how to set this up in the [admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html)
 ]]>	</description>
-	<version>2.2.0</version>
+	<version>2.2.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Assistant</namespace>

--- a/lib/Migration/Version020201Date20250120174409.php
+++ b/lib/Migration/Version020201Date20250120174409.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Assistant\Migration;
+
+use Closure;
+use OCA\Assistant\AppInfo\Application;
+use OCP\IAppConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version020201Date20250120174409 extends SimpleMigrationStep {
+
+	public function __construct(
+		private IAppConfig $appConfig,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return void
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		// some app values were types as INT
+		// https://github.com/nextcloud/assistant/issues/174
+		$keysToFix = [
+			'assistant_enabled',
+			'chat_last_n_messages',
+			'free_prompt_picker_enabled',
+			'speech_to_text_picker_enabled',
+			'text_to_image_picker_enabled',
+		];
+		foreach ($keysToFix as $key) {
+			if ($this->appConfig->hasKey(Application::APP_ID, $key)
+				&& $this->appConfig->getValueType(Application::APP_ID, $key) === IAppConfig::VALUE_INT) {
+				$value = $this->appConfig->getValueInt(Application::APP_ID, $key);
+				$this->appConfig->deleteKey(Application::APP_ID, $key);
+				$this->appConfig->setValueString(Application::APP_ID, $key, (string)$value);
+			}
+		}
+	}
+}


### PR DESCRIPTION
closes #174

For some reason, some app config values were stored as integers. I think we never did that in the app. There might have been a server migration or repair step that sets the type to integer when the stored value looks like an integer.

We historically store all values as string (because we were using IConfig) and kept that even with typed values in IAppConfig. I'm pretty sure we didn't mess with those values in the Assistant.