### PR TITLE
Improve media download and preview endpoints

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -44,5 +44,6 @@ return [
 		['name' => 'assistantApi#getUserFileInfo', 'url' => '/api/{apiVersion}/file/{fileId}/info', 'verb' => 'GET', 'requirements' => $requirements],
 		['name' => 'assistantApi#shareOutputFile', 'url' => '/api/{apiVersion}/task/{ocpTaskId}/file/{fileId}/share', 'verb' => 'POST', 'requirements' => $requirements],
 		['name' => 'assistantApi#getOutputFilePreview', 'url' => '/api/{apiVersion}/task/{ocpTaskId}/output-file/{fileId}/preview', 'verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'assistantApi#getOutputFile', 'url' => '/api/{apiVersion}/task/{ocpTaskId}/output-file/{fileId}/download', 'verb' => 'GET', 'requirements' => $requirements],
 	],
 ];

--- a/lib/Controller/AssistantApiController.php
+++ b/lib/Controller/AssistantApiController.php
@@ -254,12 +254,14 @@ class AssistantApiController extends OCSController {
 	}
 
 	/**
-	 * Get output file preview
+	 * Get task output file preview
 	 *
 	 * Generate and get a preview of a task output file
 	 *
 	 * @param int $ocpTaskId The task ID
 	 * @param int $fileId The task output file ID
+	 * @param int|null $x Optional preview width in pixels
+	 * @param int|null $y Optional preview height in pixels
 	 * @return DataDownloadResponse<Http::STATUS_OK, string, array{}>|DataResponse<Http::STATUS_NOT_FOUND, '', array{}>|RedirectResponse<Http::STATUS_SEE_OTHER, array{}>
 	 *
 	 * 200: The file preview has been generated and is returned
@@ -268,20 +270,22 @@ class AssistantApiController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[NoCsrfRequired]
-	public function getOutputFilePreview(int $ocpTaskId, int $fileId): RedirectResponse|DataDownloadResponse|DataResponse {
+	public function getOutputFilePreview(int $ocpTaskId, int $fileId, ?int $x = 100, ?int $y = 100): RedirectResponse|DataDownloadResponse|DataResponse {
 		try {
-			$preview = $this->assistantService->getOutputFilePreviewFile($this->userId, $ocpTaskId, $fileId);
+			$preview = $this->assistantService->getOutputFilePreviewFile($this->userId, $ocpTaskId, $fileId, $x, $y);
 			if ($preview === null) {
 				$this->logger->error('No preview for user "' . $this->userId . '"');
 				return new DataResponse('', Http::STATUS_NOT_FOUND);
 			}
 
 			if ($preview['type'] === 'file') {
-				return new DataDownloadResponse(
+				$response = new DataDownloadResponse(
 					$preview['file']->getContent(),
-					'preview',
+					$ocpTaskId . '-' . $fileId . '-preview',
 					$preview['file']->getMimeType()
 				);
+				$response->cacheFor(60 * 60 * 24, false, true);
+				return $response;
 			} elseif ($preview['type'] === 'icon') {
 				return new RedirectResponse($preview['icon']);
 			}
@@ -290,5 +294,36 @@ class AssistantApiController extends OCSController {
 			return new DataResponse('', Http::STATUS_NOT_FOUND);
 		}
 		return new DataResponse('', Http::STATUS_NOT_FOUND);
+	}
+
+	/**
+	 * Get task output file
+	 *
+	 * Get a real task output file
+	 *
+	 * @param int $ocpTaskId The task ID
+	 * @param int $fileId The task output file ID
+	 * @return DataDownloadResponse<Http::STATUS_OK, string, array{}>|DataResponse<Http::STATUS_NOT_FOUND, '', array{}>
+	 *
+	 * 200: The file preview has been generated and is returned
+	 * 404: The output file is not found
+	 */
+	#[NoAdminRequired]
+	#[NoCsrfRequired]
+	public function getOutputFile(int $ocpTaskId, int $fileId): DataDownloadResponse|DataResponse {
+		try {
+			$taskOutputFile = $this->assistantService->getTaskOutputFile($this->userId, $ocpTaskId, $fileId);
+			$realMime = mime_content_type($taskOutputFile->fopen('rb'));
+			$response = new DataDownloadResponse(
+				$taskOutputFile->getContent(),
+				$ocpTaskId . '-' . $fileId,
+				$realMime ?: 'application/octet-stream',
+			);
+			$response->cacheFor(60 * 60 * 24, false, true);
+			return $response;
+		} catch (Exception|Throwable $e) {
+			$this->logger->error('getOutputFile error', ['exception' => $e]);
+			return new DataResponse('', Http::STATUS_NOT_FOUND);
+		}
 	}
 }

