### PR TITLE
Use new assistant theme

### DIFF
--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -61,6 +61,9 @@ class BeforeTemplateRenderedListener implements IEventListener {
 		$assistantEnabled = $adminAssistantEnabled && $userAssistantEnabled;
 		$this->initialStateService->provideInitialState('assistant-enabled', $assistantEnabled);
 		if ($assistantEnabled) {
+			$useModernStyle = version_compare($this->config->getSystemValueString('version', '0.0.0'), '32.0.0', '>=');
+			$this->initialStateService->provideInitialState('use-modern-style', $useModernStyle);
+
 			$lastTargetLanguage = $this->config->getUserValue($this->userId, Application::APP_ID, 'last_target_language', '');
 			$this->initialStateService->provideInitialState('last-target-language', $lastTargetLanguage);
 			$indexingComplete = $this->appConfig->getValueInt('context_chat', 'last_indexed_time', 0) !== 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,9 +76,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
-			"integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+			"integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -87,23 +87,23 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
-			"integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
+			"integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.3",
+				"@babel/generator": "^7.28.3",
 				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.27.3",
-				"@babel/helpers": "^7.27.4",
-				"@babel/parser": "^7.27.4",
+				"@babel/helper-module-transforms": "^7.28.3",
+				"@babel/helpers": "^7.28.3",
+				"@babel/parser": "^7.28.3",
 				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.27.4",
-				"@babel/types": "^7.27.3",
+				"@babel/traverse": "^7.28.3",
+				"@babel/types": "^7.28.2",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -119,9 +119,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.27.5.tgz",
-			"integrity": "sha512-HLkYQfRICudzcOtjGwkPvGc5nF1b4ljLZh1IRDj50lRZ718NAKVgQpIAUX8bfg6u/yuSKY3L7E0YzIV+OxrB8Q==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.0.tgz",
+			"integrity": "sha512-N4ntErOlKvcbTt01rr5wj3y55xnIdx1ymrfIr8C2WnM1Y9glFgWaGDEULJIazOX3XM9NRzhfJ6zZnQ1sBNWU+w==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -139,17 +139,17 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-			"integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+			"integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/parser": "^7.27.5",
-				"@babel/types": "^7.27.3",
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25",
+				"@babel/parser": "^7.28.3",
+				"@babel/types": "^7.28.2",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
 			},
 			"engines": {
@@ -189,19 +189,19 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-			"integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
+			"integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.27.1",
+				"@babel/helper-annotate-as-pure": "^7.27.3",
 				"@babel/helper-member-expression-to-functions": "^7.27.1",
 				"@babel/helper-optimise-call-expression": "^7.27.1",
 				"@babel/helper-replace-supers": "^7.27.1",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-				"@babel/traverse": "^7.27.1",
+				"@babel/traverse": "^7.28.3",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -231,21 +231,32 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
-			"integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+			"integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.22.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"debug": "^4.1.1",
+				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"debug": "^4.4.1",
 				"lodash.debounce": "^4.0.8",
-				"resolve": "^1.14.2"
+				"resolve": "^1.22.10"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+			}
+		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
@@ -279,16 +290,16 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-			"integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.27.1",
 				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.27.3"
+				"@babel/traverse": "^7.28.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -405,43 +416,43 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
-			"integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
+			"integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/template": "^7.27.1",
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/template": "^7.27.2",
+				"@babel/traverse": "^7.28.3",
+				"@babel/types": "^7.28.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-			"integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
+			"integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.6"
+				"@babel/types": "^7.28.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-			"integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+			"integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.27.3"
+				"@babel/types": "^7.28.2"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -522,15 +533,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
-			"integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
+			"integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/traverse": "^7.27.1"
+				"@babel/traverse": "^7.28.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -637,16 +648,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
-			"integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
+			"integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.27.1",
 				"@babel/helper-remap-async-to-generator": "^7.27.1",
-				"@babel/traverse": "^7.27.1"
+				"@babel/traverse": "^7.28.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -692,9 +703,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.5.tgz",
-			"integrity": "sha512-JF6uE2s67f0y2RZcm2kpAUEbD50vH62TyWVebxwHAlbSdM49VqPz8t4a1uIjp4NIOIZ4xzLfjY5emt/RCyC7TQ==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz",
+			"integrity": "sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -727,14 +738,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
-			"integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
+			"integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.27.1",
+				"@babel/helper-create-class-features-plugin": "^7.28.3",
 				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
@@ -745,19 +756,19 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
-			"integrity": "sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.3.tgz",
+			"integrity": "sha512-DoEWC5SuxuARF2KdKmGUq3ghfPMO6ZzR12Dnp5gubwbeWJo4dbNWXJPVlwvh4Zlq6Z7YVvL8VFxeSOJgjsx4Sg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.27.1",
-				"@babel/helper-compilation-targets": "^7.27.1",
+				"@babel/helper-annotate-as-pure": "^7.27.3",
+				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-globals": "^7.28.0",
 				"@babel/helper-plugin-utils": "^7.27.1",
 				"@babel/helper-replace-supers": "^7.27.1",
-				"@babel/traverse": "^7.27.1",
-				"globals": "^11.1.0"
+				"@babel/traverse": "^7.28.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -785,14 +796,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
-			"integrity": "sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
+			"integrity": "sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/traverse": "^7.28.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -863,6 +875,24 @@
 			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
+			"integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/plugin-transform-destructuring": "^7.28.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1154,17 +1184,18 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
-			"integrity": "sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz",
+			"integrity": "sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.27.2",
 				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/plugin-transform-destructuring": "^7.27.3",
-				"@babel/plugin-transform-parameters": "^7.27.1"
+				"@babel/plugin-transform-destructuring": "^7.28.0",
+				"@babel/plugin-transform-parameters": "^7.27.7",
+				"@babel/traverse": "^7.28.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1227,9 +1258,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
-			"integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
+			"version": "7.27.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+			"integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1298,9 +1329,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.5.tgz",
-			"integrity": "sha512-uhB8yHerfe3MWnuLAhEbeQ4afVoqv8BQsPqrTv7e/jZ9y00kJL6l9a/f4OWaKxotmjzewfEyXE1vgDJenkQ2/Q==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.3.tgz",
+			"integrity": "sha512-K3/M/a4+ESb5LEldjQb+XSrpY0nF+ZBFlTCbSnKaYAMfD8v33O6PMs4uYnOk19HlcsI8WMu3McdFPTiQHF/1/A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1507,14 +1538,14 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
-			"integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.3.tgz",
+			"integrity": "sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.27.2",
+				"@babel/compat-data": "^7.28.0",
 				"@babel/helper-compilation-targets": "^7.27.2",
 				"@babel/helper-plugin-utils": "^7.27.1",
 				"@babel/helper-validator-option": "^7.27.1",
@@ -1522,25 +1553,26 @@
 				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.3",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
 				"@babel/plugin-syntax-import-assertions": "^7.27.1",
 				"@babel/plugin-syntax-import-attributes": "^7.27.1",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.27.1",
-				"@babel/plugin-transform-async-generator-functions": "^7.27.1",
+				"@babel/plugin-transform-async-generator-functions": "^7.28.0",
 				"@babel/plugin-transform-async-to-generator": "^7.27.1",
 				"@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-				"@babel/plugin-transform-block-scoping": "^7.27.1",
+				"@babel/plugin-transform-block-scoping": "^7.28.0",
 				"@babel/plugin-transform-class-properties": "^7.27.1",
-				"@babel/plugin-transform-class-static-block": "^7.27.1",
-				"@babel/plugin-transform-classes": "^7.27.1",
+				"@babel/plugin-transform-class-static-block": "^7.28.3",
+				"@babel/plugin-transform-classes": "^7.28.3",
 				"@babel/plugin-transform-computed-properties": "^7.27.1",
-				"@babel/plugin-transform-destructuring": "^7.27.1",
+				"@babel/plugin-transform-destructuring": "^7.28.0",
 				"@babel/plugin-transform-dotall-regex": "^7.27.1",
 				"@babel/plugin-transform-duplicate-keys": "^7.27.1",
 				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
 				"@babel/plugin-transform-dynamic-import": "^7.27.1",
+				"@babel/plugin-transform-explicit-resource-management": "^7.28.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.27.1",
 				"@babel/plugin-transform-export-namespace-from": "^7.27.1",
 				"@babel/plugin-transform-for-of": "^7.27.1",
@@ -1557,15 +1589,15 @@
 				"@babel/plugin-transform-new-target": "^7.27.1",
 				"@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
 				"@babel/plugin-transform-numeric-separator": "^7.27.1",
-				"@babel/plugin-transform-object-rest-spread": "^7.27.2",
+				"@babel/plugin-transform-object-rest-spread": "^7.28.0",
 				"@babel/plugin-transform-object-super": "^7.27.1",
 				"@babel/plugin-transform-optional-catch-binding": "^7.27.1",
 				"@babel/plugin-transform-optional-chaining": "^7.27.1",
-				"@babel/plugin-transform-parameters": "^7.27.1",
+				"@babel/plugin-transform-parameters": "^7.27.7",
 				"@babel/plugin-transform-private-methods": "^7.27.1",
 				"@babel/plugin-transform-private-property-in-object": "^7.27.1",
 				"@babel/plugin-transform-property-literals": "^7.27.1",
-				"@babel/plugin-transform-regenerator": "^7.27.1",
+				"@babel/plugin-transform-regenerator": "^7.28.3",
 				"@babel/plugin-transform-regexp-modifiers": "^7.27.1",
 				"@babel/plugin-transform-reserved-words": "^7.27.1",
 				"@babel/plugin-transform-shorthand-properties": "^7.27.1",
@@ -1578,10 +1610,10 @@
 				"@babel/plugin-transform-unicode-regex": "^7.27.1",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.11.0",
-				"babel-plugin-polyfill-regenerator": "^0.6.1",
-				"core-js-compat": "^3.40.0",
+				"babel-plugin-polyfill-corejs2": "^0.4.14",
+				"babel-plugin-polyfill-corejs3": "^0.13.0",
+				"babel-plugin-polyfill-regenerator": "^0.6.5",
+				"core-js-compat": "^3.43.0",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1608,9 +1640,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+			"integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -1633,29 +1665,29 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-			"integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+			"integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.3",
-				"@babel/parser": "^7.27.4",
+				"@babel/generator": "^7.28.3",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.28.3",
 				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.3",
-				"debug": "^4.3.1",
-				"globals": "^11.1.0"
+				"@babel/types": "^7.28.2",
+				"debug": "^4.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
-			"integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
+			"version": "7.28.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+			"integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
@@ -1776,34 +1808,34 @@
 			}
 		},
 		"node_modules/@dual-bundle/import-meta-resolve": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-			"integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
+			"integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"funding": {
 				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
+				"url": "https://github.com/sponsors/JounQin"
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
-			"integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+			"integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"peer": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.0.2",
+				"@emnapi/wasi-threads": "1.1.0",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
-			"integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+			"integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1813,9 +1845,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
-			"integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1841,13 +1873,12 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-			"integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+			"integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1858,13 +1889,12 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-			"integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+			"integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1875,13 +1905,12 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-			"integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+			"integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1892,13 +1921,12 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-			"integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+			"integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1909,13 +1937,12 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-			"integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+			"integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1926,13 +1953,12 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-			"integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+			"integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1943,13 +1969,12 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-			"integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+			"integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1960,13 +1985,12 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-			"integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+			"integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1977,13 +2001,12 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-			"integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+			"integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1994,13 +2017,12 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-			"integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+			"integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2011,13 +2033,12 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-			"integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+			"integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2028,13 +2049,12 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-			"integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+			"integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2045,13 +2065,12 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-			"integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+			"integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2062,13 +2081,12 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-			"integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+			"integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2079,13 +2097,12 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-			"integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+			"integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2096,13 +2113,12 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-			"integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+			"integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2113,13 +2129,12 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-			"integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+			"integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2130,13 +2145,12 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-			"integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+			"integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2147,13 +2161,12 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-			"integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+			"integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2164,13 +2177,12 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-			"integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+			"integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2181,13 +2193,12 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-			"integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+			"integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2197,14 +2208,29 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+			"integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-			"integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+			"integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2215,13 +2241,12 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-			"integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+			"integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2232,13 +2257,12 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-			"integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+			"integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2249,13 +2273,12 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-			"integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+			"integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2347,23 +2370,6 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2390,38 +2396,38 @@
 			}
 		},
 		"node_modules/@file-type/xml": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@file-type/xml/-/xml-0.4.3.tgz",
-			"integrity": "sha512-pGRmkHf+NofNy/52r06HOTsEwdNnBsFEhN6U95s33P+ezuoxZEyBTV9lOB1/Zr0So6/9vDVfWZXLpgd0fy8cOQ==",
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/@file-type/xml/-/xml-0.4.4.tgz",
+			"integrity": "sha512-NhCyXoHlVZ8TqM476hyzwGJ24+D5IPSaZhmrPj7qXnEVb3q6jrFzA3mM9TBpknKSI9EuQeGTKRg2DXGUwvBBoQ==",
 			"license": "MIT",
 			"dependencies": {
 				"sax": "^1.4.1",
-				"strtok3": "^10.2.2"
+				"strtok3": "^10.3.4"
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
-			"integrity": "sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+			"integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.9"
+				"@floating-ui/utils": "^0.2.10"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.1.tgz",
-			"integrity": "sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+			"integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/core": "^1.7.1",
-				"@floating-ui/utils": "^0.2.9"
+				"@floating-ui/core": "^1.7.3",
+				"@floating-ui/utils": "^0.2.10"
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-			"integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
 			"license": "MIT"
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -2491,20 +2497,39 @@
 			"license": "BSD-3-Clause",
 			"peer": true
 		},
