### PR TITLE
Gracefully handle scheduling errors in the UI

### DIFF
--- a/src/assistant.js
+++ b/src/assistant.js
@@ -161,10 +161,10 @@ export async function openAssistantForm({
 					})
 				})
 				.catch(error => {
-					app.unmount()
-					console.error('Assistant scheduling error', error)
-					showError(t('assistant', 'Assistant error') + ': ' + error?.response?.data)
-					reject(new Error('Assistant scheduling error'))
+					view.loading = false
+					view.showSyncTaskRunning = false
+					console.error('Assistant scheduling error', error?.response?.data?.ocs?.data?.message)
+					showError(t('assistant', 'Assistant error') + ': ' + t('assistant', 'Something went wrong when scheduling the task'))
 				})
 		}
 		modalMountPoint.addEventListener('sync-submit', (data) => {
@@ -589,10 +589,10 @@ export async function openAssistantTask(
 				})
 			})
 			.catch(error => {
-				app.unmount()
-				console.error('Assistant scheduling error', error)
-				showError(t('assistant', 'Assistant error') + ': ' + error?.response?.data)
-				// reject(new Error('Assistant scheduling error'))
+				view.loading = false
+				view.showSyncTaskRunning = false
+				console.error('Assistant scheduling error', error?.response?.data?.ocs?.data?.message)
+				showError(t('assistant', 'Assistant error') + ': ' + t('assistant', 'Something went wrong when scheduling the task'))
 			})
 	}
 	modalMountPoint.addEventListener('sync-submit', (data) => {
@@ -731,7 +731,10 @@ export async function addAssistantMenuEntry() {
 		}, 1000)
 		openAssistantForm({ appId: 'assistant' })
 			.then(r => {
-				console.debug('scheduled task', r)
+				console.debug('[Assistant header menu entry] scheduled task', r)
+			})
+			.catch(error => {
+				console.error('[Assistant header menu entry] Assistant openAssistantForm promise rejected:', error.message)
 			})
 	})
 }

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -149,8 +149,10 @@ export default {
 					})
 				})
 				.catch(error => {
-					console.error('Assistant scheduling error', error)
-					showError(t('assistant', 'Failed to schedule your task'))
+					this.loading = false
+					this.showSyncTaskRunning = false
+					console.error('Assistant scheduling error', error?.response?.data?.ocs?.data?.message)
+					showError(t('assistant', 'Assistant error') + ': ' + t('assistant', 'Something went wrong when scheduling the task'))
 				})
 				.then(() => {
 				})


### PR DESCRIPTION
### "Simple" way to reproduce

Try to schedule a task with invalid output so the scheduling request fails. I did this by running an old translation task again (with "Try again") after having changed the provider so the language enum values had changed.

### Issue

When the scheduling request fails

1. If the assistant was opened from the top menu, the modal is closed
2. If the assistant was opened from a notification, we stay in a weird loading state but still having the old task loaded (so canceling actually deletes the old task...)
3. On the assistant standalone page, same as 2.
4. In every case, we get an ugly toast message with `[Object, Object]` because we try to display the message from the response with accessing the wrong attributes

### Fix

When the scheduling request fails

* Do not close the assistant modal (case 1.)
* Put the assistant back in its previous state: nothing is loading, we stay on the current task
* Print the error in the browser log

Additional change: Catch the promise error (case 1.) on the upper level to prevent the error to reach the top and polute the browser log.

### Question

Should we include the error message returned in the scheduling response in case of error in the toast message?
For now a static `Assistant error: Something went wrong when scheduling the task` is shown.
I'm wondering because in the specific example I witnessed, the manager validation error is not really meant to be displayed to the user.