### PR TITLE
fix: use theme-neutral background for agency confirmation card

### DIFF
--- a/src/components/ChattyLLM/AgencyConfirmation.vue
+++ b/src/components/ChattyLLM/AgencyConfirmation.vue
@@ -80,8 +80,13 @@ export default {
 </script>
 
 <style lang="scss">
-.agency-confirmation > div {
-	width: 100%;
+.agency-confirmation {
+	background-color: var(--color-main-background) !important;
+	border: 2px solid var(--color-border-dark) !important;
+
+	> div {
+		width: 100%;
+	}
 }
 </style>
 


### PR DESCRIPTION
Fixes #260

The agency confirmation NcNoteCard in "Chat with AI" uses `type="info"`, which gives it a hardcoded blue background regardless of the server's primary theme color. This looks out of place when the primary color is changed to something non-blue (red, green, etc.).

Per @marcoambrosini's suggestion, this overrides the NcNoteCard background with `--color-main-background` and adds a `--color-border-dark` border for visual separation. The inner action items already use `--color-primary-element-light-hover`, which correctly follows the theme.

**Before** (blue card clashes with red theme):

![before](https://raw.githubusercontent.com/nextcloud/assistant/e7feb2ff/before.png)

**After** (neutral background, follows any theme):

![after](https://raw.githubusercontent.com/nextcloud/assistant/e7feb2ff/after.png)

cc @janepie @marcoambrosini