### PR TITLE
Add param in openAssistantForm to restrict which task types are displayed

### DIFF
--- a/src/assistant.js
+++ b/src/assistant.js
@@ -39,7 +39,8 @@ window.assistantPollTimerId = null
  * @param {string} params.appId the scheduling app id
  * @param {string} params.customId the task custom identifier
  * @param {string} params.identifier DEPRECATED the task custom identifier
- * @param {string} params.taskType the text processing task type class
+ * @param {string} params.taskType the selected task type ID
+ * @param {Array} params.taskTypeIdList the task types to display (all if not specified)
  * @param {string} params.input DEPRECATED optional initial input text
  * @param {object} params.inputs optional initial named inputs
  * @param {boolean} params.isInsideViewer Should be true if this function is called while the Viewer is displayed
@@ -49,7 +50,7 @@ window.assistantPollTimerId = null
  * @return {Promise<unknown>}
  */
 export async function openAssistantForm({
-	appId, taskType = null, input = '', inputs = {},
+	appId, taskType = null, taskTypeIdList = null, input = '', inputs = {},
 	isInsideViewer = undefined, closeOnResult = false, actionButtons = undefined,
 	customId = '', identifier = '', mountPoint = null,
 }) {
@@ -92,6 +93,7 @@ export async function openAssistantForm({
 				initSelectedTaskTypeId: selectedTaskTypeId,
 				showSyncTaskRunning: false,
 				actionButtons,
+				taskTypeIdList,
 				/*
 				// events emitted by the root component can be listened to this way
 				// this is a handler for the 'load-task' event

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -233,6 +233,10 @@ export default {
 			type: Array,
 			default: () => [],
 		},
+		taskTypeIdList: {
+			type: [Array, null],
+			default: null,
+		},
 	},
 	emits: [
 		'sync-submit',
@@ -266,7 +270,11 @@ export default {
 			return null
 		},
 		sortedTaskTypes() {
-			return this.taskTypes.slice().sort((a, b) => {
+			const filteredTaskTypes = this.taskTypeIdList !== null
+				? this.taskTypes.slice().filter(t => this.taskTypeIdList.find(tt => tt === t.id))
+				: this.taskTypes.slice()
+
+			return filteredTaskTypes.sort((a, b) => {
 				const prioA = a.priority
 				const prioB = b.priority
 				return prioA > prioB

--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -36,6 +36,7 @@
 					:progress="progress"
 					:expected-runtime="expectedRuntime"
 					:is-notify-enabled="isNotifyEnabled"
+					:task-type-id-list="taskTypeIdList"
 					@sync-submit="onSyncSubmit"
 					@action-button-clicked="onActionButtonClicked"
 					@try-again="onTryAgain"
@@ -93,6 +94,10 @@ export default {
 		actionButtons: {
 			type: Array,
 			default: () => [],
+		},
+		taskTypeIdList: {
+			type: [Array, null],
+			default: null,
 		},
 	},
 	emits: [


### PR DESCRIPTION
This will be useful for apps that integrate the assistant, like Text, and only want to display the task types that make sense in their context.

This branch is based on #258 to avoid future conflicts.