+		"node_modules/@isaacs/balanced-match": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@isaacs/brace-expansion": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@isaacs/balanced-match": "^4.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@jridgewell/set-array": "^1.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -2518,27 +2543,16 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.30",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+			"integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -2548,41 +2562,12 @@
 			}
 		},
 		"node_modules/@keyv/serialize": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
-			"integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
+			"integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"buffer": "^6.0.3"
-			}
-		},
-		"node_modules/@keyv/serialize/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
+			"peer": true
 		},
 		"node_modules/@material-symbols/svg-700": {
 			"version": "0.33.0",
@@ -2603,21 +2588,21 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@microsoft/api-extractor": {
-			"version": "7.52.8",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.8.tgz",
-			"integrity": "sha512-cszYIcjiNscDoMB1CIKZ3My61+JOhpERGlGr54i6bocvGLrcL/wo9o+RNXMBrb7XgLtKaizZWUpqRduQuHQLdg==",
+			"version": "7.52.11",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.11.tgz",
+			"integrity": "sha512-IKQ7bHg6f/Io3dQds6r9QPYk4q0OlR9A4nFDtNhUt3UUIhyitbxAqRN1CLjUVtk6IBk3xzyCMOdwwtIXQ7AlGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@microsoft/api-extractor-model": "7.30.6",
+				"@microsoft/api-extractor-model": "7.30.7",
 				"@microsoft/tsdoc": "~0.15.1",
 				"@microsoft/tsdoc-config": "~0.17.1",
-				"@rushstack/node-core-library": "5.13.1",
+				"@rushstack/node-core-library": "5.14.0",
 				"@rushstack/rig-package": "0.5.3",
-				"@rushstack/terminal": "0.15.3",
-				"@rushstack/ts-command-line": "5.0.1",
+				"@rushstack/terminal": "0.15.4",
+				"@rushstack/ts-command-line": "5.0.2",
 				"lodash": "~4.17.15",
-				"minimatch": "~3.0.3",
+				"minimatch": "10.0.3",
 				"resolve": "~1.22.1",
 				"semver": "~7.5.4",
 				"source-map": "~0.6.1",
@@ -2628,26 +2613,15 @@
 			}
 		},
 		"node_modules/@microsoft/api-extractor-model": {
-			"version": "7.30.6",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.6.tgz",
-			"integrity": "sha512-znmFn69wf/AIrwHya3fxX6uB5etSIn6vg4Q4RB/tb5VDDs1rqREc+AvMC/p19MUN13CZ7+V/8pkYPTj7q8tftg==",
+			"version": "7.30.7",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.7.tgz",
+			"integrity": "sha512-TBbmSI2/BHpfR9YhQA7nH0nqVmGgJ0xH0Ex4D99/qBDAUpnhA2oikGmdXanbw9AWWY/ExBYIpkmY8dBHdla3YQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@microsoft/tsdoc": "~0.15.1",
 				"@microsoft/tsdoc-config": "~0.17.1",
-				"@rushstack/node-core-library": "5.13.1"
-			}
-		},
-		"node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"@rushstack/node-core-library": "5.14.0"
 			}
 		},
 		"node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
@@ -2664,16 +2638,19 @@
 			}
 		},
 		"node_modules/@microsoft/api-extractor/node_modules/minimatch": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+			"integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"@isaacs/brace-expansion": "^5.0.0"
 			},
 			"engines": {
-				"node": "*"
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@microsoft/api-extractor/node_modules/semver": {
@@ -2758,9 +2735,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
-			"integrity": "sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -2768,21 +2745,20 @@
 			"dependencies": {
 				"@emnapi/core": "^1.4.3",
 				"@emnapi/runtime": "^1.4.3",
-				"@tybys/wasm-util": "^0.9.0"
+				"@tybys/wasm-util": "^0.10.0"
 			}
 		},
 		"node_modules/@nextcloud/auth": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.5.1.tgz",
-			"integrity": "sha512-cToowJmI9rvIXuWvpvHp4tKm1ZzK4tlPh4rAuEjX6Dvpq74ia52yJYGJFR2maag/i/tMl9m0diZtHgSog6GTGg==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.5.2.tgz",
+			"integrity": "sha512-1dr+Xhvg2QtsFC23KFXJSkU524EVgI/+WFBGTZ8tFa+9hmcZ3CqZIHjtXm3KxUvezwAY5023Ml0n2vpdYkpBXQ==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@nextcloud/browser-storage": "^0.4.0",
 				"@nextcloud/event-bus": "^3.3.2"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/axios": {
@@ -2854,35 +2830,61 @@
 			}
 		},
 		"node_modules/@nextcloud/dialogs": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-7.0.0-rc.1.tgz",
-			"integrity": "sha512-9NzgKFhWE85XV9wKLONYBlPswIVzPctiirbaRTGsLPcB/mCDiFiEErAARPr+RIwRqDNSQHVjHEcRTujfT6t1XA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-7.0.0-rc.2.tgz",
+			"integrity": "sha512-RtMLMPj6RdJxA3BUGJPBfpGhpj69Gbs0HI9MHzb+OhCU6YzFjIKNERUqB/WE+2Cyxj6MjAciJjwcT4Lt7RerjA==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@mdi/js": "^7.4.47",
-				"@nextcloud/auth": "^2.5.1",
+				"@nextcloud/auth": "^2.5.2",
 				"@nextcloud/axios": "^2.5.1",
 				"@nextcloud/browser-storage": "^0.4.0",
 				"@nextcloud/event-bus": "^3.3.2",
-				"@nextcloud/files": "^3.10.2",
-				"@nextcloud/initial-state": "^2.2.0",
-				"@nextcloud/l10n": "^3.3.0",
+				"@nextcloud/files": "^3.12.0",
+				"@nextcloud/initial-state": "^3.0.0",
+				"@nextcloud/l10n": "^3.4.0",
 				"@nextcloud/paths": "^2.2.1",
 				"@nextcloud/router": "^3.0.1",
-				"@nextcloud/sharing": "^0.2.4",
+				"@nextcloud/sharing": "^0.2.5",
 				"@nextcloud/typings": "^1.9.1",
 				"@nextcloud/vue": "^9.0.0-rc.2",
 				"@types/toastify-js": "^1.12.4",
-				"@vueuse/core": "^13.1.0",
+				"@vueuse/core": "^13.7.0",
 				"cancelable-promise": "^4.3.1",
 				"p-queue": "^8.1.0",
 				"toastify-js": "^1.12.0",
-				"vue": "^3.5.16",
+				"vite-plugin-node-polyfills": "^0.24.0",
+				"vue": "^3.5.20",
 				"webdav": "^5.8.0"
 			},
 			"engines": {
 				"node": "^20 || ^22",
 				"npm": "^10.0.0"
+			}
+		},
+		"node_modules/@nextcloud/dialogs/node_modules/@nextcloud/initial-state": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+			"integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+			"license": "GPL-3.0-or-later",
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
+		"node_modules/@nextcloud/dialogs/node_modules/@nextcloud/l10n": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.4.0.tgz",
+			"integrity": "sha512-K4UBSl0Ou6sXXLxyjuhktRf2FyTCjyvHxJyBLmS2z3YEYcRkpf8ib3XneRwEQIEpzBPQjul2/ZdFlt7umd8Gaw==",
+			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/router": "^3.0.1",
+				"@nextcloud/typings": "^1.9.1",
+				"@types/escape-html": "^1.0.4",
+				"dompurify": "^3.2.6",
+				"escape-html": "^1.0.3"
+			},
+			"engines": {
+				"node": "^20 || ^22 || ^24"
 			}
 		},
 		"node_modules/@nextcloud/eslint-config": {
@@ -2973,9 +2975,9 @@
 			}
 		},
 		"node_modules/@nextcloud/files": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.11.0.tgz",
-			"integrity": "sha512-upOupwyjGlNoHY94M6xcXyazNTa6heY2uFY6ZjnIus19pyMQloXxnxwrd95cvdm8t3NxofMd2VG+DaDbK1FuXQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.0.tgz",
+			"integrity": "sha512-LVZklgooZzBj2jkbPRZO4jnnvW5+RvOn7wN5weyOZltF6i2wVMbg1Y/Czl2pi/UNMjUm5ENqc0j7FgxMBo8bwA==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@nextcloud/auth": "^2.5.1",
@@ -3035,17 +3037,33 @@
 			}
 		},
 		"node_modules/@nextcloud/moment": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.4.tgz",
-			"integrity": "sha512-ibc1v3HshmI8q1jkfwj5tKgBnOSCpaVp1Nx0uSqnoStUsh5qdf235xA0UFtro+yFuGgfpTbos4gTzfXIoC2enA==",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.5.tgz",
+			"integrity": "sha512-sQjQ/D40sdedtq4ywuANSxqG0VhIB/i+QtZ6Voz3nyZWhkyyqGxdj9rQu9AyEvas3/Jlspdom5chc+a8jOmHxQ==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/l10n": "^3.2.0",
+				"@nextcloud/l10n": "^3.4.0",
 				"moment": "^2.30.1"
 			},
 			"engines": {
 				"node": "^20.0.0",
 				"npm": "^10.0.0"
+			}
+		},
+		"node_modules/@nextcloud/moment/node_modules/@nextcloud/l10n": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.4.0.tgz",
+			"integrity": "sha512-K4UBSl0Ou6sXXLxyjuhktRf2FyTCjyvHxJyBLmS2z3YEYcRkpf8ib3XneRwEQIEpzBPQjul2/ZdFlt7umd8Gaw==",
+			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/router": "^3.0.1",
+				"@nextcloud/typings": "^1.9.1",
+				"@types/escape-html": "^1.0.4",
+				"dompurify": "^3.2.6",
+				"escape-html": "^1.0.3"
+			},
+			"engines": {
+				"node": "^20 || ^22 || ^24"
 			}
 		},
 		"node_modules/@nextcloud/paths": {
@@ -3072,16 +3090,15 @@
 			}
 		},
 		"node_modules/@nextcloud/sharing": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.2.4.tgz",
-			"integrity": "sha512-kOLAr0w4NDUGPF42L22i9iSs6Z3ylTsE0RudAGDBzw/pnxGY8PEwZI2j0IMAFRfQ7XFNcpV/EVHI5YCMxtxGMQ==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.2.5.tgz",
+			"integrity": "sha512-B3K5Dq9b5dexDA5n3AAuCF69Huwhrpw0J72fsVXV4KpPdImjhVPlExAv5o70AoXa+OqN4Rwn6gqJw+3ED892zg==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@nextcloud/initial-state": "^2.2.0"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/stylelint-config": {
@@ -3104,9 +3121,9 @@
 			}
 		},
 		"node_modules/@nextcloud/timezones": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.2.0.tgz",
-			"integrity": "sha512-1mwQ+asTFOgv9rxPoAMEbDF8JfnenIa2EGNS+8MATCyi6WXxYh0Lhkaq1d3l2+xNbUPHgMnk4cRYsvIo319lkA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-1.0.0.tgz",
+			"integrity": "sha512-9b7Wms2mzB4RAltf8s9dY40PcU5ova5QjQJw1Gty35e54alKyx33BqUOy4gEbkzmYSrW4aZcLcMrOO5Bj2eIzg==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"ical.js": "^2.1.0"
@@ -3129,87 +3146,95 @@
 			}
 		},
 		"node_modules/@nextcloud/vite-config": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-2.3.5.tgz",
-			"integrity": "sha512-Q3qwzAkdUJhcWhYyx5ssp1qzHvfbCUHUexQPEJcuPBfdUceqcYPvTB4zn8vIX2PRddIBLSuVpz+QTBf5ox9sqA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-2.5.0.tgz",
+			"integrity": "sha512-i9Cjo9ITgEWJ5ws/I7f5d5S+GSy9zM8DqjFMvwvserrfSHXmJvPhF9XVRT89CbSMYtGoCYzJMNxe6jNp9FF3nw==",
 			"dev": true,
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@rollup/plugin-replace": "^6.0.2",
-				"@vitejs/plugin-vue": "^5.2.3",
+				"@vitejs/plugin-vue": "^6.0.1",
 				"browserslist-to-esbuild": "^2.1.1",
-				"magic-string": "^0.30.17",
+				"magic-string": "^0.30.18",
 				"rollup-plugin-corejs": "^1.0.1",
 				"rollup-plugin-esbuild-minify": "^1.3.0",
 				"rollup-plugin-license": "^3.6.0",
-				"rollup-plugin-node-externals": "^8.0.0",
+				"rollup-plugin-node-externals": "^8.1.0",
 				"spdx-expression-parse": "^4.0.0",
 				"vite-plugin-css-injected-by-js": "^3.5.2",
