### PR TITLE
fix: explicitly set default sources when creating new session

### DIFF
--- a/lib/Controller/ChattyLLMController.php
+++ b/lib/Controller/ChattyLLMController.php
@@ -147,6 +147,7 @@ class ChattyLLMController extends OCSController {
 			$systemMsg->setRole('system');
 			$systemMsg->setContent($userInstructions);
 			$systemMsg->setTimestamp($session->getTimestamp());
+			$systemMsg->setSources('[]');
 			$this->messageMapper->insert($systemMsg);
 
 			return new JSONResponse([


### PR DESCRIPTION
Extracts from nextcloud.log
```
 "Exception": "OC\\DB\\Exceptions\\DbalException",
    "Message": "An exception occurred while executing a query: SQLSTATE[HY000]: General error: 1364 Field 'sources' doesn't have a default value",

 "message": "Failed to create a chat session",
    "exception": {
      "query": "INSERT INTO `*PREFIX*assistant_chat_msgs` (`session_id`, `role`, `content`, `timestamp`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4)"
    },
    "CustomMessage": "Failed to create a chat session"
```