### PR TITLE
fix: hide "Generate image" menu entry when no TextToImage provider is available

### DIFF
--- a/lib/Listener/LoadAdditionalScriptsListener.php
+++ b/lib/Listener/LoadAdditionalScriptsListener.php
@@ -50,8 +50,8 @@ class LoadAdditionalScriptsListener implements IEventListener {
 
 		// New file menu to generate images
 		$isNewFileMenuEnabled = $this->appConfig->getValueInt(Application::APP_ID, 'new_image_file_menu_plugin', 1, lazy: true) === 1;
-		if ($isNewFileMenuEnabled) {
-			$hasText2Image = array_key_exists(TextToImage::ID, $availableTaskTypes);
+		$hasText2Image = array_key_exists(TextToImage::ID, $availableTaskTypes);
+		if ($isNewFileMenuEnabled && $hasText2Image) {
 			$this->initialStateService->provideInitialState('new-file-generate-image', [
 				'hasText2Image' => $hasText2Image,
 			]);


### PR DESCRIPTION
## Summary

The "Generate image using AI" entry in the Files "New" menu was appearing even when no `TextToImage` task processing provider was registered. This led users to a dead-end dialog showing the feature is unavailable.

## Changes

**`lib/Listener/LoadAdditionalScriptsListener.php`**: Move the `$hasText2Image` check into the `if` condition so the `filesNewMenu` script is only loaded when a TextToImage provider is actually available.

Before:
```php
if ($isNewFileMenuEnabled) {
    $hasText2Image = array_key_exists(TextToImage::ID, $availableTaskTypes);
    // script always loaded regardless of $hasText2Image
```

After:
```php
$hasText2Image = array_key_exists(TextToImage::ID, $availableTaskTypes);
if ($isNewFileMenuEnabled && $hasText2Image) {
    // script only loaded when provider exists
```

Fixes #505