### PR TITLE
Add custom input and output forms for context_chat_search

### DIFF
--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -65,13 +65,14 @@ class AssistantService {
 		TextToText::ID => 2,
 		'context_chat:context_chat' => 3,
 		'legacy:TextProcessing:OCA\ContextChat\TextProcessing\ContextChatTaskType' => 3,
-		AudioToText::ID => 4,
-		TextToTextTranslate::ID => 5,
-		ContextWrite::ID => 6,
-		TextToImage::ID => 7,
-		TextToTextSummary::ID => 8,
-		TextToTextHeadline::ID => 9,
-		TextToTextTopics::ID => 10,
+		'context_chat:context_chat_search' => 4,
+		AudioToText::ID => 5,
+		TextToTextTranslate::ID => 6,
+		ContextWrite::ID => 7,
+		TextToImage::ID => 8,
+		TextToTextSummary::ID => 9,
+		TextToTextHeadline::ID => 10,
+		TextToTextTopics::ID => 11,
 	];
 
 	public array $informationSources;

--- a/src/components/AssistantFormInputs.vue
+++ b/src/components/AssistantFormInputs.vue
@@ -3,9 +3,10 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<ContextChatInputForm v-if="selectedTaskTypeId === 'context_chat:context_chat'"
+	<ContextChatInputForm v-if="['context_chat:context_chat', 'context_chat:context_chat_search'].includes(selectedTaskTypeId)"
 		:inputs="inputs"
 		:task-type="selectedTaskType"
+		:is-search="selectedTaskTypeId === 'context_chat:context_chat_search'"
 		@update:inputs="$emit('update:inputs', $event)" />
 	<div v-else class="assistant-inputs">
 		<div class="input-container">

--- a/src/components/AssistantFormInputs.vue
+++ b/src/components/AssistantFormInputs.vue
@@ -6,7 +6,6 @@
 	<ContextChatInputForm v-if="['context_chat:context_chat', 'context_chat:context_chat_search'].includes(selectedTaskTypeId)"
 		:inputs="inputs"
 		:task-type="selectedTaskType"
-		:is-search="selectedTaskTypeId === 'context_chat:context_chat_search'"
 		@update:inputs="$emit('update:inputs', $event)" />
 	<div v-else class="assistant-inputs">
 		<div class="input-container">

--- a/src/components/AssistantFormOutputs.vue
+++ b/src/components/AssistantFormOutputs.vue
@@ -8,6 +8,10 @@
 			class="output-fields"
 			:output-shape="selectedTaskType.outputShape"
 			:output="outputs" />
+		<ContextChatSearchOutputForm v-else-if="selectedTaskTypeId === 'context_chat:context_chat_search'"
+			class="output-fields"
+			:output-shape="selectedTaskType.outputShape"
+			:output="outputs" />
 		<TaskTypeFields v-else
 			class="output-fields"
 			:is-output="true"
@@ -36,6 +40,7 @@
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 
 import ContextChatOutputForm from './ContextChat/ContextChatOutputForm.vue'