-				"vite-plugin-dts": "^4.5.3",
-				"vite-plugin-node-polyfills": "^0.23.0"
+				"vite-plugin-dts": "^4.5.4",
+				"vite-plugin-node-polyfills": "^0.24.0"
 			},
 			"engines": {
-				"node": "^20 || ^22",
-				"npm": "^10"
+				"node": "^20 || ^22 || ^24"
 			},
 			"peerDependencies": {
 				"browserslist": ">=4.0",
 				"sass": ">=1.60",
-				"vite": "^5 || ^6"
+				"vite": "^7.1.4"
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "9.0.0-rc.5",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.5.tgz",
-			"integrity": "sha512-1wg4siIYhahWs9yvvyd+rvuJGNbYbpPKT2fRQaaXYEmQW+Y04Opv3DXA6OzwssR5W9+Xgs/VSLjdBSOGJEZHBw==",
+			"version": "9.0.0-rc.8",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.8.tgz",
+			"integrity": "sha512-fUMbQZjZ985Hm+8zaxPErp1DwlNqVELzj5MK+Z+qR5iDisILY6PKGguKGvLI8wNwQrIIgJtK9vK9AZcALowiOg==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",
-				"@floating-ui/dom": "^1.6.13",
-				"@nextcloud/auth": "^2.4.0",
+				"@floating-ui/dom": "^1.7.4",
+				"@nextcloud/auth": "^2.5.2",
 				"@nextcloud/axios": "^2.5.1",
 				"@nextcloud/browser-storage": "^0.4.0",
 				"@nextcloud/capabilities": "^1.2.0",
 				"@nextcloud/event-bus": "^3.3.2",
-				"@nextcloud/initial-state": "^2.2.0",
+				"@nextcloud/initial-state": "^3.0.0",
 				"@nextcloud/l10n": "^3.4.0",
 				"@nextcloud/logger": "^3.0.2",
 				"@nextcloud/router": "^3.0.1",
-				"@nextcloud/sharing": "^0.2.4",
-				"@nextcloud/timezones": "^0.2.0",
+				"@nextcloud/sharing": "^0.2.5",
+				"@nextcloud/timezones": "^1.0.0",
 				"@vuepic/vue-datepicker": "^11.0.2",
-				"@vueuse/components": "^13.0.0",
-				"@vueuse/core": "^13.0.0",
+				"@vueuse/components": "^13.8.0",
+				"@vueuse/core": "^13.6.0",
 				"blurhash": "^2.0.5",
 				"clone": "^2.1.2",
 				"debounce": "^2.2.0",
-				"dompurify": "^3.2.4",
-				"emoji-mart-vue-fast": "^15.0.4",
+				"dompurify": "^3.2.6",
+				"emoji-mart-vue-fast": "^15.0.5",
 				"escape-html": "^1.0.3",
 				"floating-vue": "^5.2.2",
-				"focus-trap": "^7.6.4",
-				"linkifyjs": "^4.2.0",
-				"p-queue": "^8.0.1",
+				"focus-trap": "^7.6.5",
+				"linkifyjs": "^4.3.2",
+				"p-queue": "^8.1.0",
 				"rehype-external-links": "^3.0.0",
 				"rehype-highlight": "^7.0.2",
 				"rehype-react": "^8.0.0",
 				"remark-breaks": "^4.0.0",
 				"remark-parse": "^11.0.0",
-				"remark-rehype": "^11.1.1",
+				"remark-rehype": "^11.1.2",
 				"remark-unlink-protocols": "^1.0.0",
-				"splitpanes": "^4.0.3",
+				"splitpanes": "^4.0.4",
 				"striptags": "^3.2.0",
 				"tabbable": "^6.2.0",
 				"tributejs": "^5.1.3",
 				"unified": "^11.0.5",
 				"unist-builder": "^4.0.0",
 				"unist-util-visit": "^5.0.0",
-				"vue": "^3.5.13",
-				"vue-router": "^4.5.0",
+				"vue": "^3.5.18",
+				"vue-router": "^4.5.1",
 				"vue-select": "^4.0.0-beta.6"
 			},
 			"engines": {
 				"node": "^20.11.0 || ^22 || ^24"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/initial-state": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+			"integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+			"license": "GPL-3.0-or-later",
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/vue/node_modules/@nextcloud/l10n": {
@@ -3295,7 +3320,6 @@
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
 			"integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -3336,7 +3360,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3358,7 +3381,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3380,7 +3402,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3402,7 +3423,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3424,7 +3444,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3446,7 +3465,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3468,7 +3486,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3490,7 +3507,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3512,7 +3528,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3534,7 +3549,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3556,7 +3570,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3578,7 +3591,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3600,7 +3612,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3615,11 +3626,17 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-beta.29",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.29.tgz",
+			"integrity": "sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@rollup/plugin-inject": {
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
 			"integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@rollup/pluginutils": "^5.0.1",
@@ -3664,7 +3681,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
 			"integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0",
@@ -3684,13 +3700,12 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.1.tgz",
-			"integrity": "sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz",
+			"integrity": "sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==",
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3699,13 +3714,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.1.tgz",
-			"integrity": "sha512-RurZetXqTu4p+G0ChbnkwBuAtwAbIwJkycw1n6GvlGlBuS4u5qlr5opix8cBAYFJgaY05TWtM+LaoFggUmbZEQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz",
+			"integrity": "sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3714,13 +3728,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.1.tgz",
-			"integrity": "sha512-fM/xPesi7g2M7chk37LOnmnSTHLG/v2ggWqKj3CCA1rMA4mm5KVBT1fNoswbo1JhPuNNZrVwpTvlCVggv8A2zg==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz",
+			"integrity": "sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3729,13 +3742,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.1.tgz",
-			"integrity": "sha512-gDnWk57urJrkrHQ2WVx9TSVTH7lSlU7E3AFqiko+bgjlh78aJ88/3nycMax52VIVjIm3ObXnDL2H00e/xzoipw==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz",
+			"integrity": "sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3744,13 +3756,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.1.tgz",
-			"integrity": "sha512-wnFQmJ/zPThM5zEGcnDcCJeYJgtSLjh1d//WuHzhf6zT3Md1BvvhJnWoy+HECKu2bMxaIcfWiu3bJgx6z4g2XA==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz",
+			"integrity": "sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3759,13 +3770,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.1.tgz",
-			"integrity": "sha512-uBmIxoJ4493YATvU2c0upGz87f99e3wop7TJgOA/bXMFd2SvKCI7xkxY/5k50bv7J6dw1SXT4MQBQSLn8Bb/Uw==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz",
+			"integrity": "sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3774,13 +3784,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.1.tgz",
-			"integrity": "sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz",
+			"integrity": "sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==",
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3789,13 +3798,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.1.tgz",
-			"integrity": "sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz",
+			"integrity": "sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==",
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3804,13 +3812,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.1.tgz",
-			"integrity": "sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz",
+			"integrity": "sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3819,13 +3826,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.1.tgz",
-			"integrity": "sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz",
+			"integrity": "sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3834,13 +3840,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.1.tgz",
-			"integrity": "sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz",
+			"integrity": "sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==",
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3848,14 +3853,13 @@
 			],
 			"peer": true
 		},
-		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.1.tgz",
-			"integrity": "sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA==",
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz",
+			"integrity": "sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==",
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3864,13 +3868,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.1.tgz",
-			"integrity": "sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz",
+			"integrity": "sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==",
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3879,13 +3882,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.1.tgz",
-			"integrity": "sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz",
+			"integrity": "sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==",
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3894,13 +3896,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.1.tgz",
-			"integrity": "sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz",
+			"integrity": "sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==",
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3909,13 +3910,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.1.tgz",
-			"integrity": "sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz",
+			"integrity": "sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3924,13 +3924,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.1.tgz",
-			"integrity": "sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz",
+			"integrity": "sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3938,14 +3937,27 @@
 			],
 			"peer": true
 		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.1.tgz",
-			"integrity": "sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg==",
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz",
+			"integrity": "sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"peer": true
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz",
+			"integrity": "sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3954,13 +3966,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.1.tgz",
-			"integrity": "sha512-JYA3qvCOLXSsnTR3oiyGws1Dm0YTuxAAeaYGVlGpUsHqloPcFjPg+X0Fj2qODGLNwQOAcCiQmHub/V007kiH5A==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz",
+			"integrity": "sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==",
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3969,13 +3980,12 @@
 			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.1.tgz",
-			"integrity": "sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz",
+			"integrity": "sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3992,9 +4002,9 @@
 			"peer": true
 		},
 		"node_modules/@rushstack/node-core-library": {
-			"version": "5.13.1",
-			"resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.13.1.tgz",
-			"integrity": "sha512-5yXhzPFGEkVc9Fu92wsNJ9jlvdwz4RNb2bMso+/+TH0nMm1jDDDsOIf4l8GAkPxGuwPw5DH24RliWVfSPhlW/Q==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.14.0.tgz",
+			"integrity": "sha512-eRong84/rwQUlATGFW3TMTYVyqL1vfW9Lf10PH+mVGfIb9HzU3h5AASNIw+axnBLjnD0n3rT5uQBwu9fvzATrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4103,13 +4113,13 @@
 			}
 		},
 		"node_modules/@rushstack/terminal": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.3.tgz",
-			"integrity": "sha512-DGJ0B2Vm69468kZCJkPj3AH5nN+nR9SPmC0rFHtzsS4lBQ7/dgOwtwVxYP7W9JPDMuRBkJ4KHmWKr036eJsj9g==",
+			"version": "0.15.4",
+			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.4.tgz",
+			"integrity": "sha512-OQSThV0itlwVNHV6thoXiAYZlQh4Fgvie2CzxFABsbO2MWQsI4zOh3LRNigYSTrmS+ba2j0B3EObakPzf/x6Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rushstack/node-core-library": "5.13.1",
+				"@rushstack/node-core-library": "5.14.0",
 				"supports-color": "~8.1.1"
 			},
 			"peerDependencies": {
@@ -4138,13 +4148,13 @@
 			}
 		},
 		"node_modules/@rushstack/ts-command-line": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.1.tgz",
-			"integrity": "sha512-bsbUucn41UXrQK7wgM8CNM/jagBytEyJqXw/umtI8d68vFm1Jwxh1OtLrlW7uGZgjCWiiPH6ooUNa1aVsuVr3Q==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.2.tgz",
+			"integrity": "sha512-+AkJDbu1GFMPIU8Sb7TLVXDv/Q7Mkvx+wAjEl8XiXVVq+p1FmWW6M3LYpJMmoHNckSofeMecgWg5lfMwNAAsEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rushstack/terminal": "0.15.3",
+				"@rushstack/terminal": "0.15.4",
 				"@types/argparse": "1.0.38",
 				"argparse": "~1.0.9",
 				"string-argv": "~0.3.1"
@@ -4167,9 +4177,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
-			"integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+			"integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -4281,9 +4291,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/sizzle": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
-			"integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
+			"version": "2.3.10",
+			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
+			"integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
 			"license": "MIT"
 		},
 		"node_modules/@types/toastify-js": {
@@ -4547,9 +4557,9 @@
 			"license": "ISC"
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.9.2.tgz",
-			"integrity": "sha512-tS+lqTU3N0kkthU+rYp0spAYq15DU8ld9kXkaKg9sbQqJNF+WPMuNHZQGCgdxrUOEO0j22RKMwRVhF1HTl+X8A==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
 			"cpu": [
 				"arm"
 			],
@@ -4562,9 +4572,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-android-arm64": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.9.2.tgz",
-			"integrity": "sha512-MffGiZULa/KmkNjHeuuflLVqfhqLv1vZLm8lWIyeADvlElJ/GLSOkoUX+5jf4/EGtfwrNFcEaB8BRas03KT0/Q==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
 			"cpu": [
 				"arm64"
 			],
@@ -4577,9 +4587,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-darwin-arm64": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.9.2.tgz",
-			"integrity": "sha512-dzJYK5rohS1sYl1DHdJ3mwfwClJj5BClQnQSyAgEfggbUwA9RlROQSSbKBLqrGfsiC/VyrDPtbO8hh56fnkbsQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
 			"cpu": [
 				"arm64"
 			],
@@ -4592,9 +4602,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-darwin-x64": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.9.2.tgz",
-			"integrity": "sha512-gaIMWK+CWtXcg9gUyznkdV54LzQ90S3X3dn8zlh+QR5Xy7Y+Efqw4Rs4im61K1juy4YNb67vmJsCDAGOnIeffQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
 			"cpu": [
 				"x64"
 			],
@@ -4607,9 +4617,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-freebsd-x64": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.9.2.tgz",
-			"integrity": "sha512-S7QpkMbVoVJb0xwHFwujnwCAEDe/596xqY603rpi/ioTn9VDgBHnCCxh+UFrr5yxuMH+dliHfjwCZJXOPJGPnw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
 			"cpu": [
 				"x64"
 			],
@@ -4622,9 +4632,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.9.2.tgz",
-			"integrity": "sha512-+XPUMCuCCI80I46nCDFbGum0ZODP5NWGiwS3Pj8fOgsG5/ctz+/zzuBlq/WmGa+EjWZdue6CF0aWWNv84sE1uw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
 			"cpu": [
 				"arm"
 			],
@@ -4637,9 +4647,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.9.2.tgz",
-			"integrity": "sha512-sqvUyAd1JUpwbz33Ce2tuTLJKM+ucSsYpPGl2vuFwZnEIg0CmdxiZ01MHQ3j6ExuRqEDUCy8yvkDKvjYFPb8Zg==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
 			"cpu": [
 				"arm"
 			],
@@ -4652,9 +4662,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.9.2.tgz",
-			"integrity": "sha512-UYA0MA8ajkEDCFRQdng/FVx3F6szBvk3EPnkTTQuuO9lV1kPGuTB+V9TmbDxy5ikaEgyWKxa4CI3ySjklZ9lFA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4667,9 +4677,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.9.2.tgz",
-			"integrity": "sha512-P/CO3ODU9YJIHFqAkHbquKtFst0COxdphc8TKGL5yCX75GOiVpGqd1d15ahpqu8xXVsqP4MGFP2C3LRZnnL5MA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
 			"cpu": [
 				"arm64"
 			],
@@ -4682,9 +4692,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.9.2.tgz",
-			"integrity": "sha512-uKStFlOELBxBum2s1hODPtgJhY4NxYJE9pAeyBgNEzHgTqTiVBPjfTlPFJkfxyTjQEuxZbbJlJnMCrRgD7ubzw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -4697,9 +4707,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.9.2.tgz",
-			"integrity": "sha512-LkbNnZlhINfY9gK30AHs26IIVEZ9PEl9qOScYdmY2o81imJYI4IMnJiW0vJVtXaDHvBvxeAgEy5CflwJFIl3tQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -4712,9 +4722,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.9.2.tgz",
-			"integrity": "sha512-vI+e6FzLyZHSLFNomPi+nT+qUWN4YSj8pFtQZSFTtmgFoxqB6NyjxSjAxEC1m93qn6hUXhIsh8WMp+fGgxCoRg==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
 			"cpu": [
 				"riscv64"
 			],
@@ -4727,9 +4737,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.9.2.tgz",
-			"integrity": "sha512-sSO4AlAYhSM2RAzBsRpahcJB1msc6uYLAtP6pesPbZtptF8OU/CbCPhSRW6cnYOGuVmEmWVW5xVboAqCnWTeHQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
 			"cpu": [
 				"s390x"
 			],
@@ -4742,9 +4752,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.9.2.tgz",
-			"integrity": "sha512-jkSkwch0uPFva20Mdu8orbQjv2A3G88NExTN2oPTI1AJ+7mZfYW3cDCTyoH6OnctBKbBVeJCEqh0U02lTkqD5w==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
 			"cpu": [
 				"x64"
 			],
@@ -4757,9 +4767,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.9.2.tgz",
-			"integrity": "sha512-Uk64NoiTpQbkpl+bXsbeyOPRpUoMdcUqa+hDC1KhMW7aN1lfW8PBlBH4mJ3n3Y47dYE8qi0XTxy1mBACruYBaw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
 			"cpu": [
 				"x64"
 			],
@@ -4772,9 +4782,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.9.2.tgz",
-			"integrity": "sha512-EpBGwkcjDicjR/ybC0g8wO5adPNdVuMrNalVgYcWi+gYtC1XYNuxe3rufcO7dA76OHGeVabcO6cSkPJKVcbCXQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
 			"cpu": [
 				"wasm32"
 			],
@@ -4790,9 +4800,9 @@
 			}
 		},
 		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.9.2.tgz",
