### PR TITLE
Fix: use new composable for relative time

### DIFF
--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -84,7 +84,7 @@ import MicrophoneMessageIcon from 'vue-material-design-icons/MicrophoneMessage.v
 import NcListItem from '@nextcloud/vue/components/NcListItem'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 
-import moment from '@nextcloud/moment'
+import { useFormatRelativeTime } from '@nextcloud/vue'
 
 import { TASK_STATUS_STRING, SHAPE_TYPE_NAMES } from '../constants.js'
 import ImageDisplay from './fields/ImageDisplay.vue'
@@ -192,7 +192,9 @@ export default {
 			return statusTitles[this.task.status] ?? t('assistant', 'Unknown status')
 		},
 		details() {
-			return moment.unix(this.task.lastUpdated).fromNow()
+			return useFormatRelativeTime(this.task.lastUpdated * 1000, {
+				ignoreSeconds: true,
+			})
 		},
 		icon() {
 			return statusIcons[this.task.status] ?? ProgressQuestionIcon


### PR DESCRIPTION
The moments library uses the locale instead of the language for localization, fixed with the vue composable
See https://github.com/issues/created?issue=nextcloud-libraries%7Cnextcloud-moment%7C1061

<img width="495" height="505" alt="image" src="https://github.com/user-attachments/assets/de392574-6ab0-4bdf-8f17-1e790bec19e3" />
