### PR TITLE
Fix: delete assistant modal title

### DIFF
--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -7,6 +7,7 @@
 		:size="modalSize"
 		:can-close="false"
 		:name="t('assistant', 'Nextcloud Assistant')"
+		dark
 		class="assistant-modal"
 		@close="onCancel">
 		<div ref="modal_content"


### PR DESCRIPTION
fixes #118 

keeps the string as labelId for accessibility reasons