### PR TITLE
fix: trim leading and trailing whitespace in output fields

### DIFF
--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -12,7 +12,7 @@
 		<NcRichContenteditable
 			:id="id"
 			ref="input"
-			:model-value="value ?? ''"
+			:model-value="isOutput ? formattedValue : (value ?? '')"
 			:link-autocomplete="false"
 			:multiline="isMobile"
 			:maxlength="maxLength"


### PR DESCRIPTION
Fixes #15

LLM outputs often include leading/trailing whitespace and newlines. The `formattedValue` computed property in `TextInput.vue` already does `.trim()`, but it was only used for the copy button and the `hasValue` check -- the actual display still used the raw `value` prop.

This change uses `formattedValue` for the `:model-value` binding when `isOutput` is true, so output fields display trimmed text. Input fields are not affected.

**Before** (empty lines and leading spaces at top of output):

![before](https://raw.githubusercontent.com/nextcloud/assistant/3eaa8eb9fec885bcdbc8ce9c3095f06355d8caa5/before.png)

**After** (text starts immediately, no wasted space):

![after](https://raw.githubusercontent.com/nextcloud/assistant/3eaa8eb9fec885bcdbc8ce9c3095f06355d8caa5/after.png)