### PR TITLE
Fix choose file button position with RTL languages

### DIFF
--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -195,6 +195,16 @@ export default {
 </script>
 
 <style lang="scss">
+.choose-file-button {
+	right: 2px;
+	left: unset;
+}
+
+body[dir="rtl"] .choose-file-button {
+	left: 2px;
+	right: unset;
+}
+
 .text-input {
 	position: relative;
 
@@ -205,7 +215,6 @@ export default {
 
 	.choose-file-button {
 		bottom: 2px;
-		right: 2px;
 	}
 
 	.copy-button {


### PR DESCRIPTION
### LTR

![image](https://github.com/user-attachments/assets/a38df549-5a49-42cb-8b4c-09a549cc8fc7)


### RTL Before

![image](https://github.com/user-attachments/assets/3f1d8aea-a35c-4db6-b5ab-f5bbc5043126)


### RTL After


![image](https://github.com/user-attachments/assets/e2f3d302-0c03-4360-9d01-50e7ee09e855)

For some reason left must be unset when right is defined and the other way around.

cc @DaphneMuller 