### PR TITLE
Task output file download link reference

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -29,6 +29,7 @@ return [
 		['name' => 'assistantApi#displayUserFile', 'url' => '/api/{apiVersion}/file/{fileId}/display', 'verb' => 'GET', 'requirements' => $requirements],
 		['name' => 'assistantApi#getUserFileInfo', 'url' => '/api/{apiVersion}/file/{fileId}/info', 'verb' => 'GET', 'requirements' => $requirements],
 		['name' => 'assistantApi#shareOutputFile', 'url' => '/api/{apiVersion}/task/{ocpTaskId}/file/{fileId}/share', 'verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'assistantApi#saveOutputFile', 'url' => '/api/{apiVersion}/task/{ocpTaskId}/file/{fileId}/save', 'verb' => 'POST', 'requirements' => $requirements],
 		['name' => 'assistantApi#getOutputFilePreview', 'url' => '/api/{apiVersion}/task/{ocpTaskId}/output-file/{fileId}/preview', 'verb' => 'GET', 'requirements' => $requirements],
 		['name' => 'assistantApi#getOutputFile', 'url' => '/api/{apiVersion}/task/{ocpTaskId}/output-file/{fileId}/download', 'verb' => 'GET', 'requirements' => $requirements],
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -14,11 +14,13 @@ use OCA\Assistant\Listener\CSPListener;
 use OCA\Assistant\Listener\FreePrompt\FreePromptReferenceListener;
 use OCA\Assistant\Listener\SpeechToText\SpeechToTextReferenceListener;
 use OCA\Assistant\Listener\TaskFailedListener;
+use OCA\Assistant\Listener\TaskOutputFileReferenceListener;
 use OCA\Assistant\Listener\TaskSuccessfulListener;
 use OCA\Assistant\Listener\Text2Image\Text2ImageReferenceListener;
 use OCA\Assistant\Notification\Notifier;
 use OCA\Assistant\Reference\FreePromptReferenceProvider;
 use OCA\Assistant\Reference\SpeechToTextReferenceProvider;
+use OCA\Assistant\Reference\TaskOutputFileReferenceProvider;
 use OCA\Assistant\Reference\Text2ImageReferenceProvider;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -52,10 +54,12 @@ class Application extends App implements IBootstrap {
 		$context->registerReferenceProvider(Text2ImageReferenceProvider::class);
 		$context->registerReferenceProvider(FreePromptReferenceProvider::class);
 		$context->registerReferenceProvider(SpeechToTextReferenceProvider::class);
+		$context->registerReferenceProvider(TaskOutputFileReferenceProvider::class);
 
 		$context->registerEventListener(RenderReferenceEvent::class, Text2ImageReferenceListener::class);
 		$context->registerEventListener(RenderReferenceEvent::class, FreePromptReferenceListener::class);
 		$context->registerEventListener(RenderReferenceEvent::class, SpeechToTextReferenceListener::class);
+		$context->registerEventListener(RenderReferenceEvent::class, TaskOutputFileReferenceListener::class);
 
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
 

--- a/lib/Controller/AssistantApiController.php
+++ b/lib/Controller/AssistantApiController.php
@@ -234,13 +234,13 @@ class AssistantApiController extends OCSController {
 	/**
 	 * Share an output file
 	 *
-	 * Share a file that was produced by a task
+	 * Save and share a file that was produced by a task
 	 *
 	 * @param int $ocpTaskId The task ID
 	 * @param int $fileId The file ID
 	 * @return DataResponse<Http::STATUS_OK, array{shareToken: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
 	 *
-	 * 200: The file was shared
+	 * 200: The file was saved and shared
 	 * 404: The file was not found
 	 */
 	#[NoAdminRequired]
@@ -250,6 +250,29 @@ class AssistantApiController extends OCSController {
 			return new DataResponse(['shareToken' => $shareToken]);
 		} catch (\Exception $e) {
 			$this->logger->debug('Failed to share assistant output file', ['exception' => $e]);
+			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+		}
+	}
+
+	/**
+	 * Save an output file
+	 *
+	 * Save a file that was produced by a task
+	 *
+	 * @param int $ocpTaskId The task ID
+	 * @param int $fileId The file ID
+	 * @return DataResponse<Http::STATUS_OK, array{shareToken: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+	 *
+	 * 200: The file was saved
+	 * 404: The file was not found
+	 */
+	#[NoAdminRequired]
+	public function saveOutputFile(int $ocpTaskId, int $fileId): DataResponse {
+		try {
+			$info = $this->assistantService->saveOutputFile($this->userId, $ocpTaskId, $fileId);
+			return new DataResponse($info);
+		} catch (\Exception $e) {
+			$this->logger->debug('Failed to save assistant output file', ['exception' => $e]);
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 		}
 	}

--- a/lib/Controller/AssistantApiController.php
+++ b/lib/Controller/AssistantApiController.php
@@ -272,7 +272,7 @@ class AssistantApiController extends OCSController {
 			$info = $this->assistantService->saveOutputFile($this->userId, $ocpTaskId, $fileId);
 			return new DataResponse($info);
 		} catch (\Exception $e) {
-			$this->logger->debug('Failed to save assistant output file', ['exception' => $e]);
+			$this->logger->error('Failed to save assistant output file', ['exception' => $e]);
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 		}
 	}

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -64,6 +64,9 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			$indexingComplete = $this->appConfig->getValueInt('context_chat', 'last_indexed_time', 0) !== 0;
 			$this->initialStateService->provideInitialState('contextChatIndexingComplete', $indexingComplete);
 		}
+		if (class_exists(\OCA\Viewer\Event\LoadViewer::class)) {
+			$this->eventDispatcher->dispatchTyped(new \OCA\Viewer\Event\LoadViewer());
+		}
 		Util::addScript(Application::APP_ID, Application::APP_ID . '-main');
 	}
 }