-			"integrity": "sha512-EdFbGn7o1SxGmN6aZw9wAkehZJetFPao0VGZ9OMBwKx6TkvDuj6cNeLimF/Psi6ts9lMOe+Dt6z19fZQ9Ye2fw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4805,9 +4815,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.9.2.tgz",
-			"integrity": "sha512-JY9hi1p7AG+5c/dMU8o2kWemM8I6VZxfGwn1GCtf3c5i+IKcMo2NQ8OjZ4Z3/itvY/Si3K10jOBQn7qsD/whUA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -4820,9 +4830,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.9.2.tgz",
-			"integrity": "sha512-ryoo+EB19lMxAd80ln9BVf8pdOAxLb97amrQ3SFN9OCRn/5M5wvwDgAe4i8ZjhpbiHoDeP8yavcTEnpKBo7lZg==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
 			"cpu": [
 				"x64"
 			],
@@ -4835,96 +4845,99 @@
 			"peer": true
 		},
 		"node_modules/@vitejs/plugin-vue": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
-			"integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.1.tgz",
+			"integrity": "sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"@rolldown/pluginutils": "1.0.0-beta.29"
+			},
 			"engines": {
-				"node": "^18.0.0 || >=20.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"peerDependencies": {
-				"vite": "^5.0.0 || ^6.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
 				"vue": "^3.2.25"
 			}
 		},
 		"node_modules/@volar/language-core": {
-			"version": "2.4.15",
-			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
-			"integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+			"version": "2.4.23",
+			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.23.tgz",
+			"integrity": "sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/source-map": "2.4.15"
+				"@volar/source-map": "2.4.23"
 			}
 		},
 		"node_modules/@volar/source-map": {
-			"version": "2.4.15",
-			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
-			"integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+			"version": "2.4.23",
+			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.23.tgz",
+			"integrity": "sha512-Z1Uc8IB57Lm6k7q6KIDu/p+JWtf3xsXJqAX/5r18hYOTpJyBn0KXUR8oTJ4WFYOcDzWC9n3IflGgHowx6U6z9Q==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@volar/typescript": {
-			"version": "2.4.15",
-			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
-			"integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
+			"version": "2.4.23",
+			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.23.tgz",
+			"integrity": "sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/language-core": "2.4.15",
+				"@volar/language-core": "2.4.23",
 				"path-browserify": "^1.0.1",
 				"vscode-uri": "^3.0.8"
 			}
 		},
 		"node_modules/@vue/compiler-core": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
-			"integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.21.tgz",
+			"integrity": "sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.27.5",
-				"@vue/shared": "3.5.17",
+				"@babel/parser": "^7.28.3",
+				"@vue/shared": "3.5.21",
 				"entities": "^4.5.0",
 				"estree-walker": "^2.0.2",
 				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/@vue/compiler-dom": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
-			"integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.21.tgz",
+			"integrity": "sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-core": "3.5.17",
-				"@vue/shared": "3.5.17"
+				"@vue/compiler-core": "3.5.21",
+				"@vue/shared": "3.5.21"
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
-			"integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.21.tgz",
+			"integrity": "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.27.5",
-				"@vue/compiler-core": "3.5.17",
-				"@vue/compiler-dom": "3.5.17",
-				"@vue/compiler-ssr": "3.5.17",
-				"@vue/shared": "3.5.17",
+				"@babel/parser": "^7.28.3",
+				"@vue/compiler-core": "3.5.21",
+				"@vue/compiler-dom": "3.5.21",
+				"@vue/compiler-ssr": "3.5.21",
+				"@vue/shared": "3.5.21",
 				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.17",
+				"magic-string": "^0.30.18",
 				"postcss": "^8.5.6",
 				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
-			"integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
+			"integrity": "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.5.17",
-				"@vue/shared": "3.5.17"
+				"@vue/compiler-dom": "3.5.21",
+				"@vue/shared": "3.5.21"
 			}
 		},
 		"node_modules/@vue/compiler-vue2": {
@@ -4996,53 +5009,53 @@
 			}
 		},
 		"node_modules/@vue/reactivity": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.17.tgz",
-			"integrity": "sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.21.tgz",
+			"integrity": "sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/shared": "3.5.17"
+				"@vue/shared": "3.5.21"
 			}
 		},
 		"node_modules/@vue/runtime-core": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.17.tgz",
-			"integrity": "sha512-QQLXa20dHg1R0ri4bjKeGFKEkJA7MMBxrKo2G+gJikmumRS7PTD4BOU9FKrDQWMKowz7frJJGqBffYMgQYS96Q==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.21.tgz",
+			"integrity": "sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.5.17",
-				"@vue/shared": "3.5.17"
+				"@vue/reactivity": "3.5.21",
+				"@vue/shared": "3.5.21"
 			}
 		},
 		"node_modules/@vue/runtime-dom": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.17.tgz",
-			"integrity": "sha512-8El0M60TcwZ1QMz4/os2MdlQECgGoVHPuLnQBU3m9h3gdNRW9xRmI8iLS4t/22OQlOE6aJvNNlBiCzPHur4H9g==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.21.tgz",
+			"integrity": "sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.5.17",
-				"@vue/runtime-core": "3.5.17",
-				"@vue/shared": "3.5.17",
+				"@vue/reactivity": "3.5.21",
+				"@vue/runtime-core": "3.5.21",
+				"@vue/shared": "3.5.21",
 				"csstype": "^3.1.3"
 			}
 		},
 		"node_modules/@vue/server-renderer": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.17.tgz",
-			"integrity": "sha512-BOHhm8HalujY6lmC3DbqF6uXN/K00uWiEeF22LfEsm9Q93XeJ/plHTepGwf6tqFcF7GA5oGSSAAUock3VvzaCA==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.21.tgz",
+			"integrity": "sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-ssr": "3.5.17",
-				"@vue/shared": "3.5.17"
+				"@vue/compiler-ssr": "3.5.21",
+				"@vue/shared": "3.5.21"
 			},
 			"peerDependencies": {
-				"vue": "3.5.17"
+				"vue": "3.5.21"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
-			"integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
+			"integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==",
 			"license": "MIT"
 		},
 		"node_modules/@vuepic/vue-datepicker": {
@@ -5061,27 +5074,27 @@
 			}
 		},
 		"node_modules/@vueuse/components": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/components/-/components-13.4.0.tgz",
-			"integrity": "sha512-tWw1BZgKp+9kD+qiCy2uA2N7v27WUUUFHKX3lcFaefGIt/7J1CKczYO/rbZNRobRr7OidoOZuG2NZ2Ym5R2uRw==",
+			"version": "13.9.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/components/-/components-13.9.0.tgz",
+			"integrity": "sha512-0DDFpjG3hEEK+3YgSzE/OzOGqpo/KmxcXWzW2YdmgahZvaoUdegn68GmbdcHRJE7CH55dDj13Cz47iN8QoI3jQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@vueuse/core": "13.4.0",
-				"@vueuse/shared": "13.4.0"
+				"@vueuse/core": "13.9.0",
+				"@vueuse/shared": "13.9.0"
 			},
 			"peerDependencies": {
 				"vue": "^3.5.0"
 			}
 		},
 		"node_modules/@vueuse/core": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.4.0.tgz",
-			"integrity": "sha512-OnK7zW3bTq/QclEk17+vDFN3tuAm8ONb9zQUIHrYQkkFesu3WeGUx/3YzpEp+ly53IfDAT9rsYXgGW6piNZC5w==",
+			"version": "13.9.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.9.0.tgz",
+			"integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/web-bluetooth": "^0.0.21",
-				"@vueuse/metadata": "13.4.0",
-				"@vueuse/shared": "13.4.0"
+				"@vueuse/metadata": "13.9.0",
+				"@vueuse/shared": "13.9.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -5091,18 +5104,18 @@
 			}
 		},
 		"node_modules/@vueuse/metadata": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.4.0.tgz",
-			"integrity": "sha512-CPDQ/IgOeWbqItg1c/pS+Ulum63MNbpJ4eecjFJqgD/JUCJ822zLfpw6M9HzSvL6wbzMieOtIAW/H8deQASKHg==",
+			"version": "13.9.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.9.0.tgz",
+			"integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@vueuse/shared": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.4.0.tgz",
-			"integrity": "sha512-+AxuKbw8R1gYy5T21V5yhadeNM7rJqb4cPaRI9DdGnnNl3uqXh+unvQ3uCaA2DjYLbNr1+l7ht/B4qEsRegX6A==",
+			"version": "13.9.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.9.0.tgz",
+			"integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -5402,7 +5415,6 @@
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.0.0",
@@ -5414,14 +5426,12 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/assert": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
 			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.2",
@@ -5460,12 +5470,12 @@
 			"license": "MIT"
 		},
 		"node_modules/automation-events": {
-			"version": "7.1.11",
-			"resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.11.tgz",
-			"integrity": "sha512-TnclbJ0482ydRenzrR9FIbqalHScBBdQTIXv8tVunhYx8dq7E0Eq5v5CSAo67YmLXNbx5jCstHcLZDJ33iONDw==",
+			"version": "7.1.12",
+			"resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.12.tgz",
+			"integrity": "sha512-JDdPQoV58WPm15/L3ABtIEiqyxLoW+yTYIEqYtrKZ7VizLSRXhMKRZbQ8CYc2mFq/lMRKUvqOj0OcT3zANFiXA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
+				"@babel/runtime": "^7.28.3",
 				"tslib": "^2.8.1"
 			},
 			"engines": {
@@ -5476,7 +5486,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
 			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"possible-typed-array-names": "^1.0.0"
@@ -5489,26 +5498,26 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-			"integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+			"integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
+				"form-data": "^4.0.4",
 				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
-			"integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+			"integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.6.4",
+				"@babel/compat-data": "^7.27.7",
+				"@babel/helper-define-polyfill-provider": "^0.6.5",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -5516,29 +5525,29 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
-			"integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+			"integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.3",
-				"core-js-compat": "^3.40.0"
+				"@babel/helper-define-polyfill-provider": "^0.6.5",
+				"core-js-compat": "^3.43.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
-			"integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+			"integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.4"
+				"@babel/helper-define-polyfill-provider": "^0.6.5"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -5570,7 +5579,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5597,7 +5605,6 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
 			"integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/boolbase": {
@@ -5621,7 +5628,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -5632,29 +5639,27 @@
 			}
 		},
 		"node_modules/broker-factory": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.7.tgz",
-			"integrity": "sha512-RxbMXWq/Qvw9aLZMvuooMtVTm2/SV9JEpxpBbMuFhYAnDaZxctbJ+1b9ucHxADk/eQNqDijvWQjLVARqExAeyg==",
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.9.tgz",
+			"integrity": "sha512-MzvndyD6EcbkBtX4NXm/HfdO1+cOR5ONNdMCXEKfHpxGdMtuDz7+o+nJf7HMtyPH1sUVf/lEIP+DMluC5PgaBQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
-				"fast-unique-numbers": "^9.0.22",
+				"@babel/runtime": "^7.28.3",
+				"fast-unique-numbers": "^9.0.23",
 				"tslib": "^2.8.1",
-				"worker-factory": "^7.0.43"
+				"worker-factory": "^7.0.45"
 			}
 		},
 		"node_modules/brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/browser-resolve": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
 			"integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"resolve": "^1.17.0"
@@ -5664,7 +5669,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-xor": "^1.0.3",
@@ -5679,7 +5683,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserify-aes": "^1.0.4",
@@ -5691,7 +5694,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
 			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.1",
@@ -5704,7 +5706,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
 			"integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^5.2.1",
@@ -5719,7 +5720,6 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
 			"integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"bn.js": "^5.2.1",
@@ -5741,14 +5741,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/browserify-sign/node_modules/readable-stream": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
 			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"core-util-is": "~1.0.0",
