### PR TITLE
fix(ui): set min-height on modal to prevent size jump

### DIFF
--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -230,6 +230,7 @@ div[role='listbox'] {
 	align-items: center;
 	justify-content: center;
 	overflow-y: auto;
+	min-height: 500px;
 
 	> h2 {
 		display: flex;


### PR DESCRIPTION
## Summary
This PR fixes an issue where the Assistant modal "jumps" in size when it's opened, before the content is loaded. This was caused by the modal not having a defined height until the content was rendered.

## Changes Made
- Added a `min-height` of `500px` to the `.assistant-modal--content` class in `src/components/AssistantTextProcessingModal.vue`. This ensures that the modal has a consistent height from the moment it is rendered, preventing the jarring size change.

## Test Plan
- I ran `npm run build` to ensure the code builds successfully.
- I also ran `npm run lint` and `npm run stylelint` to ensure the changes are consistent with the project's coding style.
- Manual testing:
  1. Open the assistant modal.
  2. Verify that the modal appears at its final size and does not resize when the content loads.

Fixes #370