+import ContextChatSearchOutputForm from './ContextChat/ContextChatSearchOutputForm.vue'
 import TaskTypeFields from './fields/TaskTypeFields.vue'
 
 export default {
@@ -43,6 +48,7 @@ export default {
 
 	components: {
 		ContextChatOutputForm,
+		ContextChatSearchOutputForm,
 		TaskTypeFields,
 		NcNoteCard,
 	},

--- a/src/components/ContextChat/ContextChatInputForm.vue
+++ b/src/components/ContextChat/ContextChatInputForm.vue
@@ -16,7 +16,7 @@
 			:is-output="false"
 			:show-choose-button="false"
 			@update:value="onInputsChanged({ prompt: $event })" />
-		<SmallNumberField v-if="isSearch"
+		<NumberField v-if="isSearch"
 			:field="taskType.inputShape?.limit"
 			field-key="limit"
 			:value="inputs.limit"
@@ -141,7 +141,7 @@ import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 
 import TextInput from '../fields/TextInput.vue'
-import SmallNumberField from '../fields/SmallNumberField.vue'
+import NumberField from '../fields/NumberField.vue'
 
 import axios from '@nextcloud/axios'
 import { getFilePickerBuilder, showError } from '@nextcloud/dialogs'
@@ -202,7 +202,7 @@ export default {
 	name: 'ContextChatInputForm',
 
 	components: {
-		SmallNumberField,
+		NumberField,
 		TextInput,
 		FileDocumentIcon,
 		NcAvatar,

--- a/src/components/ContextChat/ContextChatInputForm.vue
+++ b/src/components/ContextChat/ContextChatInputForm.vue
@@ -20,7 +20,9 @@
 			{{ t('assistant', 'Selective context') }}
 		</NcCheckboxRadioSwitch>
 		<div v-if="sccEnabled" class="line spaced">
-			<div class="radios">
+			<!-- We can only select providers with the search task type -->
+			<div v-if="!isSearch"
+				class="radios">
 				<NcCheckboxRadioSwitch
 					type="radio"
 					:checked="inputs.scopeType"
@@ -213,6 +215,10 @@ export default {
 			type: Object,
 			required: true,
 		},
+		isSearch: {
+			type: Boolean,
+			required: true,
+		},
 	},
 
 	emits: ['update:inputs'],
@@ -325,10 +331,17 @@ export default {
 		onUpdateSccEnabled(enabled) {
 			this.$emit('update:inputs', {
 				prompt: this.inputs.prompt,
-				scopeType: enabled ? _ScopeType.SOURCE : _ScopeType.NONE,
+				scopeType: enabled
+					? this.isSearch
+						? _ScopeType.PROVIDER
+						: _ScopeType.SOURCE
+					: _ScopeType.NONE,
 				scopeList: [],
 				scopeListMeta: '[]',
 			})
+			if (enabled && this.isSearch && this.providerOptions.length === 0) {
+				this.fetchProviders()
+			}
 		},
 		onScopeTypeChanged(value) {
 			if (value === this.ScopeType.PROVIDER && this.providerOptions.length === 0) {

--- a/src/components/ContextChat/ContextChatInputForm.vue
+++ b/src/components/ContextChat/ContextChatInputForm.vue
@@ -16,6 +16,11 @@
 			:is-output="false"
 			:show-choose-button="false"
 			@update:value="onInputsChanged({ prompt: $event })" />
+		<SmallNumberField v-if="isSearch"
+			:field="taskType.inputShape?.limit"
+			field-key="limit"
+			:value="inputs.limit"
+			@update:value="onInputsChanged({ limit: $event })" />
 		<NcCheckboxRadioSwitch :checked.sync="sccEnabled" @update:checked="onUpdateSccEnabled">
 			{{ t('assistant', 'Selective context') }}
 		</NcCheckboxRadioSwitch>
@@ -136,6 +141,7 @@ import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 
 import TextInput from '../fields/TextInput.vue'
+import SmallNumberField from '../fields/SmallNumberField.vue'
 
 import axios from '@nextcloud/axios'
 import { getFilePickerBuilder, showError } from '@nextcloud/dialogs'
@@ -196,6 +202,7 @@ export default {
 	name: 'ContextChatInputForm',
 
 	components: {
+		SmallNumberField,
 		TextInput,
 		FileDocumentIcon,
 		NcAvatar,
@@ -272,6 +279,7 @@ export default {
 					scopeType: _ScopeType.NONE,
 					scopeList: [],
 					scopeListMeta: '[]',
+					limit: this.isSearch ? this.taskType.inputShapeDefaults?.limit : undefined,
 				})
 			})
 		}
@@ -331,6 +339,7 @@ export default {
 		onUpdateSccEnabled(enabled) {
 			this.$emit('update:inputs', {
 				prompt: this.inputs.prompt,
+				limit: this.isSearch ? this.inputs.limit : undefined,
 				scopeType: enabled
 					? this.isSearch
 						? _ScopeType.PROVIDER

--- a/src/components/ContextChat/ContextChatInputForm.vue
+++ b/src/components/ContextChat/ContextChatInputForm.vue
@@ -222,10 +222,6 @@ export default {
 			type: Object,
 			required: true,
 		},
-		isSearch: {
-			type: Boolean,
-			required: true,
-		},
 	},
 
 	emits: ['update:inputs'],
@@ -256,6 +252,14 @@ export default {
 				return []
 			}
 		},
+		isSearch() {
+			return this.taskType.id === 'context_chat:context_chat_search'
+		},
+	},
+	watch: {
+		taskType(newValue) {
+			this.onTaskTypeChange()
+		},
 	},
 
 	mounted() {
@@ -271,18 +275,18 @@ export default {
 				showError(t('assistant', 'Error fetching default provider key'))
 			})
 
-		// initialize the inputs if necessary
-		if (Object.keys(this.inputs).length === 0) {
-			this.$nextTick(() => {
-				this.$emit('update:inputs', {
-					prompt: '',
-					scopeType: _ScopeType.NONE,
-					scopeList: [],
-					scopeListMeta: '[]',
-					limit: this.isSearch ? this.taskType.inputShapeDefaults?.limit : undefined,
-				})
+		// initialize each input if necessary
+		this.$nextTick(() => {
+			this.$emit('update:inputs', {
+				prompt: this.inputs.prompt ?? '',
+				limit: this.isSearch
+					? (this.inputs.limit ?? this.taskType.inputShapeDefaults?.limit)
+					: undefined,
+				scopeType: this.inputs.scopeType ?? _ScopeType.NONE,
+				scopeList: this.inputs.scopeList ?? [],
+				scopeListMeta: this.inputs.scopeListMeta ?? '[]',
 			})
-		}
+		})
 	},
 
 	methods: {
@@ -375,6 +379,16 @@ export default {
 				...this.inputs,
 				...changedInputs,
 			})
+		},
+		onTaskTypeChange() {
+			this.$emit('update:inputs', {
+				prompt: this.inputs.prompt ?? '',
+				limit: this.isSearch ? this.taskType.inputShapeDefaults?.limit : undefined,
+				scopeType: _ScopeType.NONE,
+				scopeList: [],
+				scopeListMeta: '[]',
+			})
+			this.sccEnabled = false
 		},
 	},
 }

--- a/src/components/ContextChat/ContextChatSearchOutputForm.vue
+++ b/src/components/ContextChat/ContextChatSearchOutputForm.vue
@@ -53,6 +53,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+ol {
+	margin-left: 2em;
+}
+
 .cc-output__sources {
 	display: flex;
 	flex-direction: column;
@@ -61,6 +65,7 @@ export default {
 
 	&__line {
 		border-radius: var(--border-radius-large);
+		padding: 12px 16px 4px 12px;
 		&:hover {
 			background-color: var(--color-background-hover);
 		}

--- a/src/components/ContextChat/ContextChatSearchOutputForm.vue
+++ b/src/components/ContextChat/ContextChatSearchOutputForm.vue
@@ -1,0 +1,60 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="cc-output__sources">
+		<label class="cc-output__sources__label">
+			{{ outputShape.sources.description }}
+		</label>
+		<NcRichText v-for="(source, i) in sources"
+			:key="'source-' + i"
+			:text="source.url"
+			:use-markdown="false"
+			:reference-limit="1"
+			:autolink="true" />
+	</div>
+</template>
+
+<script>
+import { NcRichText } from '@nextcloud/vue/dist/Components/NcRichText.js'
+
+export default {
+	name: 'ContextChatSearchOutputForm',
+
+	components: {
+		NcRichText,
+	},
+
+	props: {
+		outputShape: {
+			type: Object,
+			required: true,
+		},
+		output: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	computed: {
+		sources() {
+			try {
+				return this.output?.sources?.map(JSON.parse) ?? []
+			} catch (e) {
+				console.error('Failed to parse sources', e)
+				return []
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.cc-output__sources {
+	display: flex;
+	flex-direction: column;
+	align-items: start;
+	gap: 8px;
+}
+</style>

--- a/src/components/ContextChat/ContextChatSearchOutputForm.vue
+++ b/src/components/ContextChat/ContextChatSearchOutputForm.vue
@@ -7,23 +7,20 @@
 		<label class="cc-output__sources__label">
 			{{ outputShape.sources.description }}
 		</label>
-		<NcRichText v-for="(source, i) in sources"
-			:key="'source-' + i"
-			:text="source.url"
-			:use-markdown="false"
-			:reference-limit="1"
-			:autolink="true" />
+		<ContextChatSource v-for="(source, i) in sources"
+			:key="'source-' + i + '-' + source.url"
+			:source="source" />
 	</div>
 </template>
 
 <script>
-import { NcRichText } from '@nextcloud/vue/dist/Components/NcRichText.js'
+import ContextChatSource from './ContextChatSource.vue'
 
 export default {
 	name: 'ContextChatSearchOutputForm',
 
 	components: {
-		NcRichText,
+		ContextChatSource,
 	},
 
 	props: {

--- a/src/components/ContextChat/ContextChatSearchOutputForm.vue
+++ b/src/components/ContextChat/ContextChatSearchOutputForm.vue
@@ -7,9 +7,14 @@
 		<label class="cc-output__sources__label">
 			{{ outputShape.sources.description }}
 		</label>
-		<ContextChatSource v-for="(source, i) in sources"
-			:key="'source-' + i + '-' + source.url"
-			:source="source" />
+		<ol>
+			<li v-for="(source, i) in sources"
+				:key="'source-' + i + '-' + source.url"
+				class="cc-output__sources__line">
+				<ContextChatSource
+					:source="source" />
+			</li>
+		</ol>
 	</div>
 </template>
 
@@ -53,5 +58,12 @@ export default {
 	flex-direction: column;
 	align-items: start;
 	gap: 8px;
+
+	&__line {
+		border-radius: var(--border-radius-large);
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
+	}
 }
 </style>

--- a/src/components/ContextChat/ContextChatSource.vue
+++ b/src/components/ContextChat/ContextChatSource.vue
@@ -1,0 +1,70 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<NcRichText
+		:text="text"
+		:use-markdown="true"
+		:reference-limit="1"
+		:references="references"
+		:autolink="true" />
+</template>
+
+<script>
+import { NcRichText } from '@nextcloud/vue/dist/Components/NcRichText.js'
+
+import { generateOcsUrl } from '@nextcloud/router'
+import axios from '@nextcloud/axios'
+
+export default {
+	name: 'ContextChatSource',
+
+	components: {
+		NcRichText,
+	},
+
+	props: {
+		source: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	data: () => {
+		return {
+			// we could initialize this with undefined but then NcRichText will try to find links
+			// and resolve them before we had a chance to do so, resulting in unnecessary requests to references/resolve
+			// with [] we inhibit the extract+resolve mechanism on NcRichText
+			// TODO This can be removed (and all the custom extract+resolve logic) when fixed in NcRichText
+			references: [],
+		}
+	},
+
+	computed: {
+		text() {
+			return '[' + this.source.label + '](' + this.source.url + ')'
+		},
+	},
+
+	mounted() {
+		this.fetch()
+	},
+
+	methods: {
+		fetch() {
+			axios.get(generateOcsUrl('references/resolve') + `?reference=${encodeURIComponent(this.source.url)}`)
+				.then((response) => {
+					this.references = Object.values(response.data.ocs.data.references)
+				})
+				.catch((error) => {
+					console.error('Failed to extract references', error)
+				})
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+// nothing yet
+</style>


### PR DESCRIPTION
This is related with 
* https://github.com/nextcloud/context_chat/pull/129

Custom forms:
* Output: one NcRichText per source
* Input: reuse the classic context chat input form but remove the "source" scope type and add the "limit" number field

![image](https://github.com/user-attachments/assets/4d39004f-75ae-436f-a061-b954b73c7150)
