### PR TITLE
Prepare 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.7.0 – 2025-09-05
+
+### Changed
+
+- Rename ai settings to assistant @lukasdotcom [#333](https://github.com/nextcloud/assistant/pull/333)
+- Improve sticker generation @lukasdotcom [#331](https://github.com/nextcloud/assistant/pull/331)
+- Replace mdi download icon with Material Symbols variant @AndyScherzinger [#348](https://github.com/nextcloud/assistant/pull/348)
+- Improve style and use new assistant components @julien-nc [#349](https://github.com/nextcloud/assistant/pull/349)
+
+### Fixed
+
+- Only show the group file action if necessary @julien-nc [#342](https://github.com/nextcloud/assistant/pull/342)
+
 ## 2.6.1 – 2025-08-09
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -62,7 +62,7 @@ Known providers:
 
 More details on how to set this up in the [admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html)
 ]]>	</description>
-	<version>2.6.1</version>
+	<version>2.7.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Assistant</namespace>


### PR DESCRIPTION
### Changed

- Rename ai settings to assistant @lukasdotcom [#333](https://github.com/nextcloud/assistant/pull/333)
- Improve sticker generation @lukasdotcom [#331](https://github.com/nextcloud/assistant/pull/331)
- Replace mdi download icon with Material Symbols variant @AndyScherzinger [#348](https://github.com/nextcloud/assistant/pull/348)
- Improve style and use new assistant components @julien-nc [#349](https://github.com/nextcloud/assistant/pull/349)

### Fixed

- Only show the group file action if necessary @julien-nc [#342](https://github.com/nextcloud/assistant/pull/342)