### PR TITLE
Show image results full width

### DIFF
--- a/src/components/fields/ImageDisplay.vue
+++ b/src/components/fields/ImageDisplay.vue
@@ -84,7 +84,10 @@ export default {
 .image-display {
 	display: flex;
 	img {
-		width: 200px;
+		// we could use object-fit:cover instead and keep width=200 but the image preview would just show a portion of the image
+		// object-fit: cover;
+		// width: 200px;
+		width: auto;
 		height: 200px;
 	}
 }


### PR DESCRIPTION
Instead of cropping the image, forcing the width to be 200px.
We could also use `object-fit: cover` to keep a square preview and just show a part of the image.

### Before

![image](https://github.com/user-attachments/assets/3cfa2ae4-d306-4643-bed9-1a6644872895)

### After

![image](https://github.com/user-attachments/assets/b9b6613c-9d2b-45a6-932a-55006e68a7c0)

closes #182