### PR TITLE
Attempt to fix the translate custom form field size when switching tasks

### DIFF
--- a/src/components/Translate/TranslateForm.vue
+++ b/src/components/Translate/TranslateForm.vue
@@ -210,6 +210,19 @@ export default {
 
 		.col {
 			width: 50%;
+			.text-field {
+				display: flex;
+				flex-direction: column;
+				:deep(.editable-input) {
+					flex-grow: 1;
+					display: flex;
+					flex-direction: column;
+				}
+				:deep(.editable-input div) {
+					height: 100% !important;
+					margin: 0 !important;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This is probably not a good way to solve the issue.

Problem is when switching to a task that has a long text input, the NcRichContentEditable component size does not adjust.

<img width="1242" height="586" alt="image" src="https://github.com/user-attachments/assets/2b1503f8-d462-4123-a023-2c87020ad0b1" />

After typing a space in one of the fields, the size adjusts.

<img width="1242" height="586" alt="image" src="https://github.com/user-attachments/assets/de8f17e6-2bef-4f81-b9d4-ef5ce989befa" />


cc @marcoambrosini 