### PR TITLE
fix: decode HTML entities when copying task output to clipboard

### DIFF
--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -59,6 +59,7 @@ import axios from '@nextcloud/axios'
 import { getFilePickerBuilder, showError } from '@nextcloud/dialogs'
 import { generateOcsUrl } from '@nextcloud/router'
 import { VALID_TEXT_MIME_TYPES, MAX_TEXT_INPUT_LENGTH } from '../../constants.js'
+import { parseSpecialSymbols } from '../../utils.js'
 
 const picker = (callback, target) => getFilePickerBuilder(t('assistant', 'Choose a text file'))
 	.setMimeTypeFilter(VALID_TEXT_MIME_TYPES)
@@ -184,7 +185,7 @@ export default {
 		},
 		async onCopy() {
 			try {
-				await navigator.clipboard.writeText(this.formattedValue)
+				await navigator.clipboard.writeText(parseSpecialSymbols(this.formattedValue))
 				this.copied = true
 				setTimeout(() => {
 					this.copied = false


### PR DESCRIPTION
Fixes #432

When copying task output containing `<` or `>` characters, they were copied as `&lt;` and `&gt;` HTML entities instead of the actual characters.

**Root cause:** `NcRichContenteditable` internally uses `innerHTML` to read content, which causes the browser to HTML-encode special characters like `<` and `>`. When the copy button calls `navigator.clipboard.writeText()`, these encoded entities are copied literally.

**Fix:** Apply the existing `parseSpecialSymbols()` utility function (from `src/utils.js`) to decode HTML entities before writing to the clipboard. This function was already created specifically for this upstream issue ([nextcloud-vue#4492](https://github.com/nextcloud-libraries/nextcloud-vue/issues/4492)) and is already used in `EditableTextField.vue` for the same purpose.