### PR TITLE
fix: reinitialize inputs on New Task button click

### DIFF
--- a/src/components/ContextChat/ContextChatInputForm.vue
+++ b/src/components/ContextChat/ContextChatInputForm.vue
@@ -260,12 +260,10 @@ export default {
 		taskType(newValue) {
 			this.onTaskTypeChange()
 		},
-		inputs: {
-			handler(newValue) {
-				if (Object.keys(newValue).length === 0) {
-					this.onInputsReset()
-				}
-			},
+		inputs(newValue) {
+			if (Object.keys(newValue).length === 0) {
+				this.onInputsReset()
+			}
 		},
 	},
 


### PR DESCRIPTION
- This fix adds reinitialization of context chat input form on the New Task button click

Fixes #383