@@ -5764,14 +5762,12 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/browserify-sign/node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
@@ -5781,23 +5777,21 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/browserify-zlib": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pako": "~1.0.5"
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.25.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-			"integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+			"version": "4.25.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
+			"integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
 			"dev": true,
 			"funding": [
 				{
@@ -5815,8 +5809,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001726",
-				"electron-to-chromium": "^1.5.173",
+				"caniuse-lite": "^1.0.30001737",
+				"electron-to-chromium": "^1.5.211",
 				"node-releases": "^2.0.19",
 				"update-browserslist-db": "^1.1.3"
 			},
@@ -5850,7 +5844,6 @@
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
 			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5875,7 +5868,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
 			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/builtin-modules": {
@@ -5896,7 +5888,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 			"integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/builtins": {
@@ -5931,33 +5922,32 @@
 			"license": "MIT"
 		},
 		"node_modules/cacheable": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.0.tgz",
-			"integrity": "sha512-SSgQTAnhd7WlJXnGlIi4jJJOiHzgnM5wRMEPaXAU4kECTAMpBoYKoZ9i5zHmclIEZbxcu3j7yY/CF8DTmwIsHg==",
+			"version": "1.10.4",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.4.tgz",
+			"integrity": "sha512-Gd7ccIUkZ9TE2odLQVS+PDjIvQCdJKUlLdJRVvZu0aipj07Qfx+XIej7hhDrKGGoIxV5m5fT/kOJNJPQhQneRg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"hookified": "^1.8.2",
-				"keyv": "^5.3.3"
+				"hookified": "^1.11.0",
+				"keyv": "^5.5.0"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.4.tgz",
-			"integrity": "sha512-ypEvQvInNpUe+u+w8BIcPkQvEqXquyyibWE/1NB5T2BTzIpS5cGEV1LZskDzPSTvNAaT4+5FutvzlvnkxOSKlw==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.0.tgz",
+			"integrity": "sha512-QG7qR2tijh1ftOvClut4YKKg1iW6cx3GZsKoGyJPxHkGWK9oJhG9P3j5deP0QQOGDowBMVQFaP+Vm4NpGYvmIQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@keyv/serialize": "^1.0.3"
+				"@keyv/serialize": "^1.1.0"
 			}
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
 			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.0",
@@ -5989,7 +5979,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -6020,9 +6009,9 @@
 			"license": "MIT"
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001726",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
-			"integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
+			"version": "1.0.30001739",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
+			"integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==",
 			"dev": true,
 			"funding": [
 				{
@@ -6121,7 +6110,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
 			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -6138,7 +6127,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
 			"integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.4",
@@ -6239,7 +6227,8 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/confbox": {
 			"version": "0.2.2",
@@ -6251,14 +6240,12 @@
 		"node_modules/console-browserify": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
-			"dev": true
+			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
 		},
 		"node_modules/constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
 			"integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/convert-source-map": {
@@ -6281,13 +6268,13 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.43.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
-			"integrity": "sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==",
+			"version": "3.45.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.1.tgz",
+			"integrity": "sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.25.0"
+				"browserslist": "^4.25.3"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -6298,7 +6285,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cosmiconfig": {
@@ -6333,7 +6319,6 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
 			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.1.0",
@@ -6344,14 +6329,12 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/create-hash": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.1",
@@ -6365,7 +6348,6 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.3",
@@ -6380,7 +6362,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
@@ -6412,7 +6393,6 @@
 			"version": "3.12.1",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
 			"integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserify-cipher": "^1.0.1",
@@ -6618,7 +6598,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0",
@@ -6636,7 +6615,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
 			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.0.1",
@@ -6672,7 +6650,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
 			"integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.1",
@@ -6683,7 +6660,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"peer": true,
@@ -6711,7 +6687,6 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.1.0",
@@ -6723,7 +6698,6 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/dir-glob": {
@@ -6774,7 +6748,6 @@
 			"version": "4.22.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
 			"integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -6854,9 +6827,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.176",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.176.tgz",
-			"integrity": "sha512-2nDK9orkm7M9ZZkjO3PjbEd3VUulQLyg5T9O3enJdFvUg46Hzd4DUvTvAuEgbdHYXyFsiG4A5sO9IzToMH1cDg==",
+			"version": "1.5.212",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.212.tgz",
+			"integrity": "sha512-gE7ErIzSW+d8jALWMcOIgf+IB6lpfsg6NwOhPVwKzDtN2qcBix47vlin4yzSregYDxTCXOUqAZjVY/Z3naS7ww==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -6864,7 +6837,6 @@
 			"version": "6.6.1",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
 			"integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.11.9",
@@ -6880,13 +6852,12 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/emoji-mart-vue-fast": {
-			"version": "15.0.4",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.4.tgz",
-			"integrity": "sha512-OjuxqoMJRTTG7Vevz0mR1ZnqY1DI8gGnmoskuuC8qL8VwwTjrGdwAO4WRWtAUN8P6Di7kxvY6cUgNETNFmbP4A==",
+			"version": "15.0.5",
+			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.5.tgz",
+			"integrity": "sha512-wnxLor8ggpqshoOPwIc33MdOC3A1XFeDLgUwYLPtNPL8VeAtXJAVrnFq1CN5PeCYAFoLo4IufHQZ9CfHD4IZiw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@babel/runtime": "^7.18.6",
@@ -7087,10 +7058,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-			"integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
-			"dev": true,
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
+			"integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -7100,31 +7070,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.5",
-				"@esbuild/android-arm": "0.25.5",
-				"@esbuild/android-arm64": "0.25.5",
-				"@esbuild/android-x64": "0.25.5",
-				"@esbuild/darwin-arm64": "0.25.5",
-				"@esbuild/darwin-x64": "0.25.5",
-				"@esbuild/freebsd-arm64": "0.25.5",
-				"@esbuild/freebsd-x64": "0.25.5",
-				"@esbuild/linux-arm": "0.25.5",
-				"@esbuild/linux-arm64": "0.25.5",
-				"@esbuild/linux-ia32": "0.25.5",
-				"@esbuild/linux-loong64": "0.25.5",
-				"@esbuild/linux-mips64el": "0.25.5",
-				"@esbuild/linux-ppc64": "0.25.5",
-				"@esbuild/linux-riscv64": "0.25.5",
-				"@esbuild/linux-s390x": "0.25.5",
-				"@esbuild/linux-x64": "0.25.5",
-				"@esbuild/netbsd-arm64": "0.25.5",
-				"@esbuild/netbsd-x64": "0.25.5",
-				"@esbuild/openbsd-arm64": "0.25.5",
-				"@esbuild/openbsd-x64": "0.25.5",
-				"@esbuild/sunos-x64": "0.25.5",
-				"@esbuild/win32-arm64": "0.25.5",
-				"@esbuild/win32-ia32": "0.25.5",
-				"@esbuild/win32-x64": "0.25.5"
+				"@esbuild/aix-ppc64": "0.25.9",
+				"@esbuild/android-arm": "0.25.9",
+				"@esbuild/android-arm64": "0.25.9",
+				"@esbuild/android-x64": "0.25.9",
+				"@esbuild/darwin-arm64": "0.25.9",
+				"@esbuild/darwin-x64": "0.25.9",
+				"@esbuild/freebsd-arm64": "0.25.9",
+				"@esbuild/freebsd-x64": "0.25.9",
+				"@esbuild/linux-arm": "0.25.9",
+				"@esbuild/linux-arm64": "0.25.9",
+				"@esbuild/linux-ia32": "0.25.9",
+				"@esbuild/linux-loong64": "0.25.9",
+				"@esbuild/linux-mips64el": "0.25.9",
+				"@esbuild/linux-ppc64": "0.25.9",
+				"@esbuild/linux-riscv64": "0.25.9",
+				"@esbuild/linux-s390x": "0.25.9",
+				"@esbuild/linux-x64": "0.25.9",
+				"@esbuild/netbsd-arm64": "0.25.9",
+				"@esbuild/netbsd-x64": "0.25.9",
+				"@esbuild/openbsd-arm64": "0.25.9",
+				"@esbuild/openbsd-x64": "0.25.9",
+				"@esbuild/openharmony-arm64": "0.25.9",
+				"@esbuild/sunos-x64": "0.25.9",
+				"@esbuild/win32-arm64": "0.25.9",
+				"@esbuild/win32-ia32": "0.25.9",
+				"@esbuild/win32-x64": "0.25.9"
 			}
 		},
 		"node_modules/escalade": {
@@ -7572,23 +7543,6 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"node_modules/eslint-plugin-n/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/eslint-plugin-n/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -7656,23 +7610,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-vue/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint-plugin-vue/node_modules/semver": {
@@ -7768,23 +7705,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"node_modules/eslint/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint/node_modules/minimatch": {
@@ -7943,7 +7863,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.x"
@@ -7953,7 +7872,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"md5.js": "^1.3.4",
@@ -7974,53 +7892,53 @@
 			"license": "MIT"
 		},
 		"node_modules/extendable-media-recorder": {
-			"version": "9.2.27",
-			"resolved": "https://registry.npmjs.org/extendable-media-recorder/-/extendable-media-recorder-9.2.27.tgz",
-			"integrity": "sha512-2X+Ixi1cxLek0Cj9x9atmhQ+apG+LwJpP2p3ypP8Pxau0poDnicrg7FTfPVQV5PW/3DHFm/eQ16vbgo5Yk3HGQ==",
+			"version": "9.2.29",
+			"resolved": "https://registry.npmjs.org/extendable-media-recorder/-/extendable-media-recorder-9.2.29.tgz",
+			"integrity": "sha512-0JHseYEzbib8MV1paUmfaQ+5Yf3UgfCXsXUx7s4X+epOCtag3WoBUB8Sglbcs3vSOnnuyV013dL5GcfC/jKEkg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
-				"media-encoder-host": "^9.0.20",
-				"multi-buffer-data-view": "^6.0.22",
-				"recorder-audio-worklet": "^6.0.48",
+				"@babel/runtime": "^7.28.3",
+				"media-encoder-host": "^9.0.22",
+				"multi-buffer-data-view": "^6.0.23",
+				"recorder-audio-worklet": "^6.0.50",
 				"standardized-audio-context": "^25.3.77",
-				"subscribable-things": "^2.1.53",
+				"subscribable-things": "^2.1.54",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/extendable-media-recorder-wav-encoder": {
-			"version": "7.0.129",
-			"resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder/-/extendable-media-recorder-wav-encoder-7.0.129.tgz",
-			"integrity": "sha512-/wqM2hnzvLy/iUlg/EU3JIF8MJcidy8I77Z7CCm5+CVEClDfcs6bH9PgghuisndwKTaud0Dh48RTD83gkfEjCw==",
+			"version": "7.0.131",
+			"resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder/-/extendable-media-recorder-wav-encoder-7.0.131.tgz",
+			"integrity": "sha512-fupOYvXrbIQhZt714VlLhARkVqjRgMofcaaxJVNG8WtpmresW4dmIEWGEDVNrSkf/8TQlNt2qV/oFlzGeFKioQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
-				"extendable-media-recorder-wav-encoder-broker": "^7.0.119",
-				"extendable-media-recorder-wav-encoder-worker": "^8.0.116",
+				"@babel/runtime": "^7.28.3",
+				"extendable-media-recorder-wav-encoder-broker": "^7.0.121",
+				"extendable-media-recorder-wav-encoder-worker": "^8.0.118",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/extendable-media-recorder-wav-encoder-broker": {
-			"version": "7.0.119",
-			"resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder-broker/-/extendable-media-recorder-wav-encoder-broker-7.0.119.tgz",
-			"integrity": "sha512-BLrFOnqFLpsmmNpSk/TfjNs4j6ImCSGtoryIpRlqNu5S/Avt6gRJI0s4UYvdK7h17PCi+8vaDr75blvmU1sYlw==",
+			"version": "7.0.121",
+			"resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder-broker/-/extendable-media-recorder-wav-encoder-broker-7.0.121.tgz",
+			"integrity": "sha512-pRRKLXKhkveeU9DiSqF/fA9dDBnMuf3Uq1jz8cpAvik8IclVqY1Wju6n74KEYrvitPJr8W+5st76G7AyI3EA9A==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
-				"broker-factory": "^3.1.7",
-				"extendable-media-recorder-wav-encoder-worker": "^8.0.116",
+				"@babel/runtime": "^7.28.3",
+				"broker-factory": "^3.1.9",
+				"extendable-media-recorder-wav-encoder-worker": "^8.0.118",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/extendable-media-recorder-wav-encoder-worker": {
-			"version": "8.0.116",
-			"resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder-worker/-/extendable-media-recorder-wav-encoder-worker-8.0.116.tgz",
-			"integrity": "sha512-bJPR0B7ZHeoqi9YoSie+UXAfEYya3efQ9eLiWuyK4KcOv+SuYQvWCoyzX5kjvb6GqIBCUnev5xulfeHRlyCwvw==",
+			"version": "8.0.118",
+			"resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder-worker/-/extendable-media-recorder-wav-encoder-worker-8.0.118.tgz",
+			"integrity": "sha512-yCZcXI2k3OorlB7ShyLsr0SgZ436doqjfAh9RlJhdwGK/LnCDvdLG4jktqSp8KY0gYFvB59o7tI3tY69SWDVWA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
+				"@babel/runtime": "^7.28.3",
 				"tslib": "^2.8.1",
-				"worker-factory": "^7.0.43"
+				"worker-factory": "^7.0.45"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -8079,12 +7997,12 @@
 			"peer": true
 		},
 		"node_modules/fast-unique-numbers": {
-			"version": "9.0.22",
-			"resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.22.tgz",
-			"integrity": "sha512-dBR+30yHAqBGvOuxxQdnn2lTLHCO6r/9B+M4yF8mNrzr3u1yiF+YVJ6u3GTyPN/VRWqaE1FcscZDdBgVKmrmQQ==",
+			"version": "9.0.23",
+			"resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.23.tgz",
+			"integrity": "sha512-jcRIaHo46nfvyvKRMaFSKXmez4jALQ3Qw49gxM5F4siz8HqkyKPPEexpCOYwBSJI1HovrDr4fEedM8QAJ7oX3w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
+				"@babel/runtime": "^7.28.3",
 				"tslib": "^2.8.1"
 			},
 			"engines": {
@@ -8092,9 +8010,9 @@
 			}
 		},
 		"node_modules/fast-uri": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-			"integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
 			"dev": true,
 			"funding": [
 				{
@@ -8149,11 +8067,13 @@
 			}
 		},
 		"node_modules/fdir": {
-			"version": "6.4.6",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-			"integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-			"dev": true,
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
 			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
 			"peerDependencies": {
 				"picomatch": "^3 || ^4"
 			},
@@ -8204,7 +8124,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -8218,7 +8138,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^6.0.0",
@@ -8293,9 +8212,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
 			"funding": [
 				{
 					"type": "individual",
@@ -8316,7 +8235,6 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
 			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-callable": "^1.2.7"
@@ -8329,9 +8247,9 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-			"integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
@@ -8357,9 +8275,9 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+			"version": "11.3.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+			"integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8383,7 +8301,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -8625,14 +8542,20 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/globalthis": {
@@ -8738,7 +8661,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0"
@@ -8795,7 +8717,6 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
 			"integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.4",
@@ -8809,7 +8730,6 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
 			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -8920,7 +8840,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hash.js": "^1.0.3",
@@ -8929,9 +8848,9 @@
 			}
 		},
 		"node_modules/hookified": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.9.1.tgz",
-			"integrity": "sha512-u3pxtGhKjcSXnGm1CX6aXS9xew535j3lkOCegbA6jdyh0BaAjTbXI4aslKstCr6zUNtoCxFGFKwjbSHdGrMB8g==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.0.tgz",
+			"integrity": "sha512-hMr1Y9TCLshScrBbV2QxJ9BROddxZ12MX9KsCtuGGy/3SmmN5H1PllKerrVlSotur9dlE8hmUKAOSa3WDzsZmQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -8981,20 +8900,18 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ical.js": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.1.0.tgz",
-			"integrity": "sha512-BOVfrH55xQ6kpS3muGvIXIg2l7p+eoe12/oS7R5yrO3TL/j/bLsR0PR+tYQESFbyTbvGgPHn9zQ6tI4FWyuSaQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
+			"integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
 			"license": "MPL-2.0"
 		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -9026,7 +8943,7 @@
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
 			"integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -9086,7 +9003,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ini": {
@@ -9159,7 +9075,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
 			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -9307,7 +9222,6 @@
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -9320,7 +9234,6 @@
 			"version": "2.16.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
 			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hasown": "^2.0.2"
@@ -9383,7 +9296,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -9422,7 +9335,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
 			"integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.3",
@@ -9441,7 +9353,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -9479,7 +9391,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
 			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.0",
@@ -9510,7 +9421,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -9573,7 +9484,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
 			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -9675,7 +9585,6 @@
 			"version": "1.1.15",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
 			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"which-typed-array": "^1.1.16"
@@ -9740,7 +9649,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
 			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/isexe": {
@@ -9755,7 +9663,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
 			"integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -9862,9 +9769,9 @@
 			}
 		},
 		"node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9941,21 +9848,21 @@
 			"peer": true
 		},
 		"node_modules/linkifyjs": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.1.tgz",
