### PR TITLE
Use the ESLINT_USE_FLAT_CONFIG=false env flag to fix 'npm lint' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 		"build": "NODE_ENV=production vite --mode production build",
 		"dev": "NODE_ENV=development vite --mode development build",
 		"watch": "NODE_ENV=development vite --mode development build --watch",
-		"lint": "eslint --ext .js,.vue src",
-		"lint:fix": "eslint --ext .js,.vue src --fix",
+		"lint": "ESLINT_USE_FLAT_CONFIG=false eslint --ext=.js,.vue src",
+		"lint:fix": "ESLINT_USE_FLAT_CONFIG=false eslint --ext=.js,.vue src --fix",
 		"stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
 		"stylelint:fix": "stylelint src/**/*.vue src/**/*.scss src/**/*.css --fix"
 	},


### PR DESCRIPTION
Recent eslint tries to load the config with a new format (called "flat"). We stick to the old one because of `@nextcloud/eslint-config` (I think).

To see the issue:
* Checkout the main branch
* run `npm ci ; npm run lint`
* Checkout this branch
* run `npm run lint`