### PR TITLE
Fix chat message avatar

### DIFF
--- a/src/components/ChattyLLM/Message.vue
+++ b/src/components/ChattyLLM/Message.vue
@@ -22,7 +22,7 @@
 					:display-name="message.role === 'human' ? displayName : t('assistant', 'Nextcloud Assistant')"
 					:is-no-user="message.role === 'assistant'"
 					:hide-status="true">
-					<template #icon>
+					<template v-if="(message.role === 'human' && newMessageLoading) || message.role === 'assistant'" #icon>
 						<NcLoadingIcon v-if="message.role === 'human' && newMessageLoading" :size="20" />
 						<AssistantIcon v-else-if="message.role === 'assistant'" :size="20" />
 					</template>


### PR DESCRIPTION
The `#icon` template of the message avatar can be empty. It seems like with previous nc/vue releases, this would fall back to `user` or `displayName`. This is not the case anymore so we always use this template.

Solution: only declare the template when we need it. Otherwise keep using the props.