--- a/lib/Controller/AssistantApiController.php
+++ b/lib/Controller/AssistantApiController.php
@@ -20,6 +20,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\OCSController;
 use OCP\DB\Exception;
+use OCP\Files\File;
 use OCP\Files\GenericFileException;
 use OCP\Files\NotPermittedException;
 use OCP\IL10N;
@@ -279,10 +280,12 @@ class AssistantApiController extends OCSController {
 			}
 
 			if ($preview['type'] === 'file') {
+				/** @var File $file */
+				$file = $preview['type'];
 				$response = new DataDownloadResponse(
-					$preview['file']->getContent(),
+					$file->getContent(),
 					$ocpTaskId . '-' . $fileId . '-preview',
-					$preview['file']->getMimeType()
+					$file->getMimeType()
 				);
 				$response->cacheFor(60 * 60 * 24, false, true);
 				return $response;

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -503,10 +503,10 @@ class AssistantService {
 	 * @throws NotPermittedException
 	 * @throws TaskProcessingException
 	 */
-	public function getOutputFilePreviewFile(string $userId, int $taskId, int $fileId): ?array {
+	public function getOutputFilePreviewFile(string $userId, int $taskId, int $fileId, ?int $x = 100, ?int $y = 100): ?array {
 		$taskOutputFile = $this->getTaskOutputFile($userId, $taskId, $fileId);
 		$realMime = mime_content_type($taskOutputFile->fopen('rb'));
-		return $this->previewService->getFilePreviewFile($taskOutputFile, 100, 100, $realMime ?: null);
+		return $this->previewService->getFilePreviewFile($taskOutputFile, $x, $y, $realMime ?: null);
 	}
 
 	/**

--- a/openapi.json
+++ b/openapi.json
@@ -1267,8 +1267,145 @@
         "/ocs/v2.php/apps/assistant/api/{apiVersion}/task/{ocpTaskId}/output-file/{fileId}/preview": {
             "get": {
                 "operationId": "assistant_api-get-output-file-preview",
-                "summary": "Get output file preview",
+                "summary": "Get task output file preview",
                 "description": "Generate and get a preview of a task output file",
+                "tags": [
+                    "assistant_api"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "ocpTaskId",
+                        "in": "path",
+                        "description": "The task ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "fileId",
+                        "in": "path",
+                        "description": "The task output file ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "x",
+                        "in": "query",
+                        "description": "Optional preview width in pixels",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "nullable": true,
+                            "default": 100
+                        }
+                    },
+                    {
+                        "name": "y",
+                        "in": "query",
+                        "description": "Optional preview height in pixels",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "nullable": true,
+                            "default": 100
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The file preview has been generated and is returned",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The output file is not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "303": {
+                        "description": "Fallback to the file type icon URL",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/assistant/api/{apiVersion}/task/{ocpTaskId}/output-file/{fileId}/download": {
+            "get": {
+                "operationId": "assistant_api-get-output-file",
+                "summary": "Get task output file",
+                "description": "Get a real task output file",
                 "tags": [
                     "assistant_api"
                 ],
@@ -1362,16 +1499,6 @@
                                             }
                                         }
                                     }
-                                }
-                            }
-                        }
-                    },
-                    "303": {
-                        "description": "Fallback to the file type icon URL",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string"
                                 }
                             }
                         }

--- a/src/components/fields/AudioDisplay.vue
+++ b/src/components/fields/AudioDisplay.vue
@@ -41,6 +41,7 @@ export default {
 
 	computed: {
 		audioUrl() {
+			// TODO, when we have task types with audio output, maybe switch to the assistant endpoint to get file with correct mimetype
 			return this.isOutput
 				? generateOcsUrl('taskprocessing/tasks/{taskId}/file/{fileId}?requesttoken={rToken}', {
 					taskId: this.providedCurrentTaskId(),

--- a/src/components/fields/ImageDisplay.vue
+++ b/src/components/fields/ImageDisplay.vue
@@ -10,7 +10,6 @@
 
 <script>
 import { generateOcsUrl } from '@nextcloud/router'
-import { getRequestToken } from '@nextcloud/auth'
 
 export default {
 	name: 'ImageDisplay',
@@ -54,10 +53,9 @@ export default {
 		},
 		imageUrl() {
 			return this.isOutput
-				? generateOcsUrl('taskprocessing/tasks/{taskId}/file/{fileId}', {
+				? generateOcsUrl('apps/assistant/api/v1/task/{taskId}/output-file/{fileId}/preview?x=300&y=300', {
 					taskId: this.myCurrentTaskId,
 					fileId: this.fileId,
-					rToken: getRequestToken(),
 				})
 				: generateOcsUrl('apps/assistant/api/v1/file/{fileId}/display', { fileId: this.fileId })
 		},

--- a/src/components/fields/ListOfMediaField.vue
+++ b/src/components/fields/ListOfMediaField.vue
@@ -231,7 +231,14 @@ export default {
 			}
 		},
 		getDownloadUrl(fileId) {
+			// taskprocessing/tasks/{taskId}/file/{fileId} result has no mimetype
+			/*
 			return generateOcsUrl('taskprocessing/tasks/{taskId}/file/{fileId}', {
+				taskId: this.providedCurrentTaskId(),
+				fileId,
+			})
+			*/
+			return generateOcsUrl('apps/assistant/api/v1/task/{taskId}/output-file/{fileId}/download', {
 				taskId: this.providedCurrentTaskId(),
 				fileId,
 			})

--- a/src/components/fields/MediaField.vue
+++ b/src/components/fields/MediaField.vue
@@ -207,7 +207,14 @@ export default {
 			this.$emit('update:value', null)
 		},
 		getDownloadUrl() {
+			// taskprocessing/tasks/{taskId}/file/{fileId} result has no mimetype
+			/*
 			return generateOcsUrl('taskprocessing/tasks/{taskId}/file/{fileId}', {
+				taskId: this.providedCurrentTaskId(),
+				fileId: this.value,
+			})
+			*/
+			return generateOcsUrl('apps/assistant/api/v1/task/{taskId}/output-file/{fileId}/download', {
 				taskId: this.providedCurrentTaskId(),
 				fileId: this.value,
 			})

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -5,6 +5,12 @@
 -->
 <files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="lib/Controller/AssistantApiController.php">
+    <InvalidReturnStatement>
+      <code><![CDATA[$response]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[DataDownloadResponse<Http::STATUS_OK, string, array{}>|DataResponse<Http::STATUS_NOT_FOUND, '', array{}>]]></code>
+    </InvalidReturnType>
     <LessSpecificReturnStatement>
       <code><![CDATA[new DataResponse(['tasks' => $serializedTasks])]]></code>
       <code><![CDATA[new DataResponse(['types' => $taskTypes])]]></code>


### PR DESCRIPTION
* Use new endpoint to download task output files. This one deduces the mimetype from the file content. (So browsers append a type extension to the file name when downloading)
* Cache download and preview endpoint responses
* Use the preview endpoint to display result images (300x300) instead of getting the complete image
* Generate openapi specs
* Fix psalm issues