### PR TITLE
Open output media list items in the viewer

### DIFF
--- a/src/components/fields/ImageDisplay.vue
+++ b/src/components/fields/ImageDisplay.vue
@@ -4,7 +4,9 @@
 -->
 <template>
 	<div class="image-display">
-		<img :src="imageUrl" :style="style">
+		<img :src="imageUrl"
+			:style="style"
+			:class="{ clickable }">
 	</div>
 </template>
 
@@ -37,6 +39,10 @@ export default {
 		borderRadius: {
 			type: [Number, null],
 			default: null,
+		},
+		clickable: {
+			type: Boolean,
+			default: false,
 		},
 	},
 
@@ -87,6 +93,10 @@ export default {
 		// width: 200px;
 		width: auto;
 		height: 200px;
+
+		&.clickable {
+			cursor: pointer !important;
+		}
 	}
 }
 </style>

--- a/src/components/fields/MediaField.vue
+++ b/src/components/fields/MediaField.vue
@@ -295,7 +295,6 @@ export default {
 			return axios.post(url).then(response => {
 				const savedPath = response.data.ocs.data.path
 				console.debug('[assistant] view output file', savedPath)
-				// This works and shows the Viewer on top the assitant's NcModal because we give it container="#content"
 				OCA.Viewer.open({ path: savedPath })
 			}).catch(error => {
 				console.error(error)


### PR DESCRIPTION
It was only done for simple/single output media items. This is now the case for output media list (list of images and files).
The only task type with an output media list is "image generation" for now.

[Kooha-2025-05-07-11-31-48.webm](https://github.com/user-attachments/assets/e22ee3df-302d-495e-86d4-2b0a9e753a4d)
