### PR TITLE
fix: prevent [object Object] error on invalid task input

### DIFF
--- a/src/assistant.js
+++ b/src/assistant.js
@@ -4,6 +4,7 @@
  */
 
 import { TASK_STATUS_STRING } from './constants.js'
+import { getErrorMessage } from './utils.js'
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 
@@ -171,7 +172,10 @@ export async function openAssistantForm({
 					view.loading = false
 					view.showSyncTaskRunning = false
 					console.error('Assistant scheduling error', error?.response?.data?.ocs?.data?.message)
-					showError(t('assistant', 'Assistant error') + ': ' + t('assistant', 'Something went wrong when scheduling the task'))
+					showError(
+						t('assistant', 'Assistant error') + ': '
+						+ (getErrorMessage(error?.response?.data?.ocs?.data?.message) ?? t('assistant', 'Something went wrong when scheduling the task')),
+					)
 				})
 		}
 		modalMountPoint.addEventListener('sync-submit', (data) => {
@@ -613,7 +617,10 @@ export async function openAssistantTask(
 				view.loading = false
 				view.showSyncTaskRunning = false
 				console.error('Assistant scheduling error', error?.response?.data?.ocs?.data?.message)
-				showError(t('assistant', 'Assistant error') + ': ' + t('assistant', 'Something went wrong when scheduling the task'))
+				showError(
+					t('assistant', 'Assistant error') + ': '
+					+ (getErrorMessage(error?.response?.data?.ocs?.data?.message) ?? t('assistant', 'Something went wrong when scheduling the task')),
+				)
 			})
 	}
 	modalMountPoint.addEventListener('sync-submit', (data) => {

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -217,6 +217,7 @@ import { generateUrl, generateOcsUrl } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
 import moment from 'moment'
 import { SHAPE_TYPE_NAMES } from '../../constants.js'
+import { getErrorMessage } from '../../utils.js'
 
 // future: type (text, image, file, etc), attachments, etc support
 
@@ -378,7 +379,7 @@ export default {
 						}
 					} catch (error) {
 						console.error('onCheckSessionTitle error:', error)
-						showError(error?.response?.data?.error ?? t('assistant', 'Error getting the generated title for the conversation'))
+						showError(getErrorMessage(error?.response?.data?.error) ?? t('assistant', 'Error getting the generated title for the conversation'))
 					}
 				}
 			} catch (error) {
@@ -443,7 +444,7 @@ export default {
 				session.title = newTitle
 			} catch (error) {
 				console.error('updateTitle error:', error)
-				showError(error?.response?.data?.error ?? t('assistant', 'Error updating title of conversation'))
+				showError(getErrorMessage(error?.response?.data?.error) ?? t('assistant', 'Error updating title of conversation'))
 			} finally {
 				this.loading.updateTitle = false
 			}
@@ -540,7 +541,7 @@ export default {
 				}
 			} catch (error) {
 				console.error('onGenerateSessionTitle error:', error)
-				showError(error?.response?.data?.error ?? t('assistant', 'Error generating a title for the conversation'))
+				showError(getErrorMessage(error?.response?.data?.error) ?? t('assistant', 'Error generating a title for the conversation'))
 			} finally {
 				this.loading.titleGeneration = false
 			}
@@ -558,7 +559,7 @@ export default {
 				}
 			} catch (error) {
 				console.error('deleteSession error:', error)
-				showError(error?.response?.data?.error ?? t('assistant', 'Error deleting conversation'))
+				showError(getErrorMessage(error?.response?.data?.error) ?? t('assistant', 'Error deleting conversation'))
 			} finally {
 				this.loading.sessionDelete = false
 				this.sessionIdToDelete = null
@@ -573,7 +574,7 @@ export default {
 			} catch (error) {
 				this.sessions = []
 				console.error('fetchSessions error:', error)
-				showError(error?.response?.data?.error ?? t('assistant', 'Error fetching conversations'))
+				showError(getErrorMessage(error?.response?.data?.error) ?? t('assistant', 'Error fetching conversations'))
 			}
 		},
 
