### PR TITLE
prepare 2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.13.0 – 2026-02-19
+
+### Changed
+
+- Only get the tasks of the current user when checking message/title generation tasks @julien-nc [#468](https://github.com/nextcloud/assistant/pull/468)
+
 ## 2.12.0 – 2025-12-17
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -62,7 +62,7 @@ Known providers:
 
 More details on how to set this up in the [admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html)
 ]]>	</description>
-	<version>2.12.0</version>
+	<version>2.13.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Assistant</namespace>


### PR DESCRIPTION
### Changed

- Only get the tasks of the current user when checking message/title generation tasks @julien-nc [#468](https://github.com/nextcloud/assistant/pull/468)