### PR TITLE
Only show the group file action if necessary

### DIFF
--- a/src/files/fileActions.js
+++ b/src/files/fileActions.js
@@ -17,7 +17,7 @@ const actionIgnoreLists = [
 	'files.public',
 ]
 
-function registerGroupAction() {
+function registerGroupAction(mimeTypes) {
 	const groupAction = new FileAction({
 		id: 'assistant-group',
 		displayName: (nodes) => {
@@ -28,7 +28,7 @@ function registerGroupAction() {
 				&& nodes.length === 1
 				&& !nodes.some(({ permissions }) => (permissions & Permission.READ) === 0)
 				&& nodes.every(({ type }) => type === FileType.File)
-			// && nodes.every(({ mime }) => ['text/plain', 'text/markdown'].includes(mime))
+				&& nodes.every(({ mime }) => mimeTypes.includes(mime))
 		},
 		iconSvgInline: () => CreationSvgIcon,
 		order: 0,
@@ -163,7 +163,14 @@ const ttsAvailable = loadState('assistant', 'tts-available', false)
 
 if (assistantEnabled) {
 	if (summarizeAvailable || sttAvailable || ttsAvailable) {
-		registerGroupAction()
+		const groupMimeTypes = []
+		if (summarizeAvailable || ttsAvailable) {
+			groupMimeTypes.push(...VALID_TEXT_MIME_TYPES)
+		}
+		if (sttAvailable) {
+			groupMimeTypes.push(...VALID_AUDIO_MIME_TYPES)
+		}
+		registerGroupAction(groupMimeTypes)
 	}
 	if (sttAvailable) {
 		registerSttAction()


### PR DESCRIPTION
The group file action is registered if at least one of summarize, stt or tts task types are available.
But then it is displayed for all files, even if there is no sub action in the group.

This adds a condition in the group action on the file mime type.