-			"integrity": "sha512-DRSlB9DKVW04c4SUdGvKK5FR6be45lTU9M76JnngqPeeGDqPwYc0zdUErtsNVMtxPXgUWV4HbXbnC4sNyBxkYg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+			"integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
 			"license": "MIT"
 		},
 		"node_modules/local-pkg": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
-			"integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
+			"integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mlly": "^1.7.4",
-				"pkg-types": "^2.0.1",
-				"quansync": "^0.2.8"
+				"pkg-types": "^2.3.0",
+				"quansync": "^0.2.11"
 			},
 			"engines": {
 				"node": ">=14"
@@ -9968,7 +9875,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^5.0.0"
@@ -10048,12 +9954,12 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.17",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+			"version": "0.30.18",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+			"integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0"
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/material-colors": {
@@ -10098,7 +10004,6 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
 			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hash-base": "^3.0.0",
@@ -10324,40 +10229,40 @@
 			"peer": true
 		},
 		"node_modules/media-encoder-host": {
-			"version": "9.0.20",
-			"resolved": "https://registry.npmjs.org/media-encoder-host/-/media-encoder-host-9.0.20.tgz",
-			"integrity": "sha512-IyEYxw6az97RNuETOAZV4YZqNAPOiF9GKIp5mVZb4HOyWd6mhkWQ34ydOzhqAWogMyc4W05kjN/VCgTtgyFmsw==",
+			"version": "9.0.22",
+			"resolved": "https://registry.npmjs.org/media-encoder-host/-/media-encoder-host-9.0.22.tgz",
+			"integrity": "sha512-bP04jb4SiZSSiyI/XvVImb45VVY9v2vf7gP8j37t+B7T5bc/Wcl97r/ktTr6uiCgFw6+u8YgLo2s1sjPqHCfdg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
-				"media-encoder-host-broker": "^8.0.19",
-				"media-encoder-host-worker": "^10.0.19",
+				"@babel/runtime": "^7.28.3",
+				"media-encoder-host-broker": "^8.0.21",
+				"media-encoder-host-worker": "^10.0.21",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/media-encoder-host-broker": {
-			"version": "8.0.19",
-			"resolved": "https://registry.npmjs.org/media-encoder-host-broker/-/media-encoder-host-broker-8.0.19.tgz",
-			"integrity": "sha512-lTpsNuaZdTCdtTHsOyww7Ae0Mwv+7mFS+O4YkFYWhXwVs0rm6XbRK5jRRn5JmcX3n1eTE1lQS5RgX8qbNaIjSg==",
+			"version": "8.0.21",
+			"resolved": "https://registry.npmjs.org/media-encoder-host-broker/-/media-encoder-host-broker-8.0.21.tgz",
+			"integrity": "sha512-6V4HuTclh7a1Fk3QAeUw3QTM1DOvk6zmPEppmNCDWgkGSWhy/GBu/eVeJc5TKC3BfWPYXx/C9Ufa+54akxtotQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
-				"broker-factory": "^3.1.7",
-				"fast-unique-numbers": "^9.0.22",
-				"media-encoder-host-worker": "^10.0.19",
+				"@babel/runtime": "^7.28.3",
+				"broker-factory": "^3.1.9",
+				"fast-unique-numbers": "^9.0.23",
+				"media-encoder-host-worker": "^10.0.21",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/media-encoder-host-worker": {
-			"version": "10.0.19",
-			"resolved": "https://registry.npmjs.org/media-encoder-host-worker/-/media-encoder-host-worker-10.0.19.tgz",
-			"integrity": "sha512-I8fwc6f41peER3RFSiwDxnIHbqU7p3pc2ghQozcw9CQfL0mWEo4IjQJtyswrrlL/HO2pgVSMQbaNzE4q/0mfDQ==",
+			"version": "10.0.21",
+			"resolved": "https://registry.npmjs.org/media-encoder-host-worker/-/media-encoder-host-worker-10.0.21.tgz",
+			"integrity": "sha512-uwuiY2oOXXrwKV7yq6rBX4Xhi+9ccm0nb3fxVftb+Liv61upuiVHvClSRAwZzkeYbQiZvx7+RrpSl4mbjNNXMA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
-				"extendable-media-recorder-wav-encoder-broker": "^7.0.119",
+				"@babel/runtime": "^7.28.3",
+				"extendable-media-recorder-wav-encoder-broker": "^7.0.121",
 				"tslib": "^2.8.1",
-				"worker-factory": "^7.0.43"
+				"worker-factory": "^7.0.45"
 			}
 		},
 		"node_modules/meow": {
@@ -10830,7 +10735,7 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -10845,7 +10750,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -10859,7 +10764,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.0.0",
@@ -10873,7 +10777,6 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mime-db": {
@@ -10901,14 +10804,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
 			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
 			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/minimatch": {
@@ -10938,16 +10839,16 @@
 			}
 		},
 		"node_modules/mlly": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-			"integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"acorn": "^8.14.0",
-				"pathe": "^2.0.1",
-				"pkg-types": "^1.3.0",
-				"ufo": "^1.5.4"
+				"acorn": "^8.15.0",
+				"pathe": "^2.0.3",
+				"pkg-types": "^1.3.1",
+				"ufo": "^1.6.1"
 			}
 		},
 		"node_modules/mlly/node_modules/confbox": {
@@ -10992,12 +10893,12 @@
 			"license": "MIT"
 		},
 		"node_modules/multi-buffer-data-view": {
-			"version": "6.0.22",
-			"resolved": "https://registry.npmjs.org/multi-buffer-data-view/-/multi-buffer-data-view-6.0.22.tgz",
-			"integrity": "sha512-SsI/exkodHsh+ofCV7An2PZWRaJC7eFVl7gtHQlMWFEDmWtb7cELr/GK32Nhe/6dZQhbr81o+Moswx9aXN3RRg==",
+			"version": "6.0.23",
+			"resolved": "https://registry.npmjs.org/multi-buffer-data-view/-/multi-buffer-data-view-6.0.23.tgz",
+			"integrity": "sha512-3Gzaez4KQw+5vcUpcfNr25V5+wxm6kxqO3AfFBEjsd9FV9yoXBeJHN45Dy1iSMD7MUBZPi1VErgce0jlKqHaUw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
+				"@babel/runtime": "^7.28.3",
 				"tslib": "^2.8.1"
 			},
 			"engines": {
@@ -11023,9 +10924,9 @@
 			}
 		},
 		"node_modules/napi-postinstall": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
-			"integrity": "sha512-ZEzHJwBhZ8qQSbknHqYcdtQVr8zUgGyM/q6h6qAyhtyVMNrSgDhrC4disf03dYW0e+czXyLnZINnCTEkWy0eJg==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
+			"integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -11057,7 +10958,6 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"peer": true
@@ -11111,7 +11011,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz",
 			"integrity": "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"assert": "^2.0.0",
@@ -11150,7 +11049,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/normalize-path": {
@@ -11182,7 +11080,6 @@
 			"version": "1.13.4",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
 			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -11195,7 +11092,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
 			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.7",
@@ -11212,7 +11108,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -11222,7 +11117,6 @@
 			"version": "4.1.7",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
 			"integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.8",
@@ -11329,7 +11223,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
 			"integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/own-keys": {
@@ -11355,7 +11248,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
@@ -11371,7 +11263,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^3.0.2"
@@ -11428,7 +11319,6 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
 			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true,
 			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/parent-module": {
@@ -11449,7 +11339,6 @@
 			"version": "5.1.7",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
 			"integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"asn1.js": "^4.10.1",
@@ -11512,14 +11401,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
 			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -11551,7 +11438,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/path-posix": {
@@ -11582,7 +11468,6 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
 			"integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"create-hash": "~1.1.3",
@@ -11600,7 +11485,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
 			"integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.1",
@@ -11613,7 +11497,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
 			"integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.1"
@@ -11623,7 +11506,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
 			"integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hash-base": "^2.0.0",
@@ -11637,10 +11519,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -11653,7 +11534,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
 			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"find-up": "^5.0.0"
@@ -11663,14 +11543,14 @@
 			}
 		},
 		"node_modules/pkg-types": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.1.0.tgz",
-			"integrity": "sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+			"integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"confbox": "^0.2.1",
-				"exsolve": "^1.0.1",
+				"confbox": "^0.2.2",
+				"exsolve": "^1.0.7",
 				"pathe": "^2.0.3"
 			}
 		},
@@ -11678,7 +11558,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
 			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -11837,7 +11716,6 @@
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
 			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6.0"
@@ -11847,7 +11725,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/property-information": {
@@ -11870,7 +11747,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
 			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.1.0",
@@ -11885,7 +11761,6 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/punycode": {
@@ -11902,7 +11777,6 @@
 			"version": "6.14.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
 			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -11915,9 +11789,9 @@
 			}
 		},
 		"node_modules/quansync": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
-			"integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+			"integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
 			"dev": true,
 			"funding": [
 				{
@@ -11935,7 +11809,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.4.x"
 			}
@@ -11972,7 +11845,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
@@ -11982,7 +11854,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"randombytes": "^2.0.5",
@@ -11993,7 +11864,6 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -12008,7 +11878,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
 			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -12020,28 +11890,28 @@
 			}
 		},
 		"node_modules/recorder-audio-worklet": {
-			"version": "6.0.48",
-			"resolved": "https://registry.npmjs.org/recorder-audio-worklet/-/recorder-audio-worklet-6.0.48.tgz",
-			"integrity": "sha512-PVlq/1hjCrPcUGqARg8rR30A303xDCao0jmlBTaUaKkN3Xme58RI7EQxurv8rw2eDwVrN+nrni0UoJoa5/v+zg==",
+			"version": "6.0.50",
+			"resolved": "https://registry.npmjs.org/recorder-audio-worklet/-/recorder-audio-worklet-6.0.50.tgz",
+			"integrity": "sha512-BI1H2Ewu3Rryz2b5hMlpSRH8ixuWHOdBXOxAOjZT6D4WkFpllKbphXEfPmFKZK+C6ytKcFG/QTjqNmznmqg3jQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
-				"broker-factory": "^3.1.7",
-				"fast-unique-numbers": "^9.0.22",
-				"recorder-audio-worklet-processor": "^5.0.35",
+				"@babel/runtime": "^7.28.3",
+				"broker-factory": "^3.1.9",
+				"fast-unique-numbers": "^9.0.23",
+				"recorder-audio-worklet-processor": "^5.0.36",
 				"standardized-audio-context": "^25.3.77",
-				"subscribable-things": "^2.1.53",
+				"subscribable-things": "^2.1.54",
 				"tslib": "^2.8.1",
-				"worker-factory": "^7.0.43"
+				"worker-factory": "^7.0.45"
 			}
 		},
 		"node_modules/recorder-audio-worklet-processor": {
-			"version": "5.0.35",
-			"resolved": "https://registry.npmjs.org/recorder-audio-worklet-processor/-/recorder-audio-worklet-processor-5.0.35.tgz",
-			"integrity": "sha512-5Nzbk/6QzC3QFQ1EG2SE34c1ygLE22lIOvLyjy7N6XxE/jpAZrL4e7xR+yihiTaG3ajiWy6UjqL4XEBMM9ahFQ==",
+			"version": "5.0.36",
+			"resolved": "https://registry.npmjs.org/recorder-audio-worklet-processor/-/recorder-audio-worklet-processor-5.0.36.tgz",
+			"integrity": "sha512-fT9QkiL3Q8rVJ6+T57KyUNYZZu5ea6Y/EgzKbzxizZdGr9JXPQYxbvwQ6hbxFZ5AJOmi7+BGuPyaJlpR8vicxA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
+				"@babel/runtime": "^7.28.3",
 				"tslib": "^2.8.1"
 			}
 		},
