### PR TITLE
fix: normalize millisecond timestamps in chat API

### DIFF
--- a/lib/Controller/ChattyLLMController.php
+++ b/lib/Controller/ChattyLLMController.php
@@ -121,6 +121,9 @@ class ChattyLLMController extends OCSController {
 	#[NoAdminRequired]
 	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['chat_api'])]
 	public function newSession(int $timestamp, ?string $title = null): JSONResponse {
+		if ($timestamp > 10_000_000_000) {
+			$timestamp = intdiv($timestamp, 1000);
+		}
 		if ($this->userId === null) {
 			return new JSONResponse(['error' => $this->l10n->t('User not logged in')], Http::STATUS_UNAUTHORIZED);
 		}
@@ -334,6 +337,9 @@ class ChattyLLMController extends OCSController {
 	public function newMessage(
 		int $sessionId, string $role, string $content, int $timestamp, ?array $attachments = null, bool $firstHumanMessage = false,
 	): JSONResponse {
+		if ($timestamp > 10_000_000_000) {
+			$timestamp = intdiv($timestamp, 1000);
+		}
 		if ($this->userId === null) {
 			return new JSONResponse(['error' => $this->l10n->t('User not logged in')], Http::STATUS_UNAUTHORIZED);
 		}


### PR DESCRIPTION
Thanks to @mpivchev for reporting this and the follow-up suggestion to guard against it server-side.

The chat API endpoints (newSession, newMessage) accept a timestamp parameter from clients but don't validate its unit. If a client sends milliseconds instead of seconds, the value gets stored as-is, causing inconsistent display in the chat UI (dates shown as year ~58000).

The current official frontend is correct (sends seconds), but the API is public and third-party clients can send either format. This adds a simple guard: if the timestamp exceeds 10,000,000,000 (year ~2286 in seconds), it is treated as milliseconds and divided by 1000.

cc @janepie for review

Closes #452