### PR TITLE
[stable32] fix: remove duplicate DuckDuckGo tool

### DIFF
--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -141,7 +141,6 @@ class AssistantService {
 			'list_decks' => $this->l10n->t('Nextcloud Deck'),
 			'list_forms' => $this->l10n->t('List forms'),
 			'list_messages_in_conversation' => $this->l10n->t('Nextcloud Talk'),
-			'duckduckgo_results_json' => $this->l10n->t('DuckDuckGo web search'),
 		];
 	}
 


### PR DESCRIPTION
Removed duplicated DuckDuckGo results localization from the service.