@@ -586,7 +587,7 @@ export default {
 				this.messages = this.messages.filter((message) => message.id !== messageId)
 			} catch (error) {
 				console.error('deleteMessage error:', error)
-				showError(error?.response?.data?.error ?? t('assistant', 'Error deleting message'))
+				showError(getErrorMessage(error?.response?.data?.error) ?? t('assistant', 'Error deleting message'))
 			} finally {
 				this.loading.messageDelete = false
 			}
@@ -647,7 +648,7 @@ export default {
 				this.messages = null
 				this.messagesAxiosController = null
 				console.error('fetchMessages error:', error)
-				showError(error?.response?.data?.error ?? t('assistant', 'Error fetching messages'))
+				showError(getErrorMessage(error?.response?.data?.error) ?? t('assistant', 'Error fetching messages'))
 			}
 		},
 
@@ -685,7 +686,7 @@ export default {
 			} catch (error) {
 				this.loading.newHumanMessage = false
 				console.error('newMessage error:', error)
-				showError(error?.response?.data?.error ?? t('assistant', 'Error creating a new message'))
+				showError(getErrorMessage(error?.response?.data?.error) ?? t('assistant', 'Error creating a new message'))
 			}
 		},
 
@@ -710,7 +711,7 @@ export default {
 			} catch (error) {
 				this.loading.newSession = false
 				console.error('newSession error:', error)
-				showError(error?.response?.data?.error ?? t('assistant', 'Error creating a new conversation'))
+				showError(getErrorMessage(error?.response?.data?.error) ?? t('assistant', 'Error creating a new conversation'))
 			}
 		},
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,24 @@ export function delay(callback, ms = 0) {
 }
 
 /**
+ * Safely extract a displayable error message string.
+ * Prevents [object Object] from being shown to the user when
+ * the API returns a non-string error value.
+ *
+ * @param {*} value The error value to extract a message from
+ * @return {string|undefined} The error message string or undefined
+ */
+export function getErrorMessage(value) {
+	if (typeof value === 'string') {
+		return value
+	}
+	if (value?.message && typeof value.message === 'string') {
+		return value.message
+	}
+	return undefined
+}
+
+/**
  * Parse special symbols in text like &amp; &lt; &gt; &sect;
  * FIXME upstream: https://github.com/nextcloud-libraries/nextcloud-vue/issues/4492
  *

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -49,6 +49,7 @@ import {
 	setNotifyReady,
 } from '../assistant.js'
 import { TASK_STATUS_STRING } from '../constants.js'
+import { getErrorMessage } from '../utils.js'
 
 export default {
 	name: 'AssistantPage',
@@ -152,7 +153,10 @@ export default {
 					this.loading = false
 					this.showSyncTaskRunning = false
 					console.error('Assistant scheduling error', error?.response?.data?.ocs?.data?.message)
-					showError(t('assistant', 'Assistant error') + ': ' + t('assistant', 'Something went wrong when scheduling the task'))
+					showError(
+						t('assistant', 'Assistant error') + ': '
+						+ (getErrorMessage(error?.response?.data?.ocs?.data?.message) ?? t('assistant', 'Something went wrong when scheduling the task')),
+					)
 				})
 				.then(() => {
 				})


### PR DESCRIPTION
Fixes #386

When scheduling a task with invalid input parameters (e.g. a speech generation task with a non-existent voice), the error response from the API can contain a non-string value. Passing this directly to `showError()` causes JavaScript to coerce it to the unintelligible string `[object Object]`.

**Changes:**

- Added `getErrorMessage()` helper in `src/utils.js` that safely extracts a displayable string from error values, returning `undefined` when the value is not a string (so the `??` fallback kicks in properly)
- Applied the helper to all 9 error handlers in `ChattyLLMInputForm.vue` that had the same vulnerable pattern
- Updated the 3 task scheduling error handlers in `assistant.js` and `AssistantPage.vue` to also display the actual server error message instead of only a generic fallback