@@ -12308,7 +12178,6 @@
 			"version": "1.22.10",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
 			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-core-module": "^2.16.0",
@@ -12392,7 +12261,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hash-base": "^3.0.0",
@@ -12400,10 +12268,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
-			"integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
-			"dev": true,
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz",
+			"integrity": "sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -12417,26 +12284,27 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.44.1",
-				"@rollup/rollup-android-arm64": "4.44.1",
-				"@rollup/rollup-darwin-arm64": "4.44.1",
-				"@rollup/rollup-darwin-x64": "4.44.1",
-				"@rollup/rollup-freebsd-arm64": "4.44.1",
-				"@rollup/rollup-freebsd-x64": "4.44.1",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.44.1",
-				"@rollup/rollup-linux-arm-musleabihf": "4.44.1",
-				"@rollup/rollup-linux-arm64-gnu": "4.44.1",
-				"@rollup/rollup-linux-arm64-musl": "4.44.1",
-				"@rollup/rollup-linux-loongarch64-gnu": "4.44.1",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.44.1",
-				"@rollup/rollup-linux-riscv64-gnu": "4.44.1",
-				"@rollup/rollup-linux-riscv64-musl": "4.44.1",
-				"@rollup/rollup-linux-s390x-gnu": "4.44.1",
-				"@rollup/rollup-linux-x64-gnu": "4.44.1",
-				"@rollup/rollup-linux-x64-musl": "4.44.1",
-				"@rollup/rollup-win32-arm64-msvc": "4.44.1",
-				"@rollup/rollup-win32-ia32-msvc": "4.44.1",
-				"@rollup/rollup-win32-x64-msvc": "4.44.1",
+				"@rollup/rollup-android-arm-eabi": "4.50.0",
+				"@rollup/rollup-android-arm64": "4.50.0",
+				"@rollup/rollup-darwin-arm64": "4.50.0",
+				"@rollup/rollup-darwin-x64": "4.50.0",
+				"@rollup/rollup-freebsd-arm64": "4.50.0",
+				"@rollup/rollup-freebsd-x64": "4.50.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.50.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.50.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.50.0",
+				"@rollup/rollup-linux-arm64-musl": "4.50.0",
+				"@rollup/rollup-linux-loongarch64-gnu": "4.50.0",
+				"@rollup/rollup-linux-ppc64-gnu": "4.50.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.50.0",
+				"@rollup/rollup-linux-riscv64-musl": "4.50.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.50.0",
+				"@rollup/rollup-linux-x64-gnu": "4.50.0",
+				"@rollup/rollup-linux-x64-musl": "4.50.0",
+				"@rollup/rollup-openharmony-arm64": "4.50.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.50.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.50.0",
+				"@rollup/rollup-win32-x64-msvc": "4.50.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -12500,9 +12368,9 @@
 			}
 		},
 		"node_modules/rollup-plugin-node-externals": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-8.0.1.tgz",
-			"integrity": "sha512-j6uve/BPEyHCmQuXpu5/LT5qXw69QLIi6YnFrs6F7tmGFXjkFDT0zqZMt0KaMuWSvkcxJFBklsKfYYoKKEPwyw==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-8.1.0.tgz",
+			"integrity": "sha512-0D3S0E0Dl1V3Q6Cywnc7wt88VAfOB9AC5QHwVdgvP1vByRHW2wnEXoK0x3VYZzJ/EmGsR5Uix5HUmMJNG+hz2Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -12578,7 +12446,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -12617,7 +12484,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
 			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -12632,10 +12498,10 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.89.2",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
-			"integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
-			"dev": true,
+			"version": "1.91.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.91.0.tgz",
+			"integrity": "sha512-aFOZHGf+ur+bp1bCHZ+u8otKGh77ZtmFyXDo4tlYvT7PWql41Kwd8wdkPqhhT+h2879IVblcHFglIMofsFd1EA==",
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -12674,7 +12540,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.1.4",
@@ -12725,21 +12590,26 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+			"integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
 			"license": "(MIT AND BSD-3-Clause)",
 			"dependencies": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "^2.0.4",
+				"safe-buffer": "^5.2.1",
+				"to-buffer": "^1.2.0"
 			},
 			"bin": {
 				"sha.js": "bin.js"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -12771,7 +12641,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
 			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -12791,7 +12660,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
 			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -12808,7 +12676,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
 			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -12827,7 +12694,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
 			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -12979,9 +12845,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.21",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-			"integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+			"version": "3.0.22",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -13072,7 +12938,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
 			"integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "~2.0.4",
@@ -13083,7 +12948,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
 			"integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"builtin-status-codes": "^3.0.0",
@@ -13096,7 +12960,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
@@ -13261,9 +13124,9 @@
 			"license": "MIT"
 		},
 		"node_modules/strtok3": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.1.tgz",
-			"integrity": "sha512-3JWEZM6mfix/GCJBBUrkA8p2Id2pBkyTkVCJKto55w080QBKZ+8R171fGrbiSp+yMO/u6F8/yUh7K4V9K+YCnw==",
+			"version": "10.3.4",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
 			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0"
@@ -13295,9 +13158,9 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "16.21.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.21.0.tgz",
-			"integrity": "sha512-ki3PpJGG7xhm3WtINoWGnlvqAmbqSexoRMbEMJzlwewSIOqPRKPlq452c22xAdEJISVi80r+I7KL9GPUiwFgbg==",
+			"version": "16.23.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.1.tgz",
+			"integrity": "sha512-dNvDTsKV1U2YtiUDfe9d2gp902veFeo3ecCWdGlmLm2WFrAV0+L5LoOj/qHSBABQwMsZPJwfC4bf39mQm1S5zw==",
 			"dev": true,
 			"funding": [
 				{
@@ -13325,7 +13188,7 @@
 				"debug": "^4.4.1",
 				"fast-glob": "^3.3.3",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^10.1.1",
+				"file-entry-cache": "^10.1.3",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
@@ -13339,7 +13202,7 @@
 				"micromatch": "^4.0.8",
 				"normalize-path": "^3.0.0",
 				"picocolors": "^1.1.1",
-				"postcss": "^8.5.5",
+				"postcss": "^8.5.6",
 				"postcss-resolve-nested-selector": "^0.1.6",
 				"postcss-safe-parser": "^7.0.1",
 				"postcss-selector-parser": "^7.1.0",
@@ -13495,9 +13358,9 @@
 			"peer": true
 		},
 		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.22.0",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.22.0.tgz",
-			"integrity": "sha512-IwcXqjPl4kgZbQH1WLb97/Pjt7XwPDSHnXsjENPhwx68bBf/Dw1/PwM8paXnFq974V1d8qP4o9ViVQqZuPAlCw==",
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.24.0.tgz",
+			"integrity": "sha512-i97fklrJl03tL1tdRVw0ZfLLvuDsdb6wxL+TrJ+PKkCbLrp2PCu2+OYdCKychIUm19nSM/35S6qz7pJpnXttoA==",
 			"dev": true,
 			"license": "CC0-1.0",
 			"peer": true
@@ -13563,27 +13426,27 @@
 			"peer": true
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.1.tgz",
-			"integrity": "sha512-zcmsHjg2B2zjuBgjdnB+9q0+cWcgWfykIcsDkWDB4GTPtl1eXUA+gTI6sO0u01AqK3cliHryTU55/b2Ow1hfZg==",
+			"version": "10.1.4",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
+			"integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"flat-cache": "^6.1.10"
+				"flat-cache": "^6.1.13"
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "6.1.10",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.10.tgz",
-			"integrity": "sha512-B6/v1f0NwjxzmeOhzfXPGWpKBVA207LS7lehaVKQnFrVktcFRfkzjZZ2gwj2i1TkEUMQht7ZMJbABUT5N+V1Nw==",
+			"version": "6.1.13",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.13.tgz",
+			"integrity": "sha512-gmtS2PaUjSPa4zjObEIn4WWliKyZzYljgxODBfxugpK6q6HU9ClXzgCJ+nlcPKY9Bt090ypTOLIFWkV0jbKFjw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"cacheable": "^1.10.0",
+				"cacheable": "^1.10.4",
 				"flatted": "^3.3.3",
-				"hookified": "^1.9.1"
+				"hookified": "^1.11.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/ignore": {
@@ -13652,12 +13515,12 @@
 			}
 		},
 		"node_modules/subscribable-things": {
-			"version": "2.1.53",
-			"resolved": "https://registry.npmjs.org/subscribable-things/-/subscribable-things-2.1.53.tgz",
-			"integrity": "sha512-zWvN9F/eYQWDKszXl4NXkyqPXvMDZDmXfcHiM5C5WQZTTY2OK+2TZeDlA9oio69FEPqPu9T6yeEcAhQ2uRmnaw==",
+			"version": "2.1.54",
+			"resolved": "https://registry.npmjs.org/subscribable-things/-/subscribable-things-2.1.54.tgz",
+			"integrity": "sha512-zjnmu4uPrYCCoFMrNK00ytEKfz/hFr01Fvn6RIb8ty8pvhnM+o4CFLyCHt3aMOQShQ72JEtrfFq/+hkZWRos/A==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
+				"@babel/runtime": "^7.28.3",
 				"rxjs-interop": "^2.0.0",
 				"tslib": "^2.8.1"
 			}
@@ -13698,7 +13561,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -13776,7 +13638,6 @@
 			"version": "2.0.12",
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
 			"integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"setimmediate": "^1.0.4"
@@ -13789,7 +13650,6 @@
 			"version": "0.2.14",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
 			"integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -13807,7 +13667,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
 			"integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"isarray": "^2.0.5",
@@ -13822,7 +13681,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -13916,7 +13775,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
 			"integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/type-check": {
@@ -13951,7 +13809,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
 			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.3",
@@ -14029,9 +13886,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -14249,39 +14106,39 @@
 			}
 		},
 		"node_modules/unrs-resolver": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.9.2.tgz",
-			"integrity": "sha512-VUyWiTNQD7itdiMuJy+EuLEErLj3uwX/EpHQF8EOf33Dq3Ju6VW1GXm+swk6+1h7a49uv9fKZ+dft9jU7esdLA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"napi-postinstall": "^0.2.4"
+				"napi-postinstall": "^0.3.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/unrs-resolver"
 			},
 			"optionalDependencies": {
-				"@unrs/resolver-binding-android-arm-eabi": "1.9.2",
-				"@unrs/resolver-binding-android-arm64": "1.9.2",
-				"@unrs/resolver-binding-darwin-arm64": "1.9.2",
-				"@unrs/resolver-binding-darwin-x64": "1.9.2",
-				"@unrs/resolver-binding-freebsd-x64": "1.9.2",
-				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.9.2",
-				"@unrs/resolver-binding-linux-arm-musleabihf": "1.9.2",
-				"@unrs/resolver-binding-linux-arm64-gnu": "1.9.2",
-				"@unrs/resolver-binding-linux-arm64-musl": "1.9.2",
-				"@unrs/resolver-binding-linux-ppc64-gnu": "1.9.2",
-				"@unrs/resolver-binding-linux-riscv64-gnu": "1.9.2",
-				"@unrs/resolver-binding-linux-riscv64-musl": "1.9.2",
-				"@unrs/resolver-binding-linux-s390x-gnu": "1.9.2",
-				"@unrs/resolver-binding-linux-x64-gnu": "1.9.2",
-				"@unrs/resolver-binding-linux-x64-musl": "1.9.2",
-				"@unrs/resolver-binding-wasm32-wasi": "1.9.2",
-				"@unrs/resolver-binding-win32-arm64-msvc": "1.9.2",
-				"@unrs/resolver-binding-win32-ia32-msvc": "1.9.2",
-				"@unrs/resolver-binding-win32-x64-msvc": "1.9.2"
+				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+				"@unrs/resolver-binding-android-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-x64": "1.11.1",
+				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -14329,7 +14186,6 @@
 			"version": "0.11.4",
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
 			"integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^1.4.1",
@@ -14362,14 +14218,12 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/util": {
 			"version": "0.12.5",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
 			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -14383,7 +14237,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/v-click-outside": {
@@ -14410,9 +14263,9 @@
 			}
 		},
 		"node_modules/vfile-message": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-			"integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -14424,25 +14277,24 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.3.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-			"integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
-			"dev": true,
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
+			"integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
-				"fdir": "^6.4.4",
-				"picomatch": "^4.0.2",
-				"postcss": "^8.5.3",
-				"rollup": "^4.34.9",
-				"tinyglobby": "^0.2.13"
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.14"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"funding": {
 				"url": "https://github.com/vitejs/vite?sponsor=1"
@@ -14451,14 +14303,14 @@
 				"fsevents": "~2.3.3"
 			},
 			"peerDependencies": {
-				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@types/node": "^20.19.0 || >=22.12.0",
 				"jiti": ">=1.21.0",
-				"less": "*",
+				"less": "^4.0.0",
 				"lightningcss": "^1.21.0",
-				"sass": "*",
-				"sass-embedded": "*",
-				"stylus": "*",
-				"sugarss": "*",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
 				"terser": "^5.16.0",
 				"tsx": "^4.8.1",
 				"yaml": "^2.4.2"
@@ -14596,10 +14448,9 @@
 			}
 		},
 		"node_modules/vite-plugin-node-polyfills": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.23.0.tgz",
-			"integrity": "sha512-4n+Ys+2bKHQohPBKigFlndwWQ5fFKwaGY6muNDMTb0fSQLyBzS+jjUNRZG9sKF0S/Go4ApG6LFnUGopjkILg3w==",
-			"dev": true,
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.24.0.tgz",
+			"integrity": "sha512-GA9QKLH+vIM8NPaGA+o2t8PDfFUl32J8rUp1zQfMKVJQiNkOX4unE51tR6ppl6iKw5yOrDAdSH7r/UIFLCVhLw==",
 			"license": "MIT",
 			"dependencies": {
 				"@rollup/plugin-inject": "^5.0.5",
@@ -14609,18 +14460,18 @@
 				"url": "https://github.com/sponsors/davidmyersdev"
 			},
 			"peerDependencies": {
-				"vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+				"vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
 			}
 		},
 		"node_modules/vite-plugin-stylelint": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/vite-plugin-stylelint/-/vite-plugin-stylelint-6.0.0.tgz",
