### PR TITLE
fix: trigger assistant icon animation on keyboard focus

### DIFF
--- a/src/components/icons/AssistantIcon.vue
+++ b/src/components/icons/AssistantIcon.vue
@@ -72,6 +72,18 @@ export default {
   animation: pulse 0.6s ease 0.2s forwards;
 }
 
+button:focus-visible .assistant-icon .star1 {
+  animation: pulse 0.6s ease forwards;
+}
+
+button:focus-visible .assistant-icon .star2 {
+  animation: pulse 0.6s ease 0.1s forwards;
+}
+
+button:focus-visible .assistant-icon .star3 {
+  animation: pulse 0.6s ease 0.2s forwards;
+}
+
 /* No animation to avoid vestibular motion triggers. */
 @media (prefers-reduced-motion: reduce) {
   .assistant-icon:hover .star1 {
@@ -85,34 +97,17 @@ export default {
   .assistant-icon:hover .star3 {
     animation: none;
   }
+
+  button:focus-visible .assistant-icon .star1,
+  button:focus-visible .assistant-icon .star2,
+  button:focus-visible .assistant-icon .star3 {
+    animation: none;
+  }
 }
 
 @keyframes pulse {
   0% { transform: scale(1); }
   50% { transform: scale(1.4); }
   100% { transform: scale(1); }
-}
-</style>
-
-<!-- Unscoped: trigger animation when a parent button receives keyboard focus -->
-<style>
-button:focus-visible .assistant-icon .star1 {
-  animation: pulse 0.6s ease forwards;
-}
-
-button:focus-visible .assistant-icon .star2 {
-  animation: pulse 0.6s ease 0.1s forwards;
-}
-
-button:focus-visible .assistant-icon .star3 {
-  animation: pulse 0.6s ease 0.2s forwards;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  button:focus-visible .assistant-icon .star1,
-  button:focus-visible .assistant-icon .star2,
-  button:focus-visible .assistant-icon .star3 {
-    animation: none;
-  }
 }
 </style>

--- a/src/components/icons/AssistantIcon.vue
+++ b/src/components/icons/AssistantIcon.vue
@@ -85,12 +85,34 @@ export default {
   .assistant-icon:hover .star3 {
     animation: none;
   }
-
 }
 
 @keyframes pulse {
   0% { transform: scale(1); }
   50% { transform: scale(1.4); }
   100% { transform: scale(1); }
+}
+</style>
+
+<!-- Unscoped: trigger animation when a parent button receives keyboard focus -->
+<style>
+button:focus-visible .assistant-icon .star1 {
+  animation: pulse 0.6s ease forwards;
+}
+
+button:focus-visible .assistant-icon .star2 {
+  animation: pulse 0.6s ease 0.1s forwards;
+}
+
+button:focus-visible .assistant-icon .star3 {
+  animation: pulse 0.6s ease 0.2s forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button:focus-visible .assistant-icon .star1,
+  button:focus-visible .assistant-icon .star2,
+  button:focus-visible .assistant-icon .star3 {
+    animation: none;
+  }
 }
 </style>


### PR DESCRIPTION
The star pulse animation on the assistant header icon only triggered on mouse hover. Keyboard users tabbing to the button saw no animation.

Added an unscoped style block with `button:focus-visible` selectors so the same pulse animation plays when the parent button receives keyboard focus. Uses `:focus-visible` (not `:focus`) to avoid firing on mouse clicks. Respects `prefers-reduced-motion`.

### Before vs After (icon zoomed 4x, keyboard focus state)

![focus comparison](https://raw.githubusercontent.com/nextcloud/assistant/a51efe3c/focus_comparison.png)

Before: stars stay static on keyboard focus. After: stars animate (mid-pulse in screenshot).

### Header area (zoomed 2x)

![header comparison](https://raw.githubusercontent.com/nextcloud/assistant/a51efe3c/header_comparison.png)

Verified via computed styles:
- Before: focus state = `animation: none`
- After: focus state = `animation: pulse 0.6s ease forwards`
- Hover still works as before, no regressions

Closes #361

AI-generated PR, second commit added manually