### PR TITLE
Fix wrong prop type for informationSourceNames in the chat UI

### DIFF
--- a/src/components/ChattyLLM/ConversationBox.vue
+++ b/src/components/ChattyLLM/ConversationBox.vue
@@ -91,7 +91,7 @@ export default {
 		return {
 			regenerateFromId: null,
 			deleteMessageId: null,
-			informationSourceNames: loadState('assistant', 'contextAgentToolSources'),
+			informationSourceNames: loadState('assistant', 'contextAgentToolSources', {}),
 		}
 	},
 

--- a/src/components/ChattyLLM/Message.vue
+++ b/src/components/ChattyLLM/Message.vue
@@ -136,7 +136,7 @@ export default {
 			default: false,
 		},
 		informationSourceNames: {
-			type: Array,
+			type: Object,
 			default: null,
 		},
 	},


### PR DESCRIPTION
And set a default value (to `{}`) if the initial state value is not set.