### PR TITLE
Prepare release v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 3.4.1 - 2026-05-04
+
+### Fixed
+- l10n: Use "teams" instead of the old "circles" @marcelklehr [#514](https://github.com/nextcloud/assistant/pull/514)
+- UI issues @julien-nc [#519](https://github.com/nextcloud/assistant/pull/519)
+- remove the dailog border @julien-nc [#520](https://github.com/nextcloud/assistant/pull/520)
+
 ## 3.4.0 - 2026-04-27
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -62,7 +62,7 @@ Known providers:
 
 More details on how to set this up in the [admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html)
 ]]>	</description>
-	<version>3.4.0</version>
+	<version>3.4.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Assistant</namespace>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Nextcloud Assistant",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Fixed
- l10n: Use "teams" instead of the old "circles" @marcelklehr [#514](https://github.com/nextcloud/assistant/pull/514)
- UI issues @julien-nc [#519](https://github.com/nextcloud/assistant/pull/519)
- remove the dailog border @julien-nc [#520](https://github.com/nextcloud/assistant/pull/520)