### PR TITLE
feat: keep input prompt when switching task types

### DIFF
--- a/src/components/AssistantFormInputs.vue
+++ b/src/components/AssistantFormInputs.vue
@@ -64,7 +64,7 @@ export default {
 	watch: {
 		selectedTaskType() {
 			console.debug('[assistant] watch selectedTaskType', this.selectedTaskType, this.selectedTaskTypeId)
-			this.setDefaultValues(true)
+			this.setDefaultValues(false)
 		},
 	},
 	mounted() {

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -429,8 +429,23 @@ export default {
 		onTaskTypeUserChange() {
 			this.$emit('new-task')
 
+			const lastInput = this.myInputs?.input
+				|| this.myInputs?.source_input // used in context write
+				|| this.myInputs?.text // used in document generation
+
 			this.$refs?.translateForm?.setDefaultValues(true)
 			this.$refs?.assistantFormInputs?.setDefaultValues(true)
+
+			// keep last prompt if new task type has text input
+			if (lastInput && this.selectedTaskType?.inputShape?.input) {
+				this.myInputs.input = lastInput
+			}
+			if (lastInput && this.selectedTaskType?.inputShape?.source_input) {
+				this.myInputs.source_input = lastInput
+			}
+			if (lastInput && this.selectedTaskType?.inputShape?.text) {
+				this.myInputs.text = lastInput
+			}
 		},
 		onSyncSubmit() {
 			console.debug('[assistant] in form submit ---------', this.myInputs)


### PR DESCRIPTION
Resolves #217.

Continuing discussion from #227:

> The only thing that is not working is the preservation of the "input" input because the default values are applied in 2 places:
> 
> * AssistantTextProcessingForm::onTaskTypeUserChange (where the input is preserved)
> 
> * AssistantFormInputs::watch::selectedTaskType
> 
> and if the second one happens after the first, the input field is cleared.

I'm not sure if `AssistantFormInputs::watch::selectedTaskType` has any purpose anymore, now that I think about it, especially now with the addition of the `TranslateForm`. Removing it fixed the issue for me.