### PR TITLE
Prepare v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 3.2.0 - 2026-01-28
+
+### Added 
+- Add support for Nextcloud 34 @marcelklehr [#448](https://github.com/nextcloud/assistant/pull/448)
+- add chat memories without delay by adding raw chats @janepie [#446](https://github.com/nextcloud/assistant/pull/446)
+
+### Changed
+- Format all Chat output in Markdown @ericfischereu [#431](https://github.com/nextcloud/assistant/pull/431)
+- Pin actions with full hash @julien-nc [#445](https://github.com/nextcloud/assistant/pull/445)
+
+
 ## 3.1.0 - 2026-01-15
 
 ### Added 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -62,7 +62,7 @@ Known providers:
 
 More details on how to set this up in the [admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html)
 ]]>	</description>
-	<version>3.2.0-dev.0</version>
+	<version>3.2.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Assistant</namespace>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Nextcloud Assistant",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Added 
- Add support for Nextcloud 34 @marcelklehr [#448](https://github.com/nextcloud/assistant/pull/448)
- add chat memories without delay by adding raw chats @janepie [#446](https://github.com/nextcloud/assistant/pull/446)

### Changed
- Format all Chat output in Markdown @ericfischereu [#431](https://github.com/nextcloud/assistant/pull/431)
- Pin actions with full hash @julien-nc [#445](https://github.com/nextcloud/assistant/pull/445)