### PR TITLE
prepare 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.7.1 – 2025-09-05
+
+### Fixed
+
+- Prevent accessing array index on null @julien-nc [#351](https://github.com/nextcloud/assistant/pull/351)
+
 ## 2.7.0 – 2025-09-05
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -62,7 +62,7 @@ Known providers:
 
 More details on how to set this up in the [admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html)
 ]]>	</description>
-	<version>2.7.0</version>
+	<version>2.7.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Assistant</namespace>


### PR DESCRIPTION
### Fixed

- Prevent accessing array index on null @julien-nc [#351](https://github.com/nextcloud/assistant/pull/351)