### PR TITLE
IONOS(assistant): feat: add filteredShape computed property to exclud…

### DIFF
--- a/src/components/fields/TaskTypeFields.vue
+++ b/src/components/fields/TaskTypeFields.vue
@@ -4,7 +4,7 @@
 -->
 <template>
 	<div class="task-type-fields">
-		<TaskTypeField v-for="(field, key) in shape"
+		<TaskTypeField v-for="(field, key) in filteredShape"
 			:key="'shape' + key"
 			:field-key="key"
 			:field="field"
@@ -107,6 +107,17 @@ export default {
 				return {}
 			}
 			return this.optionalShape
+		},
+		filteredShape() {
+			// Hide numberOfImages field
+			if (!this.isOutput && this.shape) {
+				const filtered = { ...this.shape }
+				if ('numberOfImages' in filtered) {
+					delete filtered.numberOfImages
+				}
+				return filtered
+			}
+			return this.shape
 		},
 	},
 


### PR DESCRIPTION
This pull request introduces a targeted UI improvement to the `TaskTypeFields` component. The main change is to hide the `numberOfImages` field from the rendered fields when the component is not in output mode. This makes the field display more relevant to the user's context.