-			"integrity": "sha512-qXsot4hTkAlR8aXNXhBxF1KWyP78SocCobD1mBwka85l0+nY1Ja4HEyW2x2RbC7kIs6ff9mdUxK9TqcwuxQjxw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/vite-plugin-stylelint/-/vite-plugin-stylelint-6.0.2.tgz",
+			"integrity": "sha512-whqm2m5rvfd4cYA+cpwZ3BROR/5enRGdRr65hxQNHYn6YFmP8M1xrVKEbLIEBSmmSZ7G7AEZWccS8X+UAksIXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rollup/pluginutils": "^5.1.3",
-				"debug": "^4.3.7"
+				"@rollup/pluginutils": "^5.2.0",
+				"debug": "^4.4.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -14630,7 +14481,7 @@
 				"postcss": "^7.0.0 || ^8.0.0",
 				"rollup": "^2.0.0 || ^3.0.0 || ^4.0.0",
 				"stylelint": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-				"vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+				"vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/stylelint": {
@@ -14648,7 +14499,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
 			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vscode-uri": {
@@ -14659,16 +14509,16 @@
 			"license": "MIT"
 		},
 		"node_modules/vue": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.17.tgz",
-			"integrity": "sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.21.tgz",
+			"integrity": "sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.5.17",
-				"@vue/compiler-sfc": "3.5.17",
-				"@vue/runtime-dom": "3.5.17",
-				"@vue/server-renderer": "3.5.17",
-				"@vue/shared": "3.5.17"
+				"@vue/compiler-dom": "3.5.21",
+				"@vue/compiler-sfc": "3.5.21",
+				"@vue/runtime-dom": "3.5.21",
+				"@vue/server-renderer": "3.5.21",
+				"@vue/shared": "3.5.21"
 			},
 			"peerDependencies": {
 				"typescript": "*"
@@ -14938,7 +14788,6 @@
 			"version": "1.1.19",
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
 			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
@@ -14968,13 +14817,13 @@
 			}
 		},
 		"node_modules/worker-factory": {
-			"version": "7.0.43",
-			"resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.43.tgz",
-			"integrity": "sha512-SACVoj3gWKtMVyT9N+VD11Pd/Xe58+ZFfp8b7y/PagOvj3i8lU3Uyj+Lj7WYTmSBvNLC0JFaQkx44E6DhH5+WA==",
+			"version": "7.0.45",
+			"resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.45.tgz",
+			"integrity": "sha512-FFPCiSv7MD6ZDEfiik/ErM8IrIAWajaXhezLyCo3v0FjhUWud6GXnG2BiTE91jLywXGAVCT8IF48Hhr+D/omMw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.6",
-				"fast-unique-numbers": "^9.0.22",
+				"@babel/runtime": "^7.28.3",
+				"fast-unique-numbers": "^9.0.23",
 				"tslib": "^2.8.1"
 			}
 		},
@@ -15016,7 +14865,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
 			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4"
@@ -15034,7 +14882,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"

--- a/src/components/AssistantHeaderMenuEntry.vue
+++ b/src/components/AssistantHeaderMenuEntry.vue
@@ -6,7 +6,7 @@
 	<NcHeaderButton
 		id="assistant"
 		:aria-label="t('assistant', 'Nextcloud Assistant')"
-		:description="t('assistant', 'Nextcloud Assistant desc')"
+		:description="t('assistant', 'Nextcloud Assistant header menu entry')"
 		@click="$emit('click')">
 		<template #icon>
 			<AssistantIcon :size="20" />

--- a/src/components/AssistantHeaderMenuEntry.vue
+++ b/src/components/AssistantHeaderMenuEntry.vue
@@ -3,81 +3,28 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div id="assistant"
-		class="header-menu">
-		<NcButton
-			class="trigger"
-			variant="secondary"
-			:title="t('assistant', 'Nextcloud Assistant')"
-			@click="$emit('click')">
-			<AssistantIcon class="menu-icon" :size="20" />
-		</NcButton>
-	</div>
+	<NcHeaderButton
+		id="assistant"
+		:aria-label="t('assistant', 'Nextcloud Assistant')"
+		:description="t('assistant', 'Nextcloud Assistant desc')"
+		@click="$emit('click')">
+		<template #icon>
+			<AssistantIcon :size="20" />
+		</template>
+	</NcHeaderButton>
 </template>
 
 <script>
 import AssistantIcon from './icons/AssistantIcon.vue'
 
-import NcButton from '@nextcloud/vue/components/NcButton'
+import NcHeaderButton from '@nextcloud/vue/components/NcHeaderButton'
 
 export default {
 	name: 'AssistantHeaderMenuEntry',
-
 	components: {
 		AssistantIcon,
-		NcButton,
+		NcHeaderButton,
 	},
-
 	emits: ['click'],
-
-	data() {
-		return {
-		}
-	},
-
-	computed: {
-	},
-
-	mounted() {
-	},
-
-	beforeUnmount() {
-	},
-
-	methods: {
-	},
 }
 </script>
-
-<style scoped lang="scss">
-.header-menu {
-	width: var(--header-height);
-	height: var(--header-height);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	opacity: .85;
-	&:hover {
-		opacity: 1;
-	}
-
-	.trigger {
-		width: 100%;
-		height: 100%;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		cursor: pointer;
-		background-color: rgba(0,0,0,0);
-		border: none;
-		filter: none !important;
-		color: var(--color-primary-text) !important;
-		&:hover {
-			background-color: rgba(0,0,0,0) !important;
-		}
-		.menu-icon {
-			color: var(--color-background-plain-text) !important;
-		}
-	}
-}
-</style>

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -8,8 +8,8 @@
 	<div v-else
 		class="assistant-form">
 		<span class="assistant-bubble">
-			<CreationIcon :size="16" class="icon" />
-			<span>{{ t('assistant', 'Nextcloud Assistant') }}</span>
+			<NcAssistantIcon />
+			<strong class="assistant-bubble__label">{{ t('assistant', 'Nextcloud Assistant') }}</strong>
 		</span>
 		<TaskTypeSelect
 			v-model="mySelectedTaskTypeId"
@@ -140,6 +140,7 @@ import NcAppNavigationNew from '@nextcloud/vue/components/NcAppNavigationNew'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcAssistantIcon from '@nextcloud/vue/components/NcAssistantIcon'
 
 import AssistantFormInputs from './AssistantFormInputs.vue'
 import AssistantFormOutputs from './AssistantFormOutputs.vue'
@@ -177,6 +178,7 @@ export default {
 		NcAppNavigation,
 		NcAppNavigationList,
 		NcAppNavigationNew,
+		NcAssistantIcon,
 		CreationIcon,
 		PlusIcon,
 		UnfoldLessHorizontalIcon,
@@ -571,14 +573,16 @@ export default {
 	}
 
 	.assistant-bubble {
-		align-self: start;
+		align-self: center;
 		display: flex;
-		gap: 8px;
-		background-color: var(--color-primary-element-light);
-		border-radius: var(--border-radius-rounded);
+		align-items: center;
 		padding: 2px 8px;
-		.icon {
-			color: var(--color-primary);
+		&__label {
+			// this is only effective if --color-element-assistant-icon is not set (in NC < 32)
+			background: var(--color-main-text);
+			background-image: var(--color-element-assistant-icon);
+			color: transparent;
+			background-clip: text;
 		}
 	}
 

--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -6,7 +6,6 @@
 	<NcModal v-if="show"
 		:size="modalSize"
 		:no-close="true"
-		:name="t('assistant', 'Nextcloud Assistant')"
 		dark
 		:container="null"
 		class="assistant-modal"
@@ -220,7 +219,7 @@ export default {
 .assistant-modal--content {
 	width: 100%;
 	margin: 0 auto;
-	padding: 16px;
+	padding: 8px 16px 16px 16px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/src/components/TaskTypeSelect.vue
+++ b/src/components/TaskTypeSelect.vue
@@ -285,8 +285,7 @@ export default {
 	.categoryWithSubSelected button {
 		background: var(--color-element-assistant) !important;
 		color: white !important;
-		border: none !important;
-		padding-block: 0 !important;
+		border-color: #40519A !important;
 	}
 }
 </style>

--- a/src/components/TaskTypeSelect.vue
+++ b/src/components/TaskTypeSelect.vue
@@ -12,7 +12,7 @@
 				:menu-name="variants.text"
 				:container="$refs.taskTypeSelect"
 				:primary="isCategorySelected(variants)"
-				:class="{ categoryWithSubSelected: isCategorySelected(variants) }"
+				:class="{ categoryWithSubSelected: useModernStyle && isCategorySelected(variants) }"
 				@click="onMenuCategorySelected(variants)">
 				<NcActionButton v-for="t in variants.tasks"
 					:key="t.id"
@@ -31,8 +31,8 @@
 			</NcActions>
 			<NcButton v-else
 				:key="variants.id + '-button'"
-				variant="secondary"
-				:class="{ categorySelected: isCategorySelected(variants) }"
+				:variant="isCategorySelected(variants) ? 'primary' : 'secondary'"
+				:class="{ categorySelected: useModernStyle && isCategorySelected(variants) }"
 				:title="variants.text"
 				@click="onMenuCategorySelected(variants)">
 				<template #icon>
@@ -90,6 +90,8 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcAssistantButton from '@nextcloud/vue/components/NcAssistantButton'
 
+import { loadState } from '@nextcloud/initial-state'
+
 export default {
 	name: 'TaskTypeSelect',
 
@@ -127,6 +129,7 @@ export default {
 	data() {
 		return {
 			categorySubmenu: null,
+			useModernStyle: loadState('assistant', 'use-modern-style', false),
 		}
 	},
 

--- a/src/components/TaskTypeSelect.vue
+++ b/src/components/TaskTypeSelect.vue
@@ -12,6 +12,7 @@
 				:menu-name="variants.text"
 				:container="$refs.taskTypeSelect"
 				:primary="isCategorySelected(variants)"
+				:class="{ categoryWithSubSelected: isCategorySelected(variants) }"
 				@click="onMenuCategorySelected(variants)">
 				<NcActionButton v-for="t in variants.tasks"
 					:key="t.id"
@@ -30,7 +31,8 @@
 			</NcActions>
 			<NcButton v-else
 				:key="variants.id + '-button'"
-				:variant="isCategorySelected(variants) ? 'primary' : 'secondary'"
+				variant="secondary"
+				:class="{ categorySelected: isCategorySelected(variants) }"
 				:title="variants.text"
 				@click="onMenuCategorySelected(variants)">
 				<template #icon>
@@ -73,17 +75,20 @@
 </template>
 
 <script>
-import NcActions from '@nextcloud/vue/components/NcActions'
-import NcButton from '@nextcloud/vue/components/NcButton'
-import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import MessageOutlineIcon from 'vue-material-design-icons/MessageOutline.vue'
 import DotsHorizontalIcon from 'vue-material-design-icons/DotsHorizontal.vue'
 import TextLongIcon from 'vue-material-design-icons/TextLong.vue'
 import ImageOutlineIcon from 'vue-material-design-icons/ImageOutline.vue'
 import WebIcon from 'vue-material-design-icons/Web.vue'
 import FileIcon from 'vue-material-design-icons/File.vue'
+
 import ContentPasteSearchIcon from './icons/ContentPasteSearch.vue'
 import WaveformIcon from './icons/Waveform.vue'
+
+import NcActions from '@nextcloud/vue/components/NcActions'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcAssistantButton from '@nextcloud/vue/components/NcAssistantButton'
 
 export default {
 	name: 'TaskTypeSelect',
@@ -93,6 +98,7 @@ export default {
 		NcActionButton,
 		MessageOutlineIcon,
 		NcButton,
+		NcAssistantButton,
 	},
 
 	props: {
@@ -271,6 +277,18 @@ export default {
 </script>
 
 <style lang="scss">
+.task-type-select {
+	.categorySelected,
+	.categoryWithSubSelected button {
+		background: var(--color-element-assistant) !important;
+		color: white !important;
+		border: none !important;
+		padding-block: 0 !important;
+	}
+}
+</style>
+
+<style scoped lang="scss">
 .task-type-select {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
closes #347

* [x] Adjust header menu icon: use NcHeaderButton (that comes with a transparency gradient)
<img width="253" height="48" alt="image" src="https://github.com/user-attachments/assets/753169d4-2fa9-4840-b53f-dba0e4928880" />


* [x] Adjust the main form title (icon + text color)
* [x] Change selected task type category style

<img width="1242" height="537" alt="image" src="https://github.com/user-attachments/assets/e59e5fc8-b611-4d2a-92a1-c234491e9f88" />
<img width="1242" height="537" alt="image" src="https://github.com/user-attachments/assets/a36b8656-c55f-4486-baeb-149e28050d5a" />


If we want to keep supporting NC 30 and 31, we need to be careful with this custom style that is not included in NC < 32. There is now a `use-modern-style` initial state injected to decide if we use the new css vars or not.

@marcoambrosini We can't use `NcAssistantButton` because
* NcActions is not flexible enough
* Even if we could use it to replace our `NcButton` in some places, this component does not allow to use a custom icon so we're stuck with the assistant one but we want the category one

So I went with custom styling using the css variables.
I tried to replicate the gradient in the NcAssistantButton component but this is done by using a gradient background in an element wrapping the NcButton. Here we directly use the button, no wrapping element. I couldn't find a way to have this gradient border so I removed the border which IMHO looks better than the border gradient + a different button gradient.
This is how NcAssistantButton look like with the 2 gradients:
<img width="457" height="109" alt="image" src="https://github.com/user-attachments/assets/96cd93e6-5ad6-442b-a053-be36b33510fa" />