### PR TITLE
fix(assistant): render markdown in TextInput output

### DIFF
--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -13,6 +13,7 @@
 			v-if="isOutput && hasValue && !isEditing"
 			ref="richText"
 			class="rendered-output output-wrapper"
+			:class="{ streaming: isOutput && streaming() }"
 			:title="t('assistant', 'Double-click to edit')"
 			:text="value ?? ''"
 			:use-markdown="true"
@@ -353,8 +354,14 @@ body[dir="rtl"] .output-buttons {
 	.shadowed.streaming .rich-contenteditable__input {
 		animation: pulse 2s infinite;
 	}
+	.output-wrapper.streaming {
+		animation: pulse 2s infinite;
+	}
 	@media (prefers-reduced-motion: reduce) {
 		.shadowed.streaming .rich-contenteditable__input {
+			animation: none;
+		}
+		.output-wrapper.streaming {
 			animation: none;
 		}
 	}

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -9,7 +9,16 @@
 			<br v-if="limitLabel">
 			{{ limitLabel ?? '' }}
 		</label>
+		<NcRichText
+			v-if="isOutput && hasValue && !isEditing"
+			class="rendered-output output-wrapper"
+			:title="t('assistant', 'Double-click to edit')"
+			:text="value ?? ''"
+			:use-markdown="true"
+			:autolink="true"
+			@dblclick="enterEditMode" />
 		<NcRichContenteditable
+			v-else
 			:id="id"
 			ref="input"
 			:model-value="value ?? ''"
@@ -21,7 +30,8 @@
 			:placeholder="placeholder"
 			:title="title"
 			@submit="hasValue && $emit('submit', $event)"
-			@update:model-value="$emit('update:value', $event)" />
+			@update:model-value="$emit('update:value', $event)"
+			@blur="onEditableBlur" />
 		<div v-if="isOutput && hasValue"
 			class="output-buttons">
 			<NcButton v-if="!streaming() && canImproveOutput"
@@ -73,6 +83,7 @@ import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcRichContenteditable from '@nextcloud/vue/components/NcRichContenteditable'
 import { NcLoadingIcon } from '@nextcloud/vue'
+import { NcRichText } from '@nextcloud/vue/components/NcRichText'
 
 import isMobile from '../../mixins/isMobile.js'
 
@@ -98,6 +109,7 @@ export default {
 
 	components: {
 		NcRichContenteditable,
+		NcRichText,
 		NcButton,
 		NcLoadingIcon,
 		FileDocumentOutlineIcon,
@@ -156,6 +168,7 @@ export default {
 	data() {
 		return {
 			copied: false,
+			isEditing: false,
 			maxLength: MAX_TEXT_INPUT_LENGTH,
 		}
 	},
@@ -233,6 +246,39 @@ export default {
 				showError(t('assistant', 'Result could not be copied to clipboard'))
 			}
 		},
+		enterEditMode() {
+			if (!this.isOutput) {
+				return
+			}
+			this.isEditing = true
+			this.$nextTick(() => {
+				const ref = this.$refs.input
+				if (!ref) {
+					return
+				}
+				if (typeof ref.focus === 'function') {
+					ref.focus()
+					return
+				}
+				const el = ref.$el
+				if (!el) {
+					return
+				}
+				if (typeof el.focus === 'function') {
+					el.focus()
+					return
+				}
+				const editable = el.querySelector?.('[contenteditable]')
+				if (editable && typeof editable.focus === 'function') {
+					editable.focus()
+				}
+			})
+		},
+		onEditableBlur() {
+			if (this.isOutput && this.isEditing) {
+				this.isEditing = false
+			}
+		},
 	},
 }
 </script>
@@ -272,6 +318,20 @@ body[dir="rtl"] .output-buttons {
 		bottom: 2px;
 	}
 
+	.output-wrapper {
+		display: block !important;
+		box-sizing: border-box !important;
+		border: 2px solid var(--color-primary-element) !important;
+		border-radius: var(--border-radius-large) !important;
+		padding: 8px !important;
+		padding-bottom: 42px !important;
+		max-height: 35vh !important;
+		overflow-y: auto !important;
+		.rendered-output, .rendered-output * {
+			cursor: text;
+		}
+	}
+
 	.rich-contenteditable__input {
 		min-height: calc(var(--default-clickable-area) * 3 + 4px);
 		padding-top: 5px !important;
@@ -280,6 +340,7 @@ body[dir="rtl"] .output-buttons {
 	.shadowed .rich-contenteditable__input {
 		border: 2px solid var(--color-primary-element);
 		padding-bottom: 38px !important;
+		max-height: 35vh !important;
 	}
 	.shadowed.streaming .rich-contenteditable__input {
 		animation: pulse 2s infinite;

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -325,6 +325,7 @@ body[dir="rtl"] .output-buttons {
 		border-radius: var(--border-radius-large) !important;
 		padding: 8px !important;
 		padding-bottom: 42px !important;
+		min-height: calc(var(--default-clickable-area) * 3 + 4px);
 		max-height: 35vh !important;
 		overflow-y: auto !important;
 		.rendered-output, .rendered-output * {

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -11,6 +11,7 @@
 		</label>
 		<NcRichText
 			v-if="isOutput && hasValue && !isEditing"
+			ref="richText"
 			class="rendered-output output-wrapper"
 			:title="t('assistant', 'Double-click to edit')"
 			:text="value ?? ''"
@@ -196,10 +197,16 @@ export default {
 			if (!this.streaming()) {
 				return
 			}
-			const scrollableArea = this.$refs.input?.$el?.querySelector('#' + this.id)
-			if (scrollableArea) {
-				scrollableArea.scrollTo(0, scrollableArea.scrollHeight)
-			}
+			this.$nextTick(() => {
+				const scrollableArea = this.$refs.input?.$el?.querySelector('#' + this.id)
+				if (scrollableArea) {
+					scrollableArea.scrollTo(0, scrollableArea.scrollHeight)
+				}
+				const richText = this.$refs.richText?.$el
+				if (richText) {
+					richText.scrollTo(0, richText.scrollHeight)
+				}
+			})
 		},
 	},
 


### PR DESCRIPTION
## Summary

The assistant's "generate text" form currently displays its output through NcRichContenteditable, which renders text as-is. When the underlying LLM returns markdown (heading, lists, tables, bold, links), the user sees raw markdown syntax instead of formatted content.

This PR wraps the output field in NcRichText when isOutput is true, falling back to NcRichContenteditable for the input case. Headings, lists, bold, italic, code blocks and links are now rendered. Tables are not rendered due to the markdown-it configuration of NcRichText in @nextcloud/vue, which does not enable the table plugin by default. The copy still functions and keeps the markdown as expected.

## Screenshots

**Before**
<img width="1214" height="843" alt="Screenshot_20260513_102348" src="https://github.com/user-attachments/assets/7a04975c-2120-4ded-9965-1427e4775241" />

**After**
<img width="1209" height="835" alt="Screenshot_20260513_130308" src="https://github.com/user-attachments/assets/3b61fd17-b509-4a88-b626-41ab3240d15e" />
