### PR TITLE
Fix stop polling when needed

### DIFF
--- a/src/assistant.js
+++ b/src/assistant.js
@@ -313,6 +313,7 @@ export async function pollTask(taskId, obj, callback = updateTask) {
 				console.debug('[assistant] poll request failed', error)
 				if (error.status === 404) {
 					clearInterval(window.assistantPollTimerId)
+					window.assistantPollTimerId = null
 					reject(new Error('task-not-found'))
 					return
 				}

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -107,6 +107,7 @@ export async function openAssistantForm({
 		let lastTask = null
 
 		modalMountPoint.addEventListener('cancel', () => {
+			cancelTaskPolling()
 			app.unmount()
 			reject(new Error('User cancellation'))
 		})
@@ -521,6 +522,7 @@ export async function openAssistantTask(
 	let lastTask = task
 
 	modalMountPoint.addEventListener('cancel', () => {
+		cancelTaskPolling()
 		app.unmount()
 	})
 	modalMountPoint.addEventListener('submit', (data) => {

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -183,7 +183,7 @@ import InputArea from './InputArea.vue'
 import NoSession from './NoSession.vue'
 import AgencyConfirmation from './AgencyConfirmation.vue'
 
-import axios from '@nextcloud/axios'
+import axios, { isCancel } from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
 import { generateUrl, generateOcsUrl } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
@@ -591,7 +591,7 @@ export default {
 				this.loading.initialMessages = false
 				this.messagesAxiosController = null
 			} catch (error) {
-				if (axios.isCancel(error)) {
+				if (isCancel(error)) {
 					console.debug('fetchMessages cancelled')
 					return
 				}

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -345,7 +345,7 @@ export default {
 		},
 	},
 
-	onDestroy() {
+	beforeUnmount() {
 		if (this.pollMessageGenerationTimerId) {
 			clearInterval(this.pollMessageGenerationTimerId)
 		}


### PR DESCRIPTION
closes #355

* Fix stop polling when closing the assistant while polling a classic task
* Fix stop polling when closing the assistant while polling a message generation in the chat UI (wrong component method name, `onDestroy()` does not exist anymore in vue3. We now use `beforeUnmount()`.
* Bonus: Get rid of the eslint warning about the `axios.isCancel` import