### PR TITLE
Remove dialog header and duplicate title

### DIFF
--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -228,4 +228,13 @@ export default {
 		height: 100%;
 	}
 }
+
+// TODO: upstream the following by adding a `HideHeader` prop to the NcModal component
+:deep(.modal-header) {
+	display: none !important;
+}
+:deep(.modal-container) {
+	top: 0 !important;
+	height: 100% !important;
+}
 </style>


### PR DESCRIPTION


If we have enough similar instances we should probably upstream these changes to the NcModal component, and provide a prop to hide the header there.

| Before | After |
|--------|-------|
| <img width="798" alt="Screenshot 2025-06-11 at 11 50 43" src="https://github.com/user-attachments/assets/0496c039-eaec-4c71-863d-b03f6e6c92f4" /> | <img width="798" alt="Screenshot 2025-06-11 at 11 52 11" src="https://github.com/user-attachments/assets/1eecc4b2-cc52-453e-a3ce-743638136b00" /> |