--- a/lib/Listener/TaskOutputFileReferenceListener.php
+++ b/lib/Listener/TaskOutputFileReferenceListener.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Assistant\Listener;
+
+use OCA\Assistant\AppInfo\Application;
+use OCP\Collaboration\Reference\RenderReferenceEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
+
+/**
+ * @implements IEventListener<RenderReferenceEvent>
+ */
+class TaskOutputFileReferenceListener implements IEventListener {
+	public function __construct(
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof RenderReferenceEvent) {
+			return;
+		}
+
+		Util::addScript(Application::APP_ID, Application::APP_ID . '-taskOutputFileReference');
+	}
+}

--- a/lib/Reference/TaskOutputFileReferenceProvider.php
+++ b/lib/Reference/TaskOutputFileReferenceProvider.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Assistant\Reference;
+
+use OCA\Assistant\AppInfo\Application;
+use OCP\Collaboration\Reference\IReference;
+use OCP\Collaboration\Reference\IReferenceManager;
+use OCP\Collaboration\Reference\IReferenceProvider;
+use OCP\Collaboration\Reference\LinkReferenceProvider;
+use OCP\Collaboration\Reference\Reference;
+use OCP\IURLGenerator;
+use OCP\TaskProcessing\IManager as TaskProcessingManager;
+
+class TaskOutputFileReferenceProvider implements IReferenceProvider {
+
+	private const RICH_OBJECT_TYPE = Application::APP_ID . '_task-output-file';
+
+	public function __construct(
+		private IReferenceManager $referenceManager,
+		private LinkReferenceProvider $linkReferenceProvider,
+		private IURLGenerator $urlGenerator,
+		private TaskProcessingManager $taskProcessingManager,
+		private ?string $userId,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function matchReference(string $referenceText): bool {
+		return $this->getLinkInfo($referenceText) !== null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function resolveReference(string $referenceText): ?IReference {
+		if ($this->matchReference($referenceText)) {
+			$linkInfo = $this->getLinkInfo($referenceText);
+			if ($linkInfo !== null) {
+				$taskId = $linkInfo['taskId'];
+				$task = $this->taskProcessingManager->getTask($taskId);
+				if ($task->getUserId() === null || $task->getUserId() !== $this->userId) {
+					return null;
+				}
+
+				$linkInfo['taskTypeId'] = $task->getTaskTypeId();
+				$linkInfo['taskTypeName'] = $this->taskProcessingManager->getAvailableTaskTypes()[$task->getTaskTypeId()]['name'] ?? null;
+				$reference = new Reference($referenceText);
+				$reference->setRichObject(
+					self::RICH_OBJECT_TYPE,
+					$linkInfo,
+				);
+				return $reference;
+			}
+			// fallback to opengraph
+			return $this->linkReferenceProvider->resolveReference($referenceText);
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param string $url
+	 * @return array|null
+	 */
+	private function getLinkinfo(string $url): ?array {
+		// assistant download link
+		// https://nextcloud.local/ocs/v2.php/apps/assistant/api/v1/task/42/output-file/398/download
+
+		$start = $this->urlGenerator->linkToOCSRouteAbsolute(Application::APP_ID . '.assistantApi.getOutputFile', [
+			'apiVersion' => 'v1',
+			'ocpTaskId' => 123,
+			'fileId' => 123,
+		]);
+		$start = str_replace('/task/123/output-file/123/download', '/task/', $start);
+		if (str_starts_with($url, $start)) {
+			preg_match('/\/task\/(\d+)\/output-file\/(\d+)\/download$/i', $url, $matches);
+			if (count($matches) > 2) {
+				return [
+					'taskId' => (int)$matches[1],
+					'fileId' => (int)$matches[2],
+				];
+			}
+		}
+
+		// task processing download links
+		// https://nextcloud.local/ocs/v2.php/taskprocessing/tasks/42/file/398
+
+		$start = $this->urlGenerator->linkToOCSRouteAbsolute('core.taskProcessingApi.getFileContents', [
+			'taskId' => 123,
+			'fileId' => 123,
+		]);
+		$start = str_replace('/tasks/123/file/123', '/tasks/', $start);
+		if (str_starts_with($url, $start)) {
+			preg_match('/\/tasks\/(\d+)\/file\/(\d+)$/i', $url, $matches);
+			if (count($matches) > 2) {
+				return [
+					'taskId' => (int)$matches[1],
+					'fileId' => (int)$matches[2],
+				];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * We use the userId here because when connecting/disconnecting from the GitHub account,
+	 * we want to invalidate all the user cache and this is only possible with the cache prefix
+	 * @inheritDoc
+	 */
+	public function getCachePrefix(string $referenceId): string {
+		return $this->userId ?? '';
+	}
+
+	/**
+	 * We don't use the userId here but rather a reference unique id
+	 * @inheritDoc
+	 */
+	public function getCacheKey(string $referenceId): ?string {
+		return $referenceId;
+	}
+
+	/**
+	 * @param string $userId
+	 * @return void
+	 */
+	public function invalidateUserCache(string $userId): void {
+		$this->referenceManager->invalidateCache($userId);
+	}
+}

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -453,7 +453,7 @@ class AssistantService {
 		$fileCopy = $this->saveFile($userId, $ocpTaskId, $fileId);
 		return [
 			'fileId' => $fileCopy->getId(),
-			'path' => $fileCopy->getInternalPath(),
+			'path' => preg_replace('/^files\//', '/', $fileCopy->getInternalPath()),
 		];
 	}
 

--- a/openapi.json
+++ b/openapi.json
@@ -1253,7 +1253,7 @@
             "post": {
                 "operationId": "assistant_api-share-output-file",
                 "summary": "Share an output file",
-                "description": "Share a file that was produced by a task",
+                "description": "Save and share a file that was produced by a task",
                 "tags": [
                     "assistant_api"
                 ],
@@ -1311,7 +1311,147 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "The file was shared",
+                        "description": "The file was saved and shared",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "shareToken"
+                                                    ],
+                                                    "properties": {
+                                                        "shareToken": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The file was not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "error"
+                                                    ],
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/assistant/api/{apiVersion}/task/{ocpTaskId}/file/{fileId}/save": {
+            "post": {
+                "operationId": "assistant_api-save-output-file",
+                "summary": "Save an output file",
+                "description": "Save a file that was produced by a task",
+                "tags": [
+                    "assistant_api"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "ocpTaskId",
+                        "in": "path",
+                        "description": "The task ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "fileId",
+                        "in": "path",
+                        "description": "The file ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The file was saved",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -7,6 +7,7 @@
 		:size="modalSize"
 		:can-close="false"
 		:name="t('assistant', 'Nextcloud Assistant')"
+		container="#content"
 		dark
 		class="assistant-modal"
 		@close="onCancel">

--- a/src/components/fields/FileDisplay.vue
+++ b/src/components/fields/FileDisplay.vue
@@ -5,7 +5,7 @@
 <template>
 	<div class="file-display">
 		<div class="preview">
-			<img :src="imageUrl">
+			<img :src="imageUrl" :class="{ clickable }">
 			<span v-if="fileName"
 				class="file-name"
 				:title="fileName">
@@ -39,6 +39,10 @@ export default {
 			required: true,
 		},
 		isOutput: {
+			type: Boolean,
+			default: false,
+		},
+		clickable: {
 			type: Boolean,
 			default: false,
 		},
@@ -100,6 +104,10 @@ export default {
 		justify-content: center;
 		img {
 			width: 100px;
+
+			&.clickable {
+				cursor: pointer !important;
+			}
 		}
 		.file-name {
 			max-width: 100px;

--- a/src/components/fields/MediaField.vue
+++ b/src/components/fields/MediaField.vue
@@ -295,7 +295,7 @@ export default {
 			return axios.post(url).then(response => {
 				const savedPath = response.data.ocs.data.path
 				console.debug('[assistant] view output file', savedPath)
-				// TODO find a way to make it work when the assistant is in a modal itself
+				// This works and shows the Viewer on top the assitant's NcModal because we give it container="#content"
 				OCA.Viewer.open({ path: savedPath })
 			}).catch(error => {
 				console.error(error)

--- a/src/taskOutputFileReference.js
+++ b/src/taskOutputFileReference.js
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { registerWidget } from '@nextcloud/vue/dist/Components/NcRichText.js'
+
+registerWidget('assistant_task-output-file', async (el, { richObjectType, richObject, accessible }) => {
+	const { default: Vue } = await import('vue')
+	Vue.mixin({ methods: { t, n } })
+	const { default: TaskOutputFileReferenceWidget } = await import('./views/TaskOutputFileReferenceWidget.vue')
+	const Widget = Vue.extend(TaskOutputFileReferenceWidget)
+	new Widget({
+		propsData: {
+			richObjectType,
+			richObject,
+			accessible,
+		},
+	}).$mount(el)
+}, () => {}, { hasInteractiveView: false })

--- a/src/views/TaskOutputFileReferenceWidget.vue
+++ b/src/views/TaskOutputFileReferenceWidget.vue
@@ -1,17 +1,29 @@
 <template>
 	<div class="task-output-widget">
-		<strong>
-			{{ t('assistant', 'Output file for task {taskId} ({taskTypeName})', { taskId: richObject.taskId, taskTypeName: richObject.taskTypeName }) }}
-		</strong>
+		<MediaField :field="field"
+			field-key="dummyKey"
+			:value="richObject.fileId"
+			:is-output="true" />
 	</div>
 </template>
 
 <script>
 
+import MediaField from '../components/fields/MediaField.vue'
+
+import { SHAPE_TYPE_NAMES } from '../constants.js'
+
 export default {
 	name: 'TaskOutputFileReferenceWidget',
 
 	components: {
+		MediaField,
+	},
+
+	provide() {
+		return {
+			providedCurrentTaskId: () => this.richObject.taskId,
+		}
 	},
 
 	props: {
@@ -31,6 +43,11 @@ export default {
 
 	data() {
 		return {
+			field: {
+				description: 'field desc',
+				name: t('assistant', 'Output file for task {taskId} ({taskTypeName})', { taskId: this.richObject.taskId, taskTypeName: this.richObject.taskTypeName }),
+				type: SHAPE_TYPE_NAMES.File,
+			},
 		}
 	},
 

--- a/src/views/TaskOutputFileReferenceWidget.vue
+++ b/src/views/TaskOutputFileReferenceWidget.vue
@@ -1,3 +1,7 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="task-output-widget">
 		<MediaField :field="field"

--- a/src/views/TaskOutputFileReferenceWidget.vue
+++ b/src/views/TaskOutputFileReferenceWidget.vue
@@ -1,0 +1,52 @@
+<template>
+	<div class="task-output-widget">
+		<strong>
+			{{ t('assistant', 'Output file for task {taskId} ({taskTypeName})', { taskId: richObject.taskId, taskTypeName: richObject.taskTypeName }) }}
+		</strong>
+	</div>
+</template>
+
+<script>
+
+export default {
+	name: 'TaskOutputFileReferenceWidget',
+
+	components: {
+	},
+
+	props: {
+		richObjectType: {
+			type: String,
+			default: '',
+		},
+		richObject: {
+			type: Object,
+			default: null,
+		},
+		accessible: {
+			type: Boolean,
+			default: true,
+		},
+	},
+
+	data() {
+		return {
+		}
+	},
+
+	computed: {
+	},
+
+	mounted() {
+	},
+
+	methods: {
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.task-output-widget {
+	margin: 4px;
+}
+</style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default createAppConfig({
 	imageGenerationReference: 'src/imageGenerationReference.js',
 	textGenerationReference: 'src/textGenerationReference.js',
 	speechToTextReference: 'src/speechToTextReference.js',
+    taskOutputFileReference: 'src/taskOutputFileReference.js',
 	assistantPage: 'src/assistantPage.js',
 }, {
 	config: {


### PR DESCRIPTION
2 things:

* Add a reference provider and a link preview widget for https://nextcloud.local/ocs/v2.php/apps/assistant/api/v1/task/42/output-file/398/download and https://nextcloud.local/ocs/v2.php/taskprocessing/tasks/42/file/398 links. The widget actually uses the same component we use to display output files in the assistant form (`<MediaField>`)
* Click on the MediaField preview now saves the files (in the /Assistant dir) and opens the Viewer on the file

Remaining issue: The Viewer is not displayed on top of the assistant modal. Everything is fine if we open the viewer from a link widget in Talk, or from the assistant standalone page, but no luck if the assistant itself is already in a modal.
**Solution**: Change the NcModal `container` prop to `#content`. The Viewer is then displayed on top.

[Kooha-2025-04-28-11-38-41.webm](https://github.com/user-attachments/assets/b4362efe-c365-4a82-a0dd-62e109bf5906)
