### PR TITLE
Prepare 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.3.0 – 2025-01-22
+
+### Changed
+
+- Save default target language & set detect_language as origin default @janepie @julien-nc [#167](https://github.com/nextcloud/assistant/pull/167)
+- Hide ChatWithTools and ContextAgentInteraction task types @julien-nc [#172](https://github.com/nextcloud/assistant/pull/172)
+- Add reuse compliance @AndyScherzinger [#163](https://github.com/nextcloud/assistant/pull/163)
+
+### Fixed
+
+- Fix config value types for some bools and ints we store @julien-nc [#174](https://github.com/nextcloud/assistant/pull/174)
+
 ## 2.2.0 – 2025-01-07
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -62,7 +62,7 @@ Known providers:
 
 More details on how to set this up in the [admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html)
 ]]>	</description>
-	<version>2.2.1</version>
+	<version>2.3.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Assistant</namespace>


### PR DESCRIPTION
### Changed

- Save default target language & set detect_language as origin default @janepie @julien-nc [#167](https://github.com/nextcloud/assistant/pull/167)
- Hide ChatWithTools and ContextAgentInteraction task types @julien-nc [#172](https://github.com/nextcloud/assistant/pull/172)
- Add reuse compliance @AndyScherzinger [#163](https://github.com/nextcloud/assistant/pull/163)

### Fixed

- Fix config value types for some bools and ints we store @julien-nc [#174](https://github.com/nextcloud/assistant/pull/174)