### PR TITLE
fix: hide "Generate image" file menu action when no provider available

### DIFF
--- a/src/components/FilesNewMenu/generateImageEntry.js
+++ b/src/components/FilesNewMenu/generateImageEntry.js
@@ -6,11 +6,14 @@
 import { defineAsyncComponent } from 'vue'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import { translate as t } from '@nextcloud/l10n'
+import { loadState } from '@nextcloud/initial-state'
 import Creation from '@mdi/svg/svg/creation.svg?raw'
 
 const GenerateImageDialog = defineAsyncComponent(() => import('./GenerateImageDialog.vue'))
 
 export const EntryId = 'assistant-generate-image'
+
+const state = loadState('assistant', 'new-file-generate-image', {})
 
 export const entry = {
 	id: EntryId,
@@ -18,7 +21,7 @@ export const entry = {
 	iconSvgInline: Creation,
 	order: 100,
 	enabled() {
-		return true
+		return state?.hasText2Image ?? false
 	},
 	async handler(context, content) {
 		await spawnDialog(GenerateImageDialog, {


### PR DESCRIPTION
Fixes #421

The "Generate image using AI" action in the Files "New" menu was always visible, even when no text-to-image provider is configured or image generation is disabled.

The backend already provides a `hasText2Image` flag via initial state (`new-file-generate-image`), and the `GenerateImageDialog` component already checks it to show a "no providers" error. But the menu entry's `enabled()` function was hardcoded to `return true`, so the entry always appeared.

Now `enabled()` reads the initial state and returns `false` when `hasText2Image` is not set, hiding the menu entry entirely when image generation is not available.