### PR TITLE
Prepare v3.4.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # App maintainer
-/appinfo/info.xml    @julien-nc @marcelklehr
+/appinfo/info.xml    @janepie @julien-nc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 3.4.0 - 2026-04-27
+
+### Added
+- Make the modal non modal @julien-nc [#507](https://github.com/nextcloud/assistant/pull/507)
+- Upload files on drop in MediaField and ListOfMediaField @julien-nc [#435](https://github.com/nextcloud/assistant/pull/435)
+- Show provider information in the UI @zainabnaseer1164 [#483](https://github.com/nextcloud/assistant/pull/483)
+
+### Changed
+- Extend the list of translated tool labels and associated icons @marcelklehr [#509](https://github.com/nextcloud/assistant/pull/509)
+- updated dependencies
+- Put provider names in a popover @julien-nc [#501](https://github.com/nextcloud/assistant/pull/501)
+- Less task deletion @julien-nc [#498](https://github.com/nextcloud/assistant/pull/498)
+- lazy loading appconfigs @janepie [#478](https://github.com/nextcloud/assistant/pull/478)
+
+### Fixed
+- trigger assistant icon animation on keyboard focus @bigcat88 @janepie [#462](https://github.com/nextcloud/assistant/pull/462)
+- hide "Generate image" file menu action when no provider available @bigcat88 [#460](https://github.com/nextcloud/assistant/pull/460)
+- normalize millisecond timestamps in chat API @bigcat88 [#463](https://github.com/nextcloud/assistant/pull/463)
+- Fix chat message avatar @julien-nc [#496](https://github.com/nextcloud/assistant/pull/496)
+- Fix modal being too large in narrow screens @julien-nc [#490](https://github.com/nextcloud/assistant/pull/490)
+
+
 ## 3.3.0 - 2026-02-19
 
 ### Added
@@ -22,7 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Restrict the task type list when invoking the assistant from the picker @julien-nc [#457](https://github.com/nextcloud/assistant/pull/457)
 - Only get the tasks of the current user when checking message/title generation tasks @julien-nc [#467](https://github.com/nextcloud/assistant/pull/467)
 
-### Fix
+### Fixed
 
 - Fix(ChattyLLM): Fix title generation to work with languages other than english @marcelklehr [#451](https://github.com/nextcloud/assistant/pull/451)
 - Make summary service appId for the task specific @janepie [#456](https://github.com/nextcloud/assistant/pull/456)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -62,7 +62,7 @@ Known providers:
 
 More details on how to set this up in the [admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html)
 ]]>	</description>
-	<version>3.3.1-dev.0</version>
+	<version>3.4.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Assistant</namespace>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant",
-  "version": "3.2.0",
+  "version": "3.4.0",
   "description": "Nextcloud Assistant",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Added
- Make the modal non modal @julien-nc [#507](https://github.com/nextcloud/assistant/pull/507)
- Upload files on drop in MediaField and ListOfMediaField @julien-nc [#435](https://github.com/nextcloud/assistant/pull/435)
- Show provider information in the UI @zainabnaseer1164 [#483](https://github.com/nextcloud/assistant/pull/483)

### Changed
- Extend the list of translated tool labels and associated icons @marcelklehr [#509](https://github.com/nextcloud/assistant/pull/509)
- updated dependencies
- Put provider names in a popover @julien-nc [#501](https://github.com/nextcloud/assistant/pull/501)
- Less task deletion @julien-nc [#498](https://github.com/nextcloud/assistant/pull/498)
- lazy loading appconfigs @janepie [#478](https://github.com/nextcloud/assistant/pull/478)

### Fixed
- trigger assistant icon animation on keyboard focus @bigcat88 @janepie [#462](https://github.com/nextcloud/assistant/pull/462)
- hide "Generate image" file menu action when no provider available @bigcat88 [#460](https://github.com/nextcloud/assistant/pull/460)
- normalize millisecond timestamps in chat API @bigcat88 [#463](https://github.com/nextcloud/assistant/pull/463)
- Fix chat message avatar @julien-nc [#496](https://github.com/nextcloud/assistant/pull/496)
- Fix modal being too large in narrow screens @julien-nc [#490](https://github.com/nextcloud/assistant/pull/490)
