### PR TITLE
feat: add sticker generation smart picker

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -20,11 +20,13 @@ use OCA\Assistant\Listener\TaskFailedListener;
 use OCA\Assistant\Listener\TaskOutputFileReferenceListener;
 use OCA\Assistant\Listener\TaskSuccessfulListener;
 use OCA\Assistant\Listener\Text2Image\Text2ImageReferenceListener;
+use OCA\Assistant\Listener\Text2Image\Text2StickerListener;
 use OCA\Assistant\Notification\Notifier;
 use OCA\Assistant\Reference\FreePromptReferenceProvider;
 use OCA\Assistant\Reference\SpeechToTextReferenceProvider;
 use OCA\Assistant\Reference\TaskOutputFileReferenceProvider;
 use OCA\Assistant\Reference\Text2ImageReferenceProvider;
+use OCA\Assistant\Reference\Text2StickerProvider;
 use OCA\Assistant\TaskProcessing\AudioToAudioChatProvider;
 use OCA\Assistant\TaskProcessing\ContextAgentAudioInteractionProvider;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
@@ -58,11 +60,13 @@ class Application extends App implements IBootstrap {
 		$context->registerCapability(Capabilities::class);
 
 		$context->registerReferenceProvider(Text2ImageReferenceProvider::class);
+		$context->registerReferenceProvider(Text2StickerProvider::class);
 		$context->registerReferenceProvider(FreePromptReferenceProvider::class);
 		$context->registerReferenceProvider(SpeechToTextReferenceProvider::class);
 		$context->registerReferenceProvider(TaskOutputFileReferenceProvider::class);
 
 		$context->registerEventListener(RenderReferenceEvent::class, Text2ImageReferenceListener::class);
+		$context->registerEventListener(RenderReferenceEvent::class, Text2StickerListener::class);
 		$context->registerEventListener(RenderReferenceEvent::class, FreePromptReferenceListener::class);
 		$context->registerEventListener(RenderReferenceEvent::class, SpeechToTextReferenceListener::class);
 		$context->registerEventListener(RenderReferenceEvent::class, TaskOutputFileReferenceListener::class);

--- a/lib/Listener/Text2Image/Text2StickerListener.php
+++ b/lib/Listener/Text2Image/Text2StickerListener.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Assistant\Listener\Text2Image;
+
+use OCA\Assistant\AppInfo\Application;
+use OCP\Collaboration\Reference\RenderReferenceEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\TaskProcessing\IManager as ITaskProcessingManager;
+use OCP\TaskProcessing\TaskTypes\TextToImage;
+use OCP\Util;
+
+/**
+ * @template-implements IEventListener<Event>
+ */
+class Text2StickerListener implements IEventListener {
+	public function __construct(
+		private IConfig $config,
+		private IAppConfig $appConfig,
+		private ?string $userId,
+		private ITaskProcessingManager $taskProcessingManager,
+	) {
+	}
+
+	public function handle(Event $event): void {
+
+		if (!$event instanceof RenderReferenceEvent) {
+			return;
+		}
+
+		if ($this->appConfig->getValueString(Application::APP_ID, 'text_to_sticker_picker_enabled', '1') === '1'
+			&& $this->config->getUserValue($this->userId, Application::APP_ID, 'text_to_sticker_picker_enabled', '1') === '1') {
+
+			// Double check that atleast one provider is registered
+			$availableTaskTypes = $this->taskProcessingManager->getAvailableTaskTypes();
+			$textToImageAvailable = array_key_exists(TextToImage::ID, $availableTaskTypes);
+			if ($textToImageAvailable) {
+				Util::addScript(Application::APP_ID, Application::APP_ID . '-stickerGeneration');
+			}
+		}
+	}
+}

--- a/lib/Reference/Text2StickerProvider.php
+++ b/lib/Reference/Text2StickerProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Assistant\Reference;
+
+use OCA\Assistant\AppInfo\Application;
+use OCP\Collaboration\Reference\ADiscoverableReferenceProvider;
+use OCP\Collaboration\Reference\IReference;
+use OCP\Collaboration\Reference\IReferenceManager;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+
+class Text2StickerProvider extends ADiscoverableReferenceProvider {
+
+	public function __construct(
+		private IL10N $l10n,
+		private IURLGenerator $urlGenerator,
+		private IReferenceManager $referenceManager,
+		private ?string $userId,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getId(): string {
+		return 'assistant_sticker_generation';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getTitle(): string {
+		return $this->l10n->t('AI sticker generation');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getOrder(): int {
+		return 10;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getIconUrl(): string {
+		return $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->imagePath(Application::APP_ID, 'app-dark.svg')
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function matchReference(string $referenceText): bool {
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function resolveReference(string $referenceText): ?IReference {
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCachePrefix(string $referenceId): string {
+		return $this->userId ?? '';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCacheKey(string $referenceId): ?string {
+		return $referenceId;
+	}
+
+	/**
+	 * @param string $userId
+	 * @return void
+	 */
+	public function invalidateUserCache(string $userId): void {
+		$this->referenceManager->invalidateCache($userId);
+	}
+
+
+}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -42,6 +42,7 @@ class Admin implements ISettings {
 
 		$freePromptPickerEnabled = $this->appConfig->getValueString(Application::APP_ID, 'free_prompt_picker_enabled', '1') === '1';
 		$textToImagePickerEnabled = $this->appConfig->getValueString(Application::APP_ID, 'text_to_image_picker_enabled', '1') === '1';
+		$textToStickerPickerEnabled = $this->appConfig->getValueString(Application::APP_ID, 'text_to_sticker_picker_enabled', '1') === '1';
 
 		$speechToTextEnabled = $this->appConfig->getValueString(Application::APP_ID, 'speech_to_text_picker_enabled', '1') === '1';
 		$chattyLLMUserInstructions = $this->appConfig->getValueString(Application::APP_ID, 'chat_user_instructions', Application::CHAT_USER_INSTRUCTIONS) ?: Application::CHAT_USER_INSTRUCTIONS;
@@ -53,6 +54,7 @@ class Admin implements ISettings {
 			'assistant_enabled' => $assistantEnabled,
 			'text_to_image_picker_available' => $textToImageAvailable,
 			'text_to_image_picker_enabled' => $textToImagePickerEnabled,
+			'text_to_sticker_picker_enabled' => $textToStickerPickerEnabled,
 			'free_prompt_task_type_available' => $freePromptTaskTypeAvailable,
 			'free_prompt_picker_enabled' => $freePromptPickerEnabled,
 			'speech_to_text_picker_available' => $speechToTextAvailable,

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -52,6 +52,9 @@ class Personal implements ISettings {
 		$textToImagePickerAvailable = $textToImageAvailable && $this->appConfig->getValueString(Application::APP_ID, 'text_to_image_picker_enabled', '1') === '1';
 		$textToImagePickerEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'text_to_image_picker_enabled', '1') === '1';
 
+		$textToStickerPickerAvailable = $textToImageAvailable && $this->appConfig->getValueString(Application::APP_ID, 'text_to_sticker_picker_enabled', '1') === '1';
+		$textToStickerPickerEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'text_to_sticker_picker_enabled', '1') === '1';
+
 		$freePromptPickerAvailable = $freePromptTaskTypeAvailable && $this->appConfig->getValueString(Application::APP_ID, 'free_prompt_picker_enabled', '1') === '1';
 		$freePromptPickerEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'free_prompt_picker_enabled', '1') === '1';
 
@@ -63,6 +66,8 @@ class Personal implements ISettings {
 			'assistant_enabled' => $assistantEnabled,
 			'text_to_image_picker_available' => $textToImagePickerAvailable,
 			'text_to_image_picker_enabled' => $textToImagePickerEnabled,
+			'text_to_sticker_picker_available' => $textToStickerPickerAvailable,
+			'text_to_sticker_picker_enabled' => $textToStickerPickerEnabled,
 			'free_prompt_picker_available' => $freePromptPickerAvailable,
 			'free_prompt_picker_enabled' => $freePromptPickerEnabled,
 			'speech_to_text_picker_available' => $speechToTextPickerAvailable,

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -51,6 +51,14 @@
 						{{ t('assistant', 'Enable text-to-image in smart picker') }}
 					</div>
 				</NcCheckboxRadioSwitch>
+				<NcCheckboxRadioSwitch
+					:model-value="state.text_to_sticker_picker_enabled"
+					:disabled="!state.text_to_image_picker_available"
+					@update:model-value="onCheckboxChanged($event, 'text_to_sticker_picker_enabled')">
+					<div class="checkbox-text">
+						{{ t('assistant', 'Enable text-to-sticker in smart picker') }}
+					</div>
+				</NcCheckboxRadioSwitch>
 				<NcNoteCard v-if="!state.text_to_image_picker_available" type="info">
 					<div class="checkbox-text">
 						<span>

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -37,6 +37,13 @@
 					{{ t('assistant', 'Enable AI image generation in smart picker') }}
 				</div>
 			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch v-if="state.text_to_sticker_picker_available"
+				:model-value="state.text_to_sticker_picker_enabled"
+				@update:model-value="onCheckboxChanged($event, 'text_to_image_picker_enabled')">
+				<div class="checkbox-text">
+					{{ t('assistant', 'Enable AI sticker generation in smart picker') }}
+				</div>
+			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch v-if="state.speech_to_text_picker_available"
 				:model-value="state.speech_to_text_picker_enabled"
 				@update:model-value="onCheckboxChanged($event, 'speech_to_text_picker_enabled')">

--- a/src/stickerGeneration.js
+++ b/src/stickerGeneration.js
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { registerCustomPickerElement, NcCustomPickerRenderResult } from '@nextcloud/vue/components/NcRichText'
+
+registerCustomPickerElement('assistant_sticker_generation', async (el, { providerId, accessible }) => {
+	const { createApp } = await import('vue')
+	const { default: ImageResultCustomPickerElement } = await import('./views/ImageResultCustomPickerElement.vue')
+
+	const app = createApp(
+		ImageResultCustomPickerElement,
+		{
+			inputs: {
+				input: 'cartoon, neutral background, sticker of ',
+			},
+			providerId,
+			accessible,
+			taskType: 'core:text2image',
+			outputKey: 'images',
+			multipleImages: true,
+		},
+	)
+	app.mixin({ methods: { t, n } })
+	app.mount(el)
+
+	return new NcCustomPickerRenderResult(el, app)
+}, (el, renderResult) => {
+	renderResult.object.unmount()
+})

--- a/src/views/ImageResultCustomPickerElement.vue
+++ b/src/views/ImageResultCustomPickerElement.vue
@@ -39,6 +39,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		inputs: {
+			type: Object,
+			default: () => ({}),
+			required: false,
+		},
 	},
 
 	emits: ['cancel', 'submit'],
@@ -56,6 +61,7 @@ export default {
 
 	mounted() {
 		OCA.Assistant.openAssistantForm({
+			inputs: this.inputs,
 			appId: 'assistant',
 			taskType: this.taskType,
 			closeOnResult: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default createAppConfig({
 	personalSettings: 'src/personalSettings.js',
 	adminSettings: 'src/adminSettings.js',
 	imageGenerationReference: 'src/imageGenerationReference.js',
+	stickerGeneration: 'src/stickerGeneration.js',
 	textGenerationReference: 'src/textGenerationReference.js',
 	speechToTextReference: 'src/speechToTextReference.js',
 	taskOutputFileReference: 'src/taskOutputFileReference.js',


### PR DESCRIPTION
Not sure if the sticker prompt should be hidden or not. Currently it is visible. An example sticker if the user adds dog:
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/b4ab2ea1-16ad-48d6-b20e-19a9e91249da" />
