### PR TITLE
Fix UI issues

### DIFF
--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -214,6 +214,8 @@ export default {
 	resize: both;
 	overflow: hidden;
 	filter: drop-shadow(0 0 15px rgba(77, 77, 77, 0.5));
+	color: var(--color-main-text);
+	background-color: var(--color-main-background);
 }
 
 .assistant-modal .p-dialog-header {

--- a/src/components/fields/AudioDisplay.vue
+++ b/src/components/fields/AudioDisplay.vue
@@ -78,6 +78,7 @@ export default {
 
 <style scoped lang="scss">
 audio {
+	overflow: auto;
 	border-radius: 100px;
 	&.shadowed {
 		border: 2px solid var(--color-primary-element);


### PR DESCRIPTION
* Small visual bug on browsers that render a rectangle audio player for <audio> tags (firefox)
* Set the color and background-color on the assistant modal dialog so it is inherited correctly by sub elements

With a dark system theme and the light theme enabled in NC:

| Before | After |
| --- | --- |
|<img width="1312" height="629" alt="image" src="https://github.com/user-attachments/assets/f0dbc007-2c8e-4fc7-ab61-cec0d7101b34" /> | <img width="1312" height="629" alt="image" src="https://github.com/user-attachments/assets/1fb38324-18d6-4886-a20f-215eb1ab1f0a" /> |
| <img width="609" height="270" alt="image" src="https://github.com/user-attachments/assets/48ffc226-cd31-4baf-9c5d-4b9f5f70385d" /> | <img width="614" height="273" alt="image" src="https://github.com/user-attachments/assets/e359b516-ae62-4a19-b575-df167a2aa04a" /> |

