### PR TITLE
fix: handle stale enum values when retrying tasks

### DIFF
--- a/src/assistant.js
+++ b/src/assistant.js
@@ -170,8 +170,12 @@ export async function openAssistantForm({
 				.catch(error => {
 					view.loading = false
 					view.showSyncTaskRunning = false
-					console.error('Assistant scheduling error', error?.response?.data?.ocs?.data?.message)
-					showError(t('assistant', 'Assistant error') + ': ' + t('assistant', 'Something went wrong when scheduling the task'))
+					const serverMessage = error?.response?.data?.ocs?.data?.message
+					console.error('Assistant scheduling error', serverMessage)
+					showError(
+						t('assistant', 'Assistant error') + ': '
+						+ (serverMessage || t('assistant', 'Something went wrong when scheduling the task')),
+					)
 				})
 		}
 		modalMountPoint.addEventListener('sync-submit', (data) => {
@@ -612,8 +616,12 @@ export async function openAssistantTask(
 			.catch(error => {
 				view.loading = false
 				view.showSyncTaskRunning = false
-				console.error('Assistant scheduling error', error?.response?.data?.ocs?.data?.message)
-				showError(t('assistant', 'Assistant error') + ': ' + t('assistant', 'Something went wrong when scheduling the task'))
+				const serverMessage = error?.response?.data?.ocs?.data?.message
+				console.error('Assistant scheduling error', serverMessage)
+				showError(
+					t('assistant', 'Assistant error') + ': '
+					+ (serverMessage || t('assistant', 'Something went wrong when scheduling the task')),
+				)
 			})
 	}
 	modalMountPoint.addEventListener('sync-submit', (data) => {

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -532,7 +532,10 @@ export default {
 			this.$emit('action-button-clicked', { button, output: this.myOutputs })
 		},
 		onHistoryTryAgain(e) {
-			this.$emit('try-again', e)
+			// Load the task into the form instead of auto-submitting.
+			// This lets the user review and fix stale enum values (e.g. removed models)
+			// before resubmitting.
+			this.$emit('load-task', e)
 		},
 		onHistoryLoadTask(e) {
 			this.$emit('load-task', e)

--- a/src/components/fields/EnumField.vue
+++ b/src/components/fields/EnumField.vue
@@ -70,6 +70,17 @@ export default {
 	},
 
 	watch: {
+		selectValue: {
+			handler(newVal) {
+				// If the current value doesn't match any available option, clear it.
+				// This handles stale enum values (e.g. a removed model) when loading
+				// a task from history.
+				if (this.value !== null && this.value !== undefined && this.value !== '' && newVal === undefined) {
+					this.$emit('update:value', undefined)
+				}
+			},
+			immediate: true,
+		},
 	},
 
 	mounted() {

--- a/src/components/fields/TaskTypeFields.vue
+++ b/src/components/fields/TaskTypeFields.vue
@@ -130,7 +130,7 @@ export default {
 		getOptionalInputFieldOptions(field, key) {
 			if (field.type === 'Enum'
 				&& this.optionalShapeOptions !== null
-				&& !Array.isArray(this.optionalShapeOptionsshapeOptions)
+				&& !Array.isArray(this.optionalShapeOptions)
 				&& this.optionalShapeOptions[key]
 			) {
 				return this.optionalShapeOptions[key]

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -151,8 +151,12 @@ export default {
 				.catch(error => {
 					this.loading = false
 					this.showSyncTaskRunning = false
-					console.error('Assistant scheduling error', error?.response?.data?.ocs?.data?.message)
-					showError(t('assistant', 'Assistant error') + ': ' + t('assistant', 'Something went wrong when scheduling the task'))
+					const serverMessage = error?.response?.data?.ocs?.data?.message
+					console.error('Assistant scheduling error', serverMessage)
+					showError(
+						t('assistant', 'Assistant error') + ': '
+						+ (serverMessage || t('assistant', 'Something went wrong when scheduling the task')),
+					)
 				})
 				.then(() => {
 				})


### PR DESCRIPTION
Fixes #400

When retrying a task from history whose enum field value (e.g. model, tone) is no longer available, the old code would auto-submit with the stale value and show a generic "Something went wrong" error. The user had no way to fix the input.

Changes:

- **"Try again" from sidebar now loads the task into the form** instead of auto-submitting, so the user can review and fix inputs before resubmitting (`AssistantTextProcessingForm.vue`)
- **Stale enum values are automatically cleared** when the current value doesn't match any available option (`EnumField.vue`). The dropdown shows a placeholder instead of the invalid value.
- **Server validation errors are shown to the user** instead of a generic "Something went wrong" message (`assistant.js`, `AssistantPage.vue`)
- **Fix typo in `getOptionalInputFieldOptions()`** that caused optional enum fields (like model selection in "Advanced options") to never receive dropdown options (`TaskTypeFields.vue` -- `this.optionalShapeOptionsshapeOptions` -> `this.optionalShapeOptions`)

Before/after screenshots will be added in a comment below.