### PR TITLE
fix(NumberField): use number type for NcInputField

### DIFF
--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -265,7 +265,7 @@ export default {
 						SHAPE_TYPE_NAMES.Image,
 						SHAPE_TYPE_NAMES.Audio,
 						SHAPE_TYPE_NAMES.Video,
-					].includes(fieldType) && typeof value === 'number')
+					].includes(fieldType) && typeof value === 'number' && !isNaN(value))
 					|| (fieldType === SHAPE_TYPE_NAMES.ListOfTexts && typeof value === 'object' && !!value && value.every(v => typeof v === 'string'))
 					|| (fieldType === SHAPE_TYPE_NAMES.ListOfNumbers && typeof value === 'object' && !!value && value.every(v => typeof v === 'number'))
 					|| ([

--- a/src/components/fields/NumberField.vue
+++ b/src/components/fields/NumberField.vue
@@ -11,7 +11,7 @@
 			:id="'input-' + fieldKey"
 			class="number-input-field"
 			:value="value ?? ''"
-			type="text"
+			type="number"
 			:label-outside="true"
 			:title="field.name"
 			:placeholder="field.placeholder ?? (field.description || t('assistant','Type some number'))"

--- a/src/components/fields/NumberField.vue
+++ b/src/components/fields/NumberField.vue
@@ -17,7 +17,7 @@
 			:placeholder="field.placeholder ?? (field.description || t('assistant','Type some number'))"
 			:error="!isValid"
 			:helper-text="isValid ? '' : t('assistant', 'The current value is not a number')"
-			@update:value="onUpdateValue" />
+			@update:model-value="onUpdateValue" />
 	</div>
 </template>
 


### PR DESCRIPTION
Resolves #215. This enables the use of up/down arrow keys to increment/decrement values in a number field, which I believe is preferable over tabbing between multiple buttons with constant values. Although, there are no clickable up/down arrow buttons visible in the input field which would help indicate to the user that the field is a number field (but that may be an issue with the component itself, I'm not sure).

The only other difference I could tell between the number and text fields is the emitted values of NaN and '', respectively, when the field is empty. Thus, we also need to prevent the form from submitting if any of the input fields is NaN (which, correct me if I'm wrong, I don't think is an allowed value in any context anyway).