### PR TITLE
Better naming of shared output files, support more mime types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 		"henck/rtf-to-html": "^1.2",
 		"html2text/html2text": "^4.3",
 		"phpoffice/phpword": "^1.2",
+		"ralouphie/mimey": "^1.0",
 		"smalot/pdfparser": "^2.11"
 	},
 	"scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2ea5122778117d13a792a020c986787",
+    "content-hash": "82ecee0e36d1b1a3fba5a93982fd6d62",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -301,6 +301,50 @@
                 "source": "https://github.com/PHPOffice/PHPWord/tree/1.3.0"
             },
             "time": "2024-08-30T18:03:42+00:00"
+        },
+        {
+            "name": "ralouphie/mimey",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/mimey.git",
+                "reference": "2a0e997c733b7c2f9f8b61cafb006fd5fb9fa15a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/mimey/zipball/2a0e997c733b7c2f9f8b61cafb006fd5fb9fa15a",
+                "reference": "2a0e997c733b7c2f9f8b61cafb006fd5fb9fa15a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7.0",
+                "satooshi/php-coveralls": ">=1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Mimey\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "PHP package for converting file extensions to MIME types and vice versa.",
+            "support": {
+                "issues": "https://github.com/ralouphie/mimey/issues",
+                "source": "https://github.com/ralouphie/mimey/tree/master"
+            },
+            "time": "2016-09-28T03:36:23+00:00"
         },
         {
             "name": "smalot/pdfparser",

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -439,27 +439,16 @@ class AssistantService {
 	 * @throws NotPermittedException
 	 */
 	private function getTargetFileName(File $file): string {
-		$mime = mime_content_type($file->fopen('rb'));
-		$name = $file->getName();
+		$mimeType = mime_content_type($file->fopen('rb'));
+		$fileName = $file->getName();
 
-		$mime2ext = [
-			'image/png' => '.png',
-			'image/jpeg' => '.jpg',
-			'image/webp' => '.webp',
-			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => '.xlsx',
-			'application/vnd.oasis.opendocument.spreadsheet' => '.ods',
-			'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => '.docx',
-			'application/vnd.oasis.opendocument.text-web' => '.odt',
-			'application/vnd.openxmlformats-officedocument.presentationml.presentation' => '.pptx',
-			'application/vnd.oasis.opendocument.presentation' => '.odp',
-			'application/vnd.oasis.opendocument.graphics' => '.odg',
-		];
-		$ext = $mime2ext[$mime] ?? '';
+		$mimes = new \Mimey\MimeTypes;
 
-		if (str_ends_with($name, $ext)) {
-			return $name;
+		$extension = $mimes->getExtension($mimeType);
+		if (is_string($extension) && $extension !== '' && !str_ends_with($fileName, $extension)) {
+			return $fileName . '.' . $extension;
 		}
-		return $name . $ext;
+		return $fileName;
 	}
 
 	/**

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -441,12 +441,20 @@ class AssistantService {
 	private function getTargetFileName(File $file): string {
 		$mime = mime_content_type($file->fopen('rb'));
 		$name = $file->getName();
-		$ext = '';
-		if ($mime === 'image/png') {
-			$ext = '.png';
-		} elseif ($mime === 'image/jpeg') {
-			$ext = '.jpg';
-		}
+
+		$mime2ext = [
+			'image/png' => '.png',
+			'image/jpeg' => '.jpg',
+			'image/webp' => '.webp',
+			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => '.xlsx',
+			'application/vnd.oasis.opendocument.spreadsheet' => '.ods',
+			'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => '.docx',
+			'application/vnd.oasis.opendocument.text-web' => '.odt',
+			'application/vnd.openxmlformats-officedocument.presentationml.presentation' => '.pptx',
+			'application/vnd.oasis.opendocument.presentation' => '.odp',
+			'application/vnd.oasis.opendocument.graphics' => '.odg',
+		];
+		$ext = $mime2ext[$mime] ?? '';
 
 		if (str_ends_with($name, $ext)) {
 			return $name;


### PR DESCRIPTION
When a task output file is shared from the assistant UI, the file extension is guessed from the mimetype. More types are now supported.

For the download endpoint, setting the mimetype correctly in the response headers is enough for browsers to guess the extension in the suggested file name.