### PR TITLE
Streaming responses

### DIFF
--- a/lib/Controller/ChattyLLMController.php
+++ b/lib/Controller/ChattyLLMController.php
@@ -601,7 +601,14 @@ class ChattyLLMController extends OCSController {
 		} elseif ($task->getstatus() === Task::STATUS_RUNNING || $task->getstatus() === Task::STATUS_SCHEDULED) {
 			$startTime = $task->getStartedAt() ?? time();
 			$slowPickup = ($task->getScheduledAt() + (60 * 5)) < $startTime;
-			return new JSONResponse(['task_status' => $task->getstatus(), 'slow_pickup' => $slowPickup], Http::STATUS_EXPECTATION_FAILED);
+			$responsePayload = [
+				'task_status' => $task->getstatus(),
+				'slow_pickup' => $slowPickup,
+			];
+			if ($task->getstatus() === Task::STATUS_RUNNING) {
+				$responsePayload['task_output'] = $task->getOutput();
+			}
+			return new JSONResponse($responsePayload, Http::STATUS_EXPECTATION_FAILED);
 		} elseif ($task->getstatus() === Task::STATUS_FAILED || $task->getstatus() === Task::STATUS_CANCELLED) {
 			return new JSONResponse(['error' => 'task_failed_or_canceled', 'task_status' => $task->getstatus()], Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Controller/ChattyLLMController.php
+++ b/lib/Controller/ChattyLLMController.php
@@ -550,7 +550,7 @@ class ChattyLLMController extends OCSController {
 	 *
 	 * @param int $taskId The message generation task ID
 	 * @param int $sessionId The chat session ID
-	 * @return JSONResponse<Http::STATUS_OK, AssistantChatAgencyMessage, array{}>|JSONResponse<Http::STATUS_EXPECTATION_FAILED, array{task_status: int, slow_pickup: bool}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_UNAUTHORIZED|Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+	 * @return JSONResponse<Http::STATUS_OK, AssistantChatAgencyMessage, array{}>|JSONResponse<Http::STATUS_EXPECTATION_FAILED, array{task_status: int, slow_pickup: bool, task_output?: array<string, list<numeric|string>|numeric|string>|null}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_UNAUTHORIZED|Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND, array{error: string}, array{}>
 	 * @throws MultipleObjectsReturnedException
 	 * @throws \OCP\DB\Exception
 	 *

--- a/lib/Service/ChatService.php
+++ b/lib/Service/ChatService.php
@@ -653,6 +653,7 @@ class ChatService {
 			$input['memories'] = $this->sessionSummaryService->getMemories($userId);
 		}
 		$task = new Task(TextToTextChat::ID, $input, Application::APP_ID . ':chatty-llm', $userId, $customId);
+		$task->setPreferStreaming(true);
 		try {
 			$this->taskProcessingManager->scheduleTask($task);
 		} catch (PreConditionNotMetException $e) {
@@ -700,6 +701,7 @@ class ChatService {
 			$userId,
 			$customId
 		);
+		$task->setPreferStreaming(true);
 		try {
 			$this->taskProcessingManager->scheduleTask($task);
 		} catch (PreConditionNotMetException $e) {

--- a/lib/Service/ChatService.php
+++ b/lib/Service/ChatService.php
@@ -653,6 +653,7 @@ class ChatService {
 			$input['memories'] = $this->sessionSummaryService->getMemories($userId);
 		}
 		$task = new Task(TextToTextChat::ID, $input, Application::APP_ID . ':chatty-llm', $userId, $customId);
+		/** @psalm-suppress UndefinedMethod */
 		$task->setPreferStreaming(true);
 		try {
 			$this->taskProcessingManager->scheduleTask($task);
@@ -701,6 +702,7 @@ class ChatService {
 			$userId,
 			$customId
 		);
+		/** @psalm-suppress UndefinedMethod */
 		$task->setPreferStreaming(true);
 		try {
 			$this->taskProcessingManager->scheduleTask($task);

--- a/openapi.json
+++ b/openapi.json
@@ -4874,6 +4874,33 @@
                                         },
                                         "slow_pickup": {
                                             "type": "boolean"
+                                        },
+                                        "task_output": {
+                                            "type": "object",
+                                            "nullable": true,
+                                            "additionalProperties": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            }
                                         }
                                     }
                                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nextcloud/initial-state": "^3.0.0",
         "@nextcloud/l10n": "^3.4.0",
         "@nextcloud/moment": "^1.3.1",
+        "@nextcloud/notify_push": "^1.4.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/vue": "^9.0.0-rc.5",
         "@primeuix/themes": "^2.0.3",
@@ -2871,27 +2872,27 @@
       }
     },
     "node_modules/@nextcloud/auth": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.5.3.tgz",
-      "integrity": "sha512-KIhWLk0BKcP4hvypE4o11YqKOPeFMfEFjRrhUUF+h7Fry+dhTBIEIxuQPVCKXMIpjTDd8791y8V6UdRZ2feKAQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.6.0.tgz",
+      "integrity": "sha512-VkT87+9UqpPi7O36bVEE4/MxWF8d90VQcuMlvKltsZyLSLkEGrPXgowtD75Y54k60/8SR6mXbeqBwapi8dDUbA==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/browser-storage": "^0.5.0",
-        "@nextcloud/event-bus": "^3.3.2"
+        "@nextcloud/event-bus": "^3.3.3",
+        "@nextcloud/router": "^3.1.0"
       },
       "engines": {
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/axios": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.2.tgz",
-      "integrity": "sha512-8frJb77jNMbz00TjsSqs1PymY0nIEbNM4mVmwen2tXY7wNgRai6uXilIlXKOYB9jR/F/HKRj6B4vUwVwZbhdbw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.6.0.tgz",
+      "integrity": "sha512-ehcIgyora8DAJ+STG6iFI4e+ufPVFrIA6o0FgMKeKdfyaxRJ9UM7L+n7V+rc/qv8sDiWC/hWIKwFtLw2W5yE4Q==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/auth": "^2.5.1",
-        "@nextcloud/router": "^3.0.1",
-        "axios": "^1.12.2"
+        "@nextcloud/auth": "^2.6.0",
+        "axios": "^1.15.0"
       },
       "engines": {
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
@@ -3171,6 +3172,17 @@
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"
+      }
+    },
+    "node_modules/@nextcloud/notify_push": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/notify_push/-/notify_push-1.4.0.tgz",
+      "integrity": "sha512-07UDgz1xLG9XABP8+mwQ2CsNWZu6lKzz0ErUA2HfE1ZfxXKiwVpo60t30y34UExGB9+Ok1nFaYU8fyJHncz9aQ==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@nextcloud/axios": "^2.6.0",
+        "@nextcloud/capabilities": "^1.2.1",
+        "@nextcloud/event-bus": "^3.3.3"
       }
     },
     "node_modules/@nextcloud/paths": {
@@ -5859,14 +5871,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -8667,9 +8679,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -12303,10 +12315,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@nextcloud/initial-state": "^3.0.0",
     "@nextcloud/l10n": "^3.4.0",
     "@nextcloud/moment": "^1.3.1",
+    "@nextcloud/notify_push": "^1.4.0",
     "@nextcloud/router": "^3.0.0",
     "@nextcloud/vue": "^9.0.0-rc.5",
     "@primeuix/themes": "^2.0.3",

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -124,6 +124,31 @@ export async function openAssistantForm({
 		const view = app.mount(modalMountPoint)
 		let lastTask = null
 
+		// notify push stuff
+		const isListeningTo = {}
+		// listen only if needed
+		// return true if notify_push is available
+		// we can't cleanup isListeningTo because there is no way to remove a handler with @nextcloud/notify_push
+		const listenToTaskNotifications = (pushTaskId) => {
+			if (isListeningTo[pushTaskId]) {
+				return true
+			}
+			// attempt to listen to push notifications to get the intermediate output
+			const pushChannel = 'task_' + pushTaskId
+			const hasPush = listen(pushChannel, (type, body) => {
+				console.debug('[assistant] received push notification', type, body)
+				if (pushTaskId === view.selectedTaskId) {
+					view.outputs = body
+				} else {
+					console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', view.selectedTaskId)
+				}
+			})
+			if (hasPush) {
+				isListeningTo[pushTaskId] = true
+			}
+			return hasPush
+		}
+
 		modalMountPoint.addEventListener('cancel', () => {
 			cancelTaskPolling()
 			app.unmount()
@@ -147,17 +172,7 @@ export async function openAssistantForm({
 					view.selectedTaskId = lastTask?.id
 					view.expectedRuntime = (lastTask?.completionExpectedAt - lastTask?.scheduledAt) || null
 
-					// attempt to listen to push notifications to get the intermediate output
-					const pushTaskId = task.id
-					const pushChannel = 'task_' + pushTaskId
-					const hasPush = listen(pushChannel, (type, body) => {
-						console.debug('[assistant] received push notification', type, body)
-						if (pushTaskId === view.selectedTaskId) {
-							view.outputs = body
-						} else {
-							console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', view.selectedTaskId)
-						}
-					})
+					const hasPush = listenToTaskNotifications(task.id)
 					console.debug('[assistant] HAS PUSH', hasPush)
 
 					// no need to update the task output with polling if we have push notifications
@@ -256,7 +271,10 @@ export async function openAssistantForm({
 					view.progress = null
 					view.expectedRuntime = (updatedTask?.completionExpectedAt - updatedTask?.scheduledAt) || null
 
-					pollTask(updatedTask.id, view).then(finishedTask => {
+					const hasPush = listenToTaskNotifications(task.id)
+					console.debug('[assistant] HAS PUSH', hasPush)
+
+					pollTask(updatedTask.id, view, !hasPush).then(finishedTask => {
 						console.debug('pollTask.then', finishedTask)
 						if (finishedTask.status === TASK_STATUS_STRING.successful) {
 							view.outputs = finishedTask?.output

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -136,6 +136,7 @@ export async function openAssistantForm({
 			view.progress = null
 			view.expectedRuntime = null
 			view.inputs = inputs
+			view.outputs = null
 			view.selectedTaskTypeId = taskTypeId
 
 			scheduleTask(appId, newTaskCustomId, taskTypeId, inputs)
@@ -323,11 +324,12 @@ function updateTask(task, object) {
 	}
 	object.taskStatus = task?.status
 	object.scheduledAt = task?.scheduledAt
+	object.outputs = task?.output
 }
 
 export async function pollTask(taskId, obj, callback = updateTask) {
 	return new Promise((resolve, reject) => {
-		window.assistantPollTimerId = setInterval(() => {
+		const pollOnce = () => {
 			getTask(taskId).then(response => {
 				const task = response.data?.ocs?.data?.task
 				if (window.assistantPollTimerId === null) {
@@ -353,7 +355,10 @@ export async function pollTask(taskId, obj, callback = updateTask) {
 				}
 				reject(new Error('pollTask request failed'))
 			})
-		}, 2000)
+		}
+		// start polling immediately
+		// pollOnce()
+		window.assistantPollTimerId = setInterval(pollOnce, 2000)
 	})
 }
 
@@ -606,6 +611,7 @@ export async function openAssistantTask(
 		view.isNotifyEnabled = false
 		view.expectedRuntime = null
 		view.inputs = inputs
+		view.outputs = null
 		view.selectedTaskTypeId = taskTypeId
 
 		scheduleTask('assistant', newTaskCustomId, taskTypeId, inputs)

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -257,6 +257,7 @@ export async function openAssistantForm({
 			view.showSyncTaskRunning = false
 			view.isNotifyEnabled = false
 			view.loading = false
+			view.taskStatus = task.status
 
 			view.selectedTaskTypeId = task.type
 			view.inputs = task.input
@@ -273,6 +274,7 @@ export async function openAssistantForm({
 						view.inputs = updatedTask.input
 						view.outputs = updatedTask.status === TASK_STATUS_STRING.successful ? updatedTask.output : null
 						view.selectedTaskId = updatedTask.id
+						view.taskStatus = updatedTask.status
 						lastTask = updatedTask
 						return
 					}
@@ -340,6 +342,7 @@ export async function openAssistantForm({
 			view.isNotifyEnabled = false
 			view.outputs = null
 			view.selectedTaskId = null
+			view.taskStatus = null
 			lastTask = null
 		})
 		modalMountPoint.addEventListener('background-notify', (data) => {
@@ -768,6 +771,7 @@ export async function openAssistantTask(
 		view.showSyncTaskRunning = false
 		view.isNotifyEnabled = false
 		view.loading = false
+		view.taskStatus = task.status
 
 		view.selectedTaskTypeId = task.type
 		view.inputs = task.input
@@ -784,6 +788,7 @@ export async function openAssistantTask(
 					view.inputs = updatedTask.input
 					view.outputs = updatedTask.status === TASK_STATUS_STRING.successful ? updatedTask.output : null
 					view.selectedTaskId = updatedTask.id
+					view.taskStatus = updatedTask.status
 					lastTask = updatedTask
 					return
 				}
@@ -850,6 +855,7 @@ export async function openAssistantTask(
 		view.isNotifyEnabled = false
 		view.outputs = null
 		view.selectedTaskId = null
+		view.taskStatus = null
 		lastTask = null
 	})
 	modalMountPoint.addEventListener('background-notify', (data) => {

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -8,6 +8,7 @@ import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import PrimeVue from 'primevue/config'
 import Aura from '@primeuix/themes/aura'
+import { listen } from '@nextcloud/notify_push'
 
 window.assistantPollTimerId = null
 
@@ -146,7 +147,21 @@ export async function openAssistantForm({
 					view.selectedTaskId = lastTask?.id
 					view.expectedRuntime = (lastTask?.completionExpectedAt - lastTask?.scheduledAt) || null
 
-					pollTask(task.id, view).then(finishedTask => {
+					// attempt to listen to push notifications to get the intermediate output
+					const pushTaskId = task.id
+					const pushChannel = 'task_' + pushTaskId
+					const hasPush = listen(pushChannel, (type, body) => {
+						console.debug('[assistant] received push notification', type, body)
+						if (pushTaskId === view.selectedTaskId) {
+							view.outputs = body
+						} else {
+							console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', view.selectedTaskId)
+						}
+					})
+					console.debug('[assistant] HAS PUSH', hasPush)
+
+					// no need to update the task output with polling if we have push notifications
+					pollTask(task.id, view, !hasPush).then(finishedTask => {
 						console.debug('pollTask.then', finishedTask)
 						if (finishedTask.status === TASK_STATUS_STRING.successful) {
 							if (closeOnResult) {
@@ -320,16 +335,28 @@ export async function openAssistantForm({
 	})
 }
 
-function updateTask(task, object) {
+function updateTask(task, object, updateOutput = true) {
 	if (task?.status === TASK_STATUS_STRING.running) {
 		object.progress = task?.progress * 100
 	}
 	object.taskStatus = task?.status
 	object.scheduledAt = task?.scheduledAt
-	object.outputs = task?.output
+	if (updateOutput) {
+		console.debug('[assistant] polling update output')
+		object.outputs = task?.output
+	}
 }
 
-export async function pollTask(taskId, obj, callback = updateTask) {
+/**
+ * Poll the task to update its status
+ *
+ * @param {number} taskId the task ID
+ * @param {object} obj the object to update
+ * @param {boolean} updateOutput whether to update the task output from the polling data or not
+ * @param {Function} callback the function to call to update the object
+ * @return {Promise<*>}
+ */
+export async function pollTask(taskId, obj, updateOutput = true, callback = updateTask) {
 	return new Promise((resolve, reject) => {
 		const pollOnce = () => {
 			getTask(taskId).then(response => {
@@ -339,7 +366,7 @@ export async function pollTask(taskId, obj, callback = updateTask) {
 					return
 				}
 				if (obj) {
-					callback(task, obj)
+					callback(task, obj, updateOutput)
 				}
 				if (![TASK_STATUS_STRING.scheduled, TASK_STATUS_STRING.running].includes(task?.status)) {
 					// stop polling
@@ -622,7 +649,21 @@ export async function openAssistantTask(
 				lastTask = task
 				view.selectedTaskId = lastTask?.id
 				view.expectedRuntime = (lastTask?.completionExpectedAt - lastTask?.scheduledAt) || null
-				pollTask(task.id, view).then(finishedTask => {
+
+				// attempt to listen to push notifications to get the intermediate output
+				const pushTaskId = task.id
+				const pushChannel = 'task_' + pushTaskId
+				const hasPush = listen(pushChannel, (type, body) => {
+					console.debug('[assistant] received push notification', type, body)
+					if (pushTaskId === view.selectedTaskId) {
+						view.outputs = body
+					} else {
+						console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', view.selectedTaskId)
+					}
+				})
+				console.debug('[assistant] HAS PUSH', hasPush)
+
+				pollTask(task.id, view, !hasPush).then(finishedTask => {
 					if (finishedTask.status === TASK_STATUS_STRING.successful) {
 						view.outputs = finishedTask?.output
 					} else if (finishedTask.status === TASK_STATUS_STRING.failed) {

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -488,6 +488,7 @@ export async function scheduleTask(appId, customId, taskType, inputs) {
 		type: taskType,
 		appId,
 		customId,
+		preferStreaming: true,
 	}
 	return axios.post(url, params, { signal: window.assistantAbortController.signal })
 }

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -129,6 +129,7 @@ export async function openAssistantForm({
 		// listen only if needed
 		// return true if notify_push is available
 		// we can't cleanup isListeningTo because there is no way to remove a handler with @nextcloud/notify_push
+		// TODO cleanup the handlers when we know we don't wanna listen anymore to a channel (task finished, failed...)
 		const listenToTaskNotifications = (pushTaskId) => {
 			if (isListeningTo[pushTaskId]) {
 				return true

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -304,6 +304,8 @@ export async function openAssistantForm({
 				view.loading = false
 				view.showSyncTaskRunning = false
 				view.selectedTaskId = null
+				view.outputs = null
+				view.taskStatus = null
 				lastTask = null
 			})
 		})
@@ -769,6 +771,8 @@ export async function openAssistantTask(
 			view.loading = false
 			view.showSyncTaskRunning = false
 			view.selectedTaskId = null
+			view.outputs = null
+			view.taskStatus = null
 			lastTask = null
 		})
 	})

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { TASK_STATUS_STRING } from './constants.js'
+import { TASK_STATUS_STRING, TASK_STATUS_INT } from './constants.js'
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import PrimeVue from 'primevue/config'
@@ -11,6 +11,22 @@ import Aura from '@primeuix/themes/aura'
 import { listen } from '@nextcloud/notify_push'
 
 window.assistantPollTimerId = null
+
+listen('task_update', (type, body) => {
+	console.debug('[assistant] received task update push notification', type, body)
+	const newStatus = body.new_status
+	const taskId = body.task_id
+	if (newStatus === TASK_STATUS_INT.successful) {
+		// when a task successfully finished, we want to update its status AND output
+		// in case it is not the currently selected task
+		getTask(taskId).then(response => {
+			const task = response.data?.ocs?.data?.task
+			emit('assistant:task:updated', task)
+		})
+	} else {
+		emit('assistant:task:status:updated', { taskId, status: newStatus })
+	}
+})
 
 /**
  * Creates an assistant modal and return a promise which provides the result

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -12,7 +12,7 @@ import { listen } from '@nextcloud/notify_push'
 
 window.assistantPollTimerId = null
 
-listen('task_update', (type, body) => {
+listen('taskprocessing:task_update', (type, body) => {
 	console.debug('[assistant] received task update push notification', type, body)
 	const newStatus = body.new_status
 	const taskId = body.task_id
@@ -151,7 +151,7 @@ export async function openAssistantForm({
 				return true
 			}
 			// attempt to listen to push notifications to get the intermediate output
-			const pushChannel = 'task_' + pushTaskId
+			const pushChannel = 'taskprocessing:task_id_' + pushTaskId
 			const hasPush = listen(pushChannel, (type, body) => {
 				console.debug('[assistant] received push notification', type, body)
 				if (pushTaskId === view.selectedTaskId) {
@@ -659,7 +659,7 @@ export async function openAssistantTask(
 			return true
 		}
 		// attempt to listen to push notifications to get the intermediate output
-		const pushChannel = 'task_' + pushTaskId
+		const pushChannel = 'taskprocessing:task_id_' + pushTaskId
 		const hasPush = listen(pushChannel, (type, body) => {
 			console.debug('[assistant] received push notification', type, body)
 			if (pushTaskId === view.selectedTaskId) {

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -138,7 +138,7 @@ export async function openAssistantForm({
 			const hasPush = listen(pushChannel, (type, body) => {
 				console.debug('[assistant] received push notification', type, body)
 				if (pushTaskId === view.selectedTaskId) {
-					view.outputs = body
+					view.outputs = body ?? null
 				} else {
 					console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', view.selectedTaskId)
 				}
@@ -646,7 +646,7 @@ export async function openAssistantTask(
 		const hasPush = listen(pushChannel, (type, body) => {
 			console.debug('[assistant] received push notification', type, body)
 			if (pushTaskId === view.selectedTaskId) {
-				view.outputs = body
+				view.outputs = body ?? null
 			} else {
 				console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', view.selectedTaskId)
 			}

--- a/src/assistant.js
+++ b/src/assistant.js
@@ -632,6 +632,31 @@ export async function openAssistantTask(
 	const view = app.mount(modalMountPoint)
 	let lastTask = task
 
+	// notify push stuff
+	const isListeningTo = {}
+	// listen only if needed
+	// return true if notify_push is available
+	// we can't cleanup isListeningTo because there is no way to remove a handler with @nextcloud/notify_push
+	const listenToTaskNotifications = (pushTaskId) => {
+		if (isListeningTo[pushTaskId]) {
+			return true
+		}
+		// attempt to listen to push notifications to get the intermediate output
+		const pushChannel = 'task_' + pushTaskId
+		const hasPush = listen(pushChannel, (type, body) => {
+			console.debug('[assistant] received push notification', type, body)
+			if (pushTaskId === view.selectedTaskId) {
+				view.outputs = body
+			} else {
+				console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', view.selectedTaskId)
+			}
+		})
+		if (hasPush) {
+			isListeningTo[pushTaskId] = true
+		}
+		return hasPush
+	}
+
 	modalMountPoint.addEventListener('cancel', () => {
 		cancelTaskPolling()
 		app.unmount()
@@ -668,17 +693,7 @@ export async function openAssistantTask(
 				view.selectedTaskId = lastTask?.id
 				view.expectedRuntime = (lastTask?.completionExpectedAt - lastTask?.scheduledAt) || null
 
-				// attempt to listen to push notifications to get the intermediate output
-				const pushTaskId = task.id
-				const pushChannel = 'task_' + pushTaskId
-				const hasPush = listen(pushChannel, (type, body) => {
-					console.debug('[assistant] received push notification', type, body)
-					if (pushTaskId === view.selectedTaskId) {
-						view.outputs = body
-					} else {
-						console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', view.selectedTaskId)
-					}
-				})
+				const hasPush = listenToTaskNotifications(task.id)
 				console.debug('[assistant] HAS PUSH', hasPush)
 
 				pollTask(task.id, view, !hasPush).then(finishedTask => {
@@ -767,7 +782,9 @@ export async function openAssistantTask(
 				view.progress = null
 				view.expectedRuntime = (updatedTask?.completionExpectedAt - updatedTask?.scheduledAt) || null
 
-				pollTask(updatedTask.id, view).then(finishedTask => {
+				const hasPush = listenToTaskNotifications(task.id)
+
+				pollTask(updatedTask.id, view, !hasPush).then(finishedTask => {
 					console.debug('pollTask.then', finishedTask)
 					if (finishedTask.status === TASK_STATUS_STRING.successful) {
 						view.outputs = finishedTask?.output

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -896,14 +896,6 @@ export default {
 				flex-wrap: wrap;
 				width: 100%;
 				padding: 4px 0 4px 10px;
-				> label {
-					animation: blink 2s infinite;
-				}
-				@media (prefers-reduced-motion: reduce) {
-					> label {
-						animation: none;
-					}
-				}
 			}
 
 			&__provider {
@@ -950,18 +942,6 @@ export default {
 		width: 100%;
 		padding: 16px;
 		min-height: 0;
-	}
-}
-
-@keyframes blink {
-	0% {
-		opacity: 1;
-	}
-	50% {
-		opacity: 0;
-	}
-	100% {
-		opacity: 1;
 	}
 }
 </style>

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -899,6 +899,11 @@ export default {
 				> label {
 					animation: blink 2s infinite;
 				}
+				@media (prefers-reduced-motion: reduce) {
+					> label {
+						animation: none;
+					}
+				}
 			}
 
 			&__provider {

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -74,6 +74,25 @@
 								</template>
 							</NcPopover>
 						</div>
+						<div v-if="showSubtitle"
+							class="session-area__top-bar__subtitle">
+							{{ t('assistant', 'Getting results…') }}
+							<NcButton
+								@click="$emit('background-notify', !isNotifyEnabled)">
+								<template #icon>
+									<BellRingOutlineIcon v-if="isNotifyEnabled" />
+									<BellOutlineIcon v-else />
+								</template>
+								{{ t('assistant', 'Get notified when the task finishes') }}
+							</NcButton>
+							<NcButton
+								@click="$emit('cancel-task')">
+								<template #icon>
+									<CloseIcon />
+								</template>
+								{{ t('assistant', 'Cancel task') }}
+							</NcButton>
+						</div>
 					</div>
 					<div v-if="mySelectedTaskTypeId === 'core:text2text:translate'"
 						class="session-area__chat-area">
@@ -151,6 +170,9 @@ import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import UnfoldLessHorizontalIcon from 'vue-material-design-icons/UnfoldLessHorizontal.vue'
 import UnfoldMoreHorizontalIcon from 'vue-material-design-icons/UnfoldMoreHorizontal.vue'
 import InformationBoxIcon from 'vue-material-design-icons/InformationBox.vue'
+import BellOutlineIcon from 'vue-material-design-icons/BellOutline.vue'
+import BellRingOutlineIcon from 'vue-material-design-icons/BellRingOutline.vue'
+import CloseIcon from 'vue-material-design-icons/Close.vue'
 
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -210,6 +232,9 @@ export default {
 		UnfoldLessHorizontalIcon,
 		UnfoldMoreHorizontalIcon,
 		InformationBoxIcon,
+		BellOutlineIcon,
+		BellRingOutlineIcon,
+		CloseIcon,
 		AssistantFormInputs,
 		AssistantFormOutputs,
 		ChattyLLMInputForm,
@@ -414,6 +439,9 @@ export default {
 		},
 		showRunningEmptyContent() {
 			return this.showSyncTaskRunning && this.myOutputs === null
+		},
+		showSubtitle() {
+			return this.showSyncTaskRunning && this.myOutputs !== null
 		},
 	},
 	watch: {
@@ -835,12 +863,12 @@ export default {
 
 		&__top-bar {
 			display: flex;
+			flex-direction: column;
 			justify-content: space-between;
 			align-items: center;
-			gap: 4px;
 			position: sticky;
 			top: 0;
-			height: calc(var(--default-clickable-area) + var(--default-grid-baseline) * 2);
+			// height: calc(var(--default-clickable-area) + var(--default-grid-baseline) * 2);
 			box-sizing: border-box;
 			border-bottom: 1px solid var(--color-border);
 			padding-left: 52px;
@@ -856,6 +884,15 @@ export default {
 				min-width: 0;
 				overflow-x: auto;
 				white-space: nowrap;
+			}
+
+			&__subtitle {
+				display: flex;
+				gap: 8px;
+				align-items: center;
+				flex-wrap: wrap;
+				width: 100%;
+				padding: 4px 0 4px 10px;
 			}
 
 			&__provider {

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -42,7 +42,7 @@
 					</NcAppNavigationList>
 				</NcAppNavigation>
 				<RunningEmptyContent
-					v-if="showSyncTaskRunning"
+					v-if="showRunningEmptyContent"
 					class="running-area"
 					:description="shortInput"
 					:progress="progress"
@@ -174,7 +174,7 @@ import TaskList from './TaskList.vue'
 import TaskTypeSelect from './TaskTypeSelect.vue'
 import TranslateForm from './Translate/TranslateForm.vue'
 
-import { SHAPE_TYPE_NAMES, MAX_TEXT_INPUT_LENGTH } from '../constants.js'
+import { SHAPE_TYPE_NAMES, MAX_TEXT_INPUT_LENGTH, TASK_STATUS_STRING } from '../constants.js'
 
 import axios from '@nextcloud/axios'
 import { generateOcsUrl, generateUrl } from '@nextcloud/router'
@@ -344,6 +344,9 @@ export default {
 			return this.selectedTaskType
 		},
 		canSubmit() {
+			if (this.taskStatus === TASK_STATUS_STRING.running) {
+				return false
+			}
 			// otherwise, check that none of the properties of myInputs are empty
 			console.debug('[assistant] canSubmit', this.myInputs)
 			if (Object.keys(this.myInputs).length === 0) {
@@ -408,6 +411,9 @@ export default {
 		},
 		actionButtonsToShow() {
 			return this.hasOutput ? this.actionButtons : []
+		},
+		showRunningEmptyContent() {
+			return this.showSyncTaskRunning && this.myOutputs === null
 		},
 	},
 	watch: {

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -61,8 +61,7 @@
 									<NcButton
 										:aria-label="t('assistant', 'Provider name')">
 										<template #icon>
-											<NcLoadingIcon v-if="streaming" :size="20" />
-											<InformationBoxIcon v-else :size="20" />
+											<InformationBoxIcon :size="20" />
 										</template>
 									</NcButton>
 								</template>
@@ -77,7 +76,9 @@
 						</div>
 						<div v-if="streaming"
 							class="session-area__top-bar__subtitle">
-							{{ t('assistant', 'Getting results…') }}
+							<label>
+								{{ t('assistant', 'Getting results…') }}
+							</label>
 							<NcButton
 								@click="$emit('background-notify', !isNotifyEnabled)">
 								<template #icon>
@@ -895,6 +896,9 @@ export default {
 				flex-wrap: wrap;
 				width: 100%;
 				padding: 4px 0 4px 10px;
+				> label {
+					animation: blink 2s infinite;
+				}
 			}
 
 			&__provider {
@@ -941,6 +945,18 @@ export default {
 		width: 100%;
 		padding: 16px;
 		min-height: 0;
+	}
+}
+
+@keyframes blink {
+	0% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 1;
 	}
 }
 </style>

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -377,22 +377,23 @@ export default {
 			return this.selectedTaskType
 		},
 		canSubmit() {
+			const inputs = this.myInputs
 			if (this.taskStatus === TASK_STATUS_STRING.running) {
 				return false
 			}
 			// otherwise, check that none of the properties of myInputs are empty
-			console.debug('[assistant] canSubmit', this.myInputs)
-			if (Object.keys(this.myInputs).length === 0) {
+			console.debug('[assistant] canSubmit', inputs)
+			if (Object.keys(inputs).length === 0) {
 				return false
 			}
 			const taskType = this.selectedTaskType
 			// check that all fields required by the task type are defined
 			return Object.keys(taskType.inputShape).every(k => {
-				if (this.myInputs[k] === null || this.myInputs[k] === undefined) {
+				if (inputs[k] === null || inputs[k] === undefined) {
 					return false
 				}
 				const fieldType = taskType.inputShape[k].type
-				const value = this.myInputs[k]
+				const value = inputs[k]
 				return ([SHAPE_TYPE_NAMES.Text, SHAPE_TYPE_NAMES.Enum].includes(fieldType)
 						&& typeof value === 'string'
 						&& !!value?.trim()

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -74,27 +74,30 @@
 								</template>
 							</NcPopover>
 						</div>
-						<div v-if="streaming"
+						<NcNoteCard v-if="streaming"
+							type="info"
 							class="session-area__top-bar__subtitle">
-							<label>
-								{{ t('assistant', 'Getting results…') }}
-							</label>
-							<NcButton
-								@click="$emit('background-notify', !isNotifyEnabled)">
-								<template #icon>
-									<BellRingOutlineIcon v-if="isNotifyEnabled" />
-									<BellOutlineIcon v-else />
-								</template>
-								{{ t('assistant', 'Get notified when the task finishes') }}
-							</NcButton>
-							<NcButton
-								@click="$emit('cancel-task')">
-								<template #icon>
-									<CloseIcon />
-								</template>
-								{{ t('assistant', 'Cancel task') }}
-							</NcButton>
-						</div>
+							<div class="subtitle-content">
+								<label>
+									{{ t('assistant', 'Getting results…') }}
+								</label>
+								<NcButton
+									@click="$emit('background-notify', !isNotifyEnabled)">
+									<template #icon>
+										<BellRingOutlineIcon v-if="isNotifyEnabled" />
+										<BellOutlineIcon v-else />
+									</template>
+									{{ t('assistant', 'Get notified when the task finishes') }}
+								</NcButton>
+								<NcButton
+									@click="$emit('cancel-task')">
+									<template #icon>
+										<CloseIcon />
+									</template>
+									{{ t('assistant', 'Cancel task') }}
+								</NcButton>
+							</div>
+						</NcNoteCard>
 					</div>
 					<div v-if="mySelectedTaskTypeId === 'core:text2text:translate'"
 						class="session-area__chat-area">
@@ -187,6 +190,7 @@ import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcAssistantIcon from '@nextcloud/vue/components/NcAssistantIcon'
 import NcPopover from '@nextcloud/vue/components/NcPopover'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 
 import AssistantFormInputs from './AssistantFormInputs.vue'
 import AssistantFormOutputs from './AssistantFormOutputs.vue'
@@ -229,6 +233,7 @@ export default {
 		NcAppNavigationNew,
 		NcAssistantIcon,
 		NcPopover,
+		NcNoteCard,
 		CreationIcon,
 		PlusIcon,
 		UnfoldLessHorizontalIcon,
@@ -874,12 +879,12 @@ export default {
 			// height: calc(var(--default-clickable-area) + var(--default-grid-baseline) * 2);
 			box-sizing: border-box;
 			border-bottom: 1px solid var(--color-border);
-			padding-left: 52px;
 			padding-right: 0.5em;
 			font-weight: bold;
 			background-color: var(--color-main-background);
 
 			&__title {
+				padding-left: 52px;
 				display: flex;
 				align-items: center;
 				gap: 0.5em;
@@ -890,12 +895,16 @@ export default {
 			}
 
 			&__subtitle {
-				display: flex;
-				gap: 8px;
-				align-items: center;
-				flex-wrap: wrap;
-				width: 100%;
-				padding: 4px 0 4px 10px;
+				margin-left: 22px;
+				align-self: start;
+				.subtitle-content {
+					display: flex;
+					gap: 8px;
+					align-items: center;
+					flex-wrap: wrap;
+					width: 100%;
+					padding: 4px 0 4px 0px;
+				}
 			}
 
 			&__provider {

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -61,7 +61,8 @@
 									<NcButton
 										:aria-label="t('assistant', 'Provider name')">
 										<template #icon>
-											<InformationBoxIcon :size="20" />
+											<NcLoadingIcon v-if="streaming" :size="20" />
+											<InformationBoxIcon v-else :size="20" />
 										</template>
 									</NcButton>
 								</template>
@@ -74,7 +75,7 @@
 								</template>
 							</NcPopover>
 						</div>
-						<div v-if="showSubtitle"
+						<div v-if="streaming"
 							class="session-area__top-bar__subtitle">
 							{{ t('assistant', 'Getting results…') }}
 							<NcButton
@@ -440,7 +441,7 @@ export default {
 		showRunningEmptyContent() {
 			return this.showSyncTaskRunning && this.myOutputs === null
 		},
-		showSubtitle() {
+		streaming() {
 			return this.showSyncTaskRunning && this.myOutputs !== null
 		},
 	},

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -244,6 +244,7 @@ export default {
 	provide() {
 		return {
 			providedCurrentTaskId: () => this.selectedTaskId,
+			streaming: () => this.streaming,
 		}
 	},
 	props: {

--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -217,7 +217,7 @@ export default {
 	height: calc(100vh - 32px);
 	max-height: calc(100vh - 32px);
 	height: 80%;
-	width: 50%;
+	width: 70%;
 	resize: both;
 	overflow: hidden;
 	filter: drop-shadow(0 0 15px rgba(77, 77, 77, 0.5));

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -945,7 +945,7 @@ export default {
 						'in session',
 						pushSessionId,
 						'the selected session is',
-						this.active.id,
+						this.active?.id,
 					)
 				}
 

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -319,6 +319,7 @@ export default {
 			// [{ id: number, session_id: number, role: string, content: string, timestamp: number, sources:string }]
 			messages: [], // null when failed to fetch
 			streamingMessage: null,
+			isListeningTo: {},
 			messagesAxiosController: null, // for request cancellation
 			allMessagesLoaded: false,
 			loading: {
@@ -922,15 +923,16 @@ export default {
 			}
 		},
 
-		async pollGenerationTask(taskId, sessionId) {
+		listenToTaskNotifications(pushTaskId, pushSessionId) {
 			// attempt to listen to push notifications to get the intermediate output
-			const pushTaskId = taskId
+			if (this.isListeningTo[pushTaskId]) {
+				return true
+			}
 			const pushChannel = 'task_' + pushTaskId
-			const pushSessionId = this.active.id
 			const hasPush = listen(pushChannel, (type, body) => {
 				console.debug('[assistant] received push notification', type, body)
 				if (pushSessionId === this.active.id) {
-					this.updateStreamingMessage(body.output, sessionId)
+					this.updateStreamingMessage(body.output, pushSessionId)
 				} else {
 					console.debug(
 						'[assistant] ignoring push notification for task',
@@ -942,6 +944,12 @@ export default {
 					)
 				}
 			})
+			this.isListeningTo[pushTaskId] = true
+			return hasPush
+		},
+
+		async pollGenerationTask(taskId, sessionId) {
+			const hasPush = this.listenToTaskNotifications(taskId, this.active.id)
 			console.debug('[assistant] HAS PUSH', hasPush)
 
 			return new Promise((resolve, reject) => {

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -98,7 +98,10 @@
 				</div>
 			</div>
 			<div ref="chatArea"
-				class="session-area__chat-area">
+				class="session-area__chat-area"
+				@wheel="onUserScroll"
+				@keydown="onUserScroll"
+				@touchstart="onUserScroll">
 				<NoSession v-if="loading.newSession"
 					:name="t('assistant', 'Creating a new conversation')"
 					description="">
@@ -320,6 +323,8 @@ export default {
 			// [{ id: number, session_id: number, role: string, content: string, timestamp: number, sources:string }]
 			messages: [], // null when failed to fetch
 			streamingMessage: null,
+			// only used while streaming to prevent auto scrolling after some user scrolling happened
+			userScrolled: false,
 			isListeningTo: {},
 			messagesAxiosController: null, // for request cancellation
 			allMessagesLoaded: false,
@@ -481,6 +486,9 @@ export default {
 	},
 
 	methods: {
+		onUserScroll() {
+			this.userScrolled = true
+		},
 		async checkSession(sessionId, isAssignment) {
 			try {
 				if (this.active?.id == null || this.active?.id !== sessionId) {
@@ -503,6 +511,7 @@ export default {
 				if (checkSessionResponseData.messageTaskId !== null) {
 					try {
 						this.loading.llmGeneration = true
+						this.userScrolled = false
 						const message = await this.pollGenerationTask(checkSessionResponseData.messageTaskId, sessionId)
 						console.debug('checkTaskPolling result:', message)
 						this.messages.push(message)
@@ -516,6 +525,7 @@ export default {
 						showError(t('assistant', 'Error generating a response'))
 					}
 					this.streamingMessage = null
+					this.userScrolled = false
 				}
 				if (checkSessionResponseData.titleTaskId !== null) {
 					try {
@@ -578,6 +588,9 @@ export default {
 				return
 			}
 			if (this.messages == null) {
+				return
+			}
+			if (this.userScrolled) {
 				return
 			}
 
@@ -904,6 +917,7 @@ export default {
 				this.slowPickup = false
 				this.loading.llmGeneration = true
 				this.loading.llmRunning = false
+				this.userScrolled = false
 				const params = {
 					sessionId,
 				}
@@ -929,6 +943,7 @@ export default {
 				this.loading.llmGeneration = false
 				this.loading.llmRunning = false
 				this.streamingMessage = null
+				this.userScrolled = false
 			}
 		},
 
@@ -937,6 +952,7 @@ export default {
 				const sessionId = this.active.id
 				this.loading.llmGeneration = true
 				this.loading.llmRunning = false
+				this.userScrolled = false
 				const regenerationResponse = await axios.get(getChatURL('/regenerate'), { params: { messageId, sessionId } })
 				const regenerationResponseData = regenerationResponse.data
 				console.debug('scheduleRegenerationTask response:', regenerationResponse)
@@ -955,6 +971,7 @@ export default {
 				this.loading.llmGeneration = false
 				this.loading.llmRunning = false
 				this.streamingMessage = null
+				this.userScrolled = false
 			}
 		},
 

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -249,6 +249,7 @@ import axios, { isCancel } from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
 import { generateUrl, generateOcsUrl } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
+import { listen } from '@nextcloud/notify_push'
 import moment from 'moment'
 import { SHAPE_TYPE_NAMES, TASK_STATUS_INT } from '../../constants.js'
 import ICAL from 'ical.js'
@@ -922,6 +923,27 @@ export default {
 		},
 
 		async pollGenerationTask(taskId, sessionId) {
+			// attempt to listen to push notifications to get the intermediate output
+			const pushTaskId = taskId
+			const pushChannel = 'task_' + pushTaskId
+			const pushSessionId = this.active.id
+			const hasPush = listen(pushChannel, (type, body) => {
+				console.debug('[assistant] received push notification', type, body)
+				if (pushSessionId === this.active.id) {
+					this.updateStreamingMessage(body.output, sessionId)
+				} else {
+					console.debug(
+						'[assistant] ignoring push notification for task',
+						pushTaskId,
+						'in session',
+						pushSessionId,
+						'the selected session is',
+						this.active.id,
+					)
+				}
+			})
+			console.debug('[assistant] HAS PUSH', hasPush)
+
 			return new Promise((resolve, reject) => {
 				this.pollMessageGenerationTimerId = setInterval(() => {
 					if (this.active === null || sessionId !== this.active.id) {
@@ -967,24 +989,28 @@ export default {
 								this.loading.llmRunning = true
 							}
 							if (error.response.data.task_output?.output) {
-								if (this.streamingMessage) {
-									this.streamingMessage.content = error.response.data.task_output.output
-								} else {
-									this.streamingMessage = {
-										role: Roles.ASSISTANT,
-										content: error.response.data.task_output.output,
-										attachments: [],
-										sources: '',
-										session_id: sessionId,
-										id: 0,
-										timestamp: moment().unix(),
-									}
-								}
+								this.updateStreamingMessage(error.response.data.task_output.output, sessionId)
 							}
 						}
 					})
 				}, 2000)
 			})
+		},
+
+		updateStreamingMessage(content, sessionId) {
+			if (this.streamingMessage) {
+				this.streamingMessage.content = content
+			} else {
+				this.streamingMessage = {
+					role: Roles.ASSISTANT,
+					content,
+					attachments: [],
+					sources: '',
+					session_id: sessionId,
+					id: 0,
+					timestamp: moment().unix(),
+				}
+			}
 		},
 
 		getLastHumanMessage() {

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -1004,7 +1004,7 @@ export default {
 							if (error.response.data.task_status === TASK_STATUS_INT.running) {
 								this.loading.llmRunning = true
 							}
-							if (error.response.data.task_output?.output) {
+							if (!hasPush && error.response.data.task_output?.output) {
 								this.updateStreamingMessage(error.response.data.task_output.output, sessionId)
 							}
 						}

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -357,6 +357,10 @@ export default {
 					message: t('assistant', 'Create a scheduled task to send me the weather every morning '),
 				},
 				{
+					aria: t('assistant', 'Ask assistant, which actions it can do for you'),
+					message: t('assistant', 'Which actions can you do for me?'),
+				},
+				{
 					aria: t('assistant', 'Ask assistant for route from Munich to Berlin using public transport'),
 					message: t('assistant', 'Can you give me a route from Munich to Berlin using public transport?'),
 				},

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -149,6 +149,7 @@
 						</NcButton>
 					</div>
 					<ConversationBox :messages="messages"
+						:streaming-message="streamingMessage"
 						:loading="loading"
 						:slow-pickup="slowPickup"
 						@regenerate="runRegenerationTask"
@@ -316,6 +317,7 @@ export default {
 			pollCheckSessionTimeout: null,
 			// [{ id: number, session_id: number, role: string, content: string, timestamp: number, sources:string }]
 			messages: [], // null when failed to fetch
+			streamingMessage: null,
 			messagesAxiosController: null, // for request cancellation
 			allMessagesLoaded: false,
 			loading: {
@@ -426,6 +428,7 @@ export default {
 			this.loading.llmGeneration = false
 			this.loading.llmRunning = false
 			this.loading.titleGeneration = false
+			this.streamingMessage = null
 			this.chatContent = ''
 			this.msgCursor = 0
 			this.messages = []
@@ -501,6 +504,7 @@ export default {
 						console.error('checkGenerationTask error:', error)
 						showError(t('assistant', 'Error generating a response'))
 					}
+					this.streamingMessage = null
 				}
 				if (checkSessionResponseData.titleTaskId !== null) {
 					try {
@@ -545,6 +549,9 @@ export default {
 			this.$nextTick(() => {
 				const lastIdx = this.messages.length - 1
 				document.querySelector('#message' + lastIdx)?.scrollIntoView()
+				document.querySelector('#message-streaming')?.scrollIntoView()
+				document.querySelector('#message-placeholder')?.scrollIntoView()
+				this.$refs.inputComponent.focus()
 				if (!this.isAssignment) {
 					this.$refs.inputComponent.focus()
 				}
@@ -864,6 +871,7 @@ export default {
 
 		async runGenerationTask(sessionId, agencyConfirm = null) {
 			try {
+				this.scrollToBottom()
 				this.slowPickup = false
 				this.loading.llmGeneration = true
 				this.loading.llmRunning = false
@@ -887,6 +895,7 @@ export default {
 			} finally {
 				this.loading.llmGeneration = false
 				this.loading.llmRunning = false
+				this.streamingMessage = null
 			}
 		},
 
@@ -908,6 +917,7 @@ export default {
 			} finally {
 				this.loading.llmGeneration = false
 				this.loading.llmRunning = false
+				this.streamingMessage = null
 			}
 		},
 
@@ -955,6 +965,21 @@ export default {
 							this.slowPickup = error.response.data.slow_pickup
 							if (error.response.data.task_status === TASK_STATUS_INT.running) {
 								this.loading.llmRunning = true
+							}
+							if (error.response.data.task_output?.output) {
+								if (this.streamingMessage) {
+									this.streamingMessage.content = error.response.data.task_output.output
+								} else {
+									this.streamingMessage = {
+										role: Roles.ASSISTANT,
+										content: error.response.data.task_output.output,
+										attachments: [],
+										sources: '',
+										session_id: sessionId,
+										id: 0,
+										timestamp: moment().unix(),
+									}
+								}
 							}
 						}
 					})

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -97,7 +97,8 @@
 					</NcActions>
 				</div>
 			</div>
-			<div class="session-area__chat-area">
+			<div ref="chatArea"
+				class="session-area__chat-area">
 				<NoSession v-if="loading.newSession"
 					:name="t('assistant', 'Creating a new conversation')"
 					description="">
@@ -451,7 +452,7 @@ export default {
 			}
 
 			await this.fetchMessages()
-			this.scrollToBottom()
+			this.scrollToLastMessage()
 
 			// start polling in case a message is currently being generated
 			this.checkSession(this.active.id, this.isAssignment)
@@ -505,7 +506,11 @@ export default {
 						const message = await this.pollGenerationTask(checkSessionResponseData.messageTaskId, sessionId)
 						console.debug('checkTaskPolling result:', message)
 						this.messages.push(message)
-						this.scrollToBottom()
+						if (this.streamingMessage === null) {
+							this.scrollToLastMessage()
+						} else {
+							this.focusOnInputField()
+						}
 					} catch (error) {
 						console.error('checkGenerationTask error:', error)
 						showError(t('assistant', 'Error generating a response'))
@@ -543,7 +548,15 @@ export default {
 				}
 			}
 		},
-		scrollToBottom() {
+		focusOnInputField() {
+			this.$nextTick(() => {
+				this.$refs.inputComponent.focus()
+				if (!this.isAssignment) {
+					this.$refs.inputComponent.focus()
+				}
+			})
+		},
+		scrollToLastMessage() {
 			console.debug('scrollToBottom: active:', this.active)
 			if (this.active == null) {
 				return
@@ -557,10 +570,20 @@ export default {
 				document.querySelector('#message' + lastIdx)?.scrollIntoView()
 				document.querySelector('#message-streaming')?.scrollIntoView()
 				document.querySelector('#message-placeholder')?.scrollIntoView()
-				this.$refs.inputComponent.focus()
-				if (!this.isAssignment) {
-					this.$refs.inputComponent.focus()
-				}
+			})
+			this.focusOnInputField()
+		},
+		scrollToBottomWhileStreaming() {
+			if (this.active == null) {
+				return
+			}
+			if (this.messages == null) {
+				return
+			}
+
+			this.$nextTick(() => {
+				const chatAreaElem = this.$refs.chatArea
+				chatAreaElem.scrollTop = chatAreaElem.scrollHeight
 			})
 		},
 
@@ -645,7 +668,7 @@ export default {
 
 			this.messages.push({ role, content, timestamp, session_id: this.active.id })
 			this.chatContent = ''
-			this.scrollToBottom()
+			this.scrollToLastMessage()
 			await this.newMessage(role, content, timestamp, this.active.id)
 		},
 
@@ -668,7 +691,7 @@ export default {
 
 			this.messages.push({ role, content, timestamp, session_id: this.active.id, attachments })
 			this.chatContent = ''
-			this.scrollToBottom()
+			this.scrollToLastMessage()
 			await this.newMessage(role, content, timestamp, this.active.id, attachments)
 		},
 
@@ -877,7 +900,7 @@ export default {
 
 		async runGenerationTask(sessionId, agencyConfirm = null) {
 			try {
-				this.scrollToBottom()
+				this.scrollToLastMessage()
 				this.slowPickup = false
 				this.loading.llmGeneration = true
 				this.loading.llmRunning = false
@@ -894,7 +917,11 @@ export default {
 				const message = await this.pollGenerationTask(generationResponseData.taskId, sessionId)
 				console.debug('checkTaskPolling result:', message)
 				this.messages.push(message)
-				this.scrollToBottom()
+				if (this.streamingMessage === null) {
+					this.scrollToLastMessage()
+				} else {
+					this.focusOnInputField()
+				}
 			} catch (error) {
 				console.error('scheduleGenerationTask error:', error)
 				showError(t('assistant', 'Error generating a response'))
@@ -916,7 +943,11 @@ export default {
 				const message = await this.pollGenerationTask(regenerationResponseData.taskId, sessionId)
 				console.debug('checkTaskPolling result:', message)
 				this.messages[this.messages.length - 1] = message
-				this.scrollToBottom()
+				if (this.streamingMessage === null) {
+					this.scrollToLastMessage()
+				} else {
+					this.focusOnInputField()
+				}
 			} catch (error) {
 				console.error('scheduleRegenerationTask error:', error)
 				showError(t('assistant', 'Error regenerating a response'))
@@ -1027,6 +1058,7 @@ export default {
 					timestamp: moment().unix(),
 				}
 			}
+			this.scrollToBottomWhileStreaming()
 		},
 
 		getLastHumanMessage() {
@@ -1112,7 +1144,7 @@ export default {
 
 			// this.messages.push({ role, content, timestamp })
 			this.chatContent = ''
-			this.scrollToBottom()
+			this.scrollToLastMessage()
 			await this.newMessage(role, content, timestamp, this.active.id, null, false, confirm)
 		},
 

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -931,8 +931,9 @@ export default {
 			const pushChannel = 'task_' + pushTaskId
 			const hasPush = listen(pushChannel, (type, body) => {
 				console.debug('[assistant] received push notification', type, body)
-				if (pushSessionId === this.active.id) {
-					this.updateStreamingMessage(body.output, pushSessionId)
+				const activeSessionId = this.active?.id
+				if (pushSessionId === activeSessionId) {
+					this.updateStreamingMessage(body?.output ?? '', pushSessionId)
 				} else {
 					console.debug(
 						'[assistant] ignoring push notification for task',
@@ -943,13 +944,16 @@ export default {
 						this.active.id,
 					)
 				}
+
 			})
-			this.isListeningTo[pushTaskId] = true
+			if (hasPush) {
+				this.isListeningTo[pushTaskId] = true
+			}
 			return hasPush
 		},
 
 		async pollGenerationTask(taskId, sessionId) {
-			const hasPush = this.listenToTaskNotifications(taskId, this.active.id)
+			const hasPush = this.listenToTaskNotifications(taskId, sessionId)
 			console.debug('[assistant] HAS PUSH', hasPush)
 
 			return new Promise((resolve, reject) => {

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -985,7 +985,7 @@ export default {
 				console.debug('[assistant] received push notification', type, body)
 				const activeSessionId = this.active?.id
 				if (pushSessionId === activeSessionId) {
-					this.updateStreamingMessage(body?.output ?? '', pushSessionId)
+					this.updateStreamingMessage(body ?? {}, pushSessionId)
 				} else {
 					console.debug(
 						'[assistant] ignoring push notification for task',
@@ -1052,8 +1052,8 @@ export default {
 							if (error.response.data.task_status === TASK_STATUS_INT.running) {
 								this.loading.llmRunning = true
 							}
-							if (!hasPush && error.response.data.task_output?.output) {
-								this.updateStreamingMessage(error.response.data.task_output.output, sessionId)
+							if (!hasPush && typeof error.response.data.task_output !== 'undefined' && error.response.data.task_output !== null) {
+								this.updateStreamingMessage(error.response.data.task_output || {}, sessionId)
 							}
 						}
 					})
@@ -1061,15 +1061,16 @@ export default {
 			})
 		},
 
-		updateStreamingMessage(content, sessionId) {
+		updateStreamingMessage({ output, sources }, sessionId) {
 			if (this.streamingMessage) {
-				this.streamingMessage.content = content
+				this.streamingMessage.content = output
+				this.streamingMessage.sources = sources
 			} else {
 				this.streamingMessage = {
 					role: Roles.ASSISTANT,
-					content,
+					content: output,
 					attachments: [],
-					sources: '',
+					sources,
 					session_id: sessionId,
 					id: 0,
 					timestamp: moment().unix(),

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -932,7 +932,7 @@ export default {
 			if (this.isListeningTo[pushTaskId]) {
 				return true
 			}
-			const pushChannel = 'task_' + pushTaskId
+			const pushChannel = 'taskprocessing:task_id_' + pushTaskId
 			const hasPush = listen(pushChannel, (type, body) => {
 				console.debug('[assistant] received push notification', type, body)
 				const activeSessionId = this.active?.id

--- a/src/components/ChattyLLM/ConversationBox.vue
+++ b/src/components/ChattyLLM/ConversationBox.vue
@@ -31,7 +31,13 @@
 				:information-source-names="informationSourceNames"
 				@regenerate="regenerate(message.id)"
 				@delete="deleteMessage(message.id)" />
-			<LoadingPlaceholder v-if="loading.llmGeneration" :slow-pickup="slowPickup" />
+			<Message v-if="streamingMessage"
+				:id="'message-streaming'"
+				:message="streamingMessage"
+				:streaming="true" />
+			<LoadingPlaceholder v-else-if="loading.llmGeneration"
+				:id="'message-placeholder'"
+				:slow-pickup="slowPickup" />
 		</div>
 	</div>
 </template>
@@ -82,6 +88,10 @@ export default {
 		slowPickup: {
 			type: Boolean,
 			default: false,
+		},
+		streamingMessage: {
+			type: Object,
+			default: null,
 		},
 	},
 

--- a/src/components/ChattyLLM/ConversationBox.vue
+++ b/src/components/ChattyLLM/ConversationBox.vue
@@ -35,6 +35,7 @@
 				:id="'message-streaming'"
 				:key="'message-streaming'"
 				:message="streamingMessage"
+				:information-source-names="informationSourceNames"
 				:streaming="true" />
 			<LoadingPlaceholder v-else-if="loading.llmGeneration"
 				:id="'message-placeholder'"

--- a/src/components/ChattyLLM/ConversationBox.vue
+++ b/src/components/ChattyLLM/ConversationBox.vue
@@ -33,10 +33,12 @@
 				@delete="deleteMessage(message.id)" />
 			<Message v-if="streamingMessage"
 				:id="'message-streaming'"
+				:key="'message-streaming'"
 				:message="streamingMessage"
 				:streaming="true" />
 			<LoadingPlaceholder v-else-if="loading.llmGeneration"
 				:id="'message-placeholder'"
+				:key="'message-placeholder'"
 				:slow-pickup="slowPickup" />
 		</div>
 	</div>

--- a/src/components/ChattyLLM/InputArea.vue
+++ b/src/components/ChattyLLM/InputArea.vue
@@ -196,6 +196,11 @@ export default {
 		font-style: italic;
 		animation: breathing 2s linear infinite normal;
 	}
+	@media (prefers-reduced-motion: reduce) {
+		:deep(&__thinking > div) {
+			animation: none;
+		}
+	}
 
 	&__button-box {
 		display: flex;

--- a/src/components/ChattyLLM/Message.vue
+++ b/src/components/ChattyLLM/Message.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div v-if="message.content || hasAttachments"
+	<div v-if="message.content || streamedMessageContent || parsedSources.length || hasAttachments"
 		class="message"
 		@mouseover="showMessageActions = true"
 		@mouseleave="showMessageActions = false">
@@ -32,7 +32,7 @@
 					{{ message.role === 'human' ? displayName : t('assistant', 'Nextcloud Assistant') }}
 				</div>
 				<div style="display: flex">
-					<NcPopover v-if="parsedSources.length">
+					<NcPopover v-if="parsedSources.length && !streaming">
 						<template #trigger>
 							<NcButton
 								:aria-label="t('assistant', 'Information sources')">
@@ -55,6 +55,14 @@
 				</div>
 			</div>
 			<NcDateTime class="message__header__timestamp" :timestamp="new Date((message?.timestamp ?? 0) * 1000)" :ignore-seconds="true" />
+		</div>
+		<div v-if="streaming" class="message__streamed-sources">
+			<NcChip v-for="(source, index) in parsedSources"
+				:key="source"
+				:text="source"
+				no-close
+				:variant="index === parsedSources.length-1 ? 'primary' : 'secondary'"
+				style="display: block; margin-bottom: 0.5em;" />
 		</div>
 		<NcRichText class="message__content"
 			:text="streaming ? streamedMessageContent : message.content"
@@ -80,6 +88,7 @@ import NcDateTime from '@nextcloud/vue/components/NcDateTime'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcPopover from '@nextcloud/vue/components/NcPopover'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import NcChip from '@nextcloud/vue/components/NcChip'
 import { NcRichText } from '@nextcloud/vue/components/NcRichText'
 
 import InformationBox from 'vue-material-design-icons/InformationBox.vue'
@@ -112,6 +121,7 @@ export default {
 		InformationBox,
 
 		MessageActions,
+		NcChip,
 	},
 
 	props: {
@@ -211,6 +221,9 @@ export default {
 			showSuccess(t('assistant', 'Message copied to clipboard'))
 		},
 		fetch() {
+			if (!this.message.content) {
+				return
+			}
 			const urlMatch = (new RegExp(PLAIN_URL_PATTERN).exec(this.message.content.trim()))
 			const mdMatch = (new RegExp(MARKDOWN_LINK_PATTERN).exec(this.message.content.trim()))
 			const firstMatch = urlMatch
@@ -270,6 +283,10 @@ export default {
 		&__timestamp {
 			color: var(--color-text-maxcontrast);
 		}
+	}
+
+	&__streamed-sources {
+		margin-left: 2.6em;
 	}
 
 	&__content {

--- a/src/components/ChattyLLM/Message.vue
+++ b/src/components/ChattyLLM/Message.vue
@@ -17,13 +17,14 @@
 			@delete="$emit('delete')" />
 		<div class="message__header">
 			<div class="message__header__role">
+				<!-- we change the user prop when newMessageLoading changes to re-render the avatar without the icon template -->
 				<NcAvatar
-					:user="message.role === 'human' ? userId : 'Nextcloud Assistant'"
+					:user="message.role === 'human' ? (newMessageLoading ? '' : userId) : 'Nextcloud Assistant'"
 					:display-name="message.role === 'human' ? displayName : t('assistant', 'Nextcloud Assistant')"
 					:is-no-user="message.role === 'assistant'"
 					:hide-status="true">
 					<template v-if="(message.role === 'human' && newMessageLoading) || message.role === 'assistant'" #icon>
-						<NcLoadingIcon v-if="message.role === 'human' && newMessageLoading" :size="20" />
+						<NcLoadingIcon v-if="(message.role === 'human' && newMessageLoading) || streaming" :size="32" />
 						<AssistantIcon v-else-if="message.role === 'assistant'" :size="20" />
 					</template>
 				</NcAvatar>
@@ -132,6 +133,10 @@ export default {
 			default: false,
 		},
 		newMessageLoading: {
+			type: Boolean,
+			default: false,
+		},
+		streaming: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/components/ChattyLLM/Message.vue
+++ b/src/components/ChattyLLM/Message.vue
@@ -57,7 +57,7 @@
 			<NcDateTime class="message__header__timestamp" :timestamp="new Date((message?.timestamp ?? 0) * 1000)" :ignore-seconds="true" />
 		</div>
 		<NcRichText class="message__content"
-			:text="message.content"
+			:text="streaming ? streamedMessageContent : message.content"
 			:use-markdown="true"
 			:reference-limit="1"
 			:references="references"
@@ -158,6 +158,7 @@ export default {
 			// with [] we inhibit the extract+resolve mechanism on NcRichText
 			// TODO This can be removed (and all the custom extract+resolve logic) when fixed in NcRichText
 			references: [],
+			streamedMessageContent: '',
 		}
 	},
 
@@ -175,6 +176,28 @@ export default {
 		},
 		audioAttachments() {
 			return this.message.attachments?.filter(a => a.type === SHAPE_TYPE_NAMES.Audio) ?? []
+		},
+	},
+
+	watch: {
+		// Pseudo streaming
+		async 'message.content'(messageContent, oldMessageContent) {
+			if (!this.streaming) {
+				return
+			}
+			if (oldMessageContent) {
+				this.streamedMessageContent = oldMessageContent
+				messageContent = messageContent.replace(oldMessageContent, '')
+			}
+			let cachedStreamedMessageContent
+			for (const char of messageContent.split('')) {
+				this.streamedMessageContent += char
+				cachedStreamedMessageContent = this.streamedMessageContent
+				await new Promise(resolve => setTimeout(resolve, 5))
+				if (cachedStreamedMessageContent !== this.streamedMessageContent) {
+					break
+				}
+			}
 		},
 	},
 

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -39,7 +39,7 @@ import axios from '@nextcloud/axios'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { generateOcsUrl } from '@nextcloud/router'
 
-import { TASK_STATUS_STRING } from '../constants.js'
+import { TASK_STATUS_STRING, TASK_STATUS_INT_TO_STRING } from '../constants.js'
 
 export default {
 	name: 'TaskList',
@@ -109,10 +109,12 @@ export default {
 	mounted() {
 		this.getTasks()
 		subscribe('assistant:task:updated', this.updateTask)
+		subscribe('assistant:task:status:updated', this.updateTaskStatus)
 	},
 
 	beforeUnmount() {
 		unsubscribe('assistant:task:updated', this.updateTask)
+		unsubscribe('assistant:task:status:updated', this.updateTaskStatus)
 	},
 
 	methods: {
@@ -136,6 +138,12 @@ export default {
 			const taskToUpdate = this.tasks.find(t => t.id === task.id)
 			if (taskToUpdate) {
 				Object.assign(taskToUpdate, task)
+			}
+		},
+		updateTaskStatus({ taskId, status }) {
+			const taskToUpdate = this.tasks.find(t => t.id === taskId)
+			if (taskToUpdate) {
+				taskToUpdate.status = TASK_STATUS_INT_TO_STRING[status] ?? TASK_STATUS_STRING.unknown
 			}
 		},
 		onTaskDelete(task) {

--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -220,7 +220,11 @@ export default {
 			Object.keys(this.taskType.outputShape).forEach(key => {
 				const field = this.taskType.outputShape[key]
 				if (field.type === SHAPE_TYPE_NAMES.Text) {
-					textOutputs.push(this.task.output[key])
+					if (this.task.output && this.task.output[key]) {
+						textOutputs.push(this.task.output[key])
+					} else {
+						console.debug('[assistant] no output for key', key)
+					}
 				}
 			})
 			return textOutputs.join(' | ')

--- a/src/components/fields/AudioRecorderWrapper.vue
+++ b/src/components/fields/AudioRecorderWrapper.vue
@@ -263,7 +263,7 @@ export default {
 			height: 16px;
 			flex: 0 0 16px;
 			border-radius: 8px;
-			background-color: var(--color-error);
+			background-color: var(--color-element-error);
 		}
 
 		@keyframes fadeOutIn {
@@ -271,7 +271,7 @@ export default {
 				opacity: 1;
 			}
 			50% {
-				opacity: .3;
+				opacity: 0.1;
 			}
 			100% {
 				opacity: 1;
@@ -280,6 +280,11 @@ export default {
 
 		.fadeOutIn {
 			animation: fadeOutIn 3s infinite;
+		}
+		@media (prefers-reduced-motion: reduce) {
+			.fadeOutIn {
+				animation: none;
+			}
 		}
 	}
 }

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -17,7 +17,7 @@
 			:multiline="isMobile"
 			:maxlength="maxLength"
 			class="editable-input"
-			:class="{ shadowed: isOutput }"
+			:class="{ shadowed: isOutput, streaming: isOutput && streaming() }"
 			:placeholder="placeholder"
 			:title="title"
 			@submit="hasValue && $emit('submit', $event)"
@@ -85,6 +85,10 @@ export default {
 
 	mixins: [
 		isMobile,
+	],
+
+	inject: [
+		'streaming',
 	],
 
 	props: {
@@ -232,8 +236,23 @@ body[dir="rtl"] .choose-file-button {
 		padding-bottom: 4px !important;
 	}
 	.shadowed .rich-contenteditable__input {
-		border: 2px solid var(--color-primary-element) !important;
+		border: 2px solid var(--color-primary-element);
 		padding-bottom: 38px !important;
+	}
+	.shadowed.streaming .rich-contenteditable__input {
+		animation: pulse 2s infinite;
+	}
+}
+
+@keyframes pulse {
+	0% {
+		box-shadow: 0 0 0 0px rgba(128, 128, 128, 0.7);
+	}
+	70% {
+		box-shadow: 0 0 0 14px rgba(128, 128, 128, 0);
+	}
+	100% {
+		box-shadow: 0 0 0 0px rgba(128, 128, 128, 0);
 	}
 }
 </style>

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -28,10 +28,16 @@
 			:title="t('assistant', 'Copy output')"
 			@click="onCopy">
 			<template #icon>
-				<ClipboardCheckOutlineIcon v-if="copied" />
+				<NcLoadingIcon v-if="streaming()" />
+				<ClipboardCheckOutlineIcon v-else-if="copied" />
 				<ContentCopyIcon v-else />
 			</template>
-			{{ t('assistant', 'Copy') }}
+			<span v-if="streaming()">
+				{{ t('assistant', 'Getting results...') }}
+			</span>
+			<span v-else>
+				{{ t('assistant', 'Copy') }}
+			</span>
 		</NcButton>
 		<NcButton v-if="!isOutput && !hasValue && showChooseButton"
 			class="choose-file-button"
@@ -52,6 +58,7 @@ import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcRichContenteditable from '@nextcloud/vue/components/NcRichContenteditable'
+import { NcLoadingIcon } from '@nextcloud/vue'
 
 import isMobile from '../../mixins/isMobile.js'
 
@@ -78,6 +85,7 @@ export default {
 	components: {
 		NcRichContenteditable,
 		NcButton,
+		NcLoadingIcon,
 		FileDocumentOutlineIcon,
 		ClipboardCheckOutlineIcon,
 		ContentCopyIcon,

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -161,6 +161,15 @@ export default {
 	},
 
 	watch: {
+		value(newValue) {
+			if (!this.streaming()) {
+				return
+			}
+			const scrollableArea = this.$refs.input?.$el?.querySelector('#' + this.id)
+			if (scrollableArea) {
+				scrollableArea.scrollTo(0, scrollableArea.scrollHeight)
+			}
+		},
 	},
 
 	mounted() {

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -242,6 +242,11 @@ body[dir="rtl"] .choose-file-button {
 	.shadowed.streaming .rich-contenteditable__input {
 		animation: pulse 2s infinite;
 	}
+	@media (prefers-reduced-motion: reduce) {
+		.shadowed.streaming .rich-contenteditable__input {
+			animation: none;
+		}
+	}
 }
 
 @keyframes pulse {

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,15 @@ export const TASK_STATUS_INT = {
 	unknown: 0,
 }
 
+export const TASK_STATUS_INT_TO_STRING = {
+	5: 'STATUS_CANCELLED',
+	4: 'STATUS_FAILED',
+	3: 'STATUS_SUCCESSFUL',
+	2: 'STATUS_RUNNING',
+	1: 'STATUS_SCHEDULED',
+	0: 'STATUS_UNKNOWN',
+}
+
 export const TASK_STATUS_STRING = {
 	cancelled: 'STATUS_CANCELLED',
 	failed: 'STATUS_FAILED',

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -40,6 +40,7 @@ import AssistantTextProcessingForm from '../components/AssistantTextProcessingFo
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
+import { listen } from '@nextcloud/notify_push'
 import {
 	cancelTask,
 	cancelTaskPolling,
@@ -128,7 +129,21 @@ export default {
 					this.task.id = task.id
 					this.task.completionExpectedAt = task.completionExpectedAt
 					this.task.scheduledAt = task.scheduledAt
-					pollTask(task.id, this, this.updateTask).then(finishedTask => {
+
+					// attempt to listen to push notifications to get the intermediate output
+					const pushTaskId = task.id
+					const pushChannel = 'task_' + pushTaskId
+					const hasPush = listen(pushChannel, (type, body) => {
+						console.debug('[assistant] received push notification', type, body)
+						if (pushTaskId === this.task.id) {
+							this.task.output = body
+						} else {
+							console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', this.task.id)
+						}
+					})
+					console.debug('[assistant] HAS PUSH', hasPush)
+
+					pollTask(task.id, this, !hasPush, this.updateTask).then(finishedTask => {
 						if (finishedTask.status === TASK_STATUS_STRING.successful) {
 							this.task.output = finishedTask?.output
 						} else if (finishedTask.status === TASK_STATUS_STRING.failed) {
@@ -202,7 +217,7 @@ export default {
 					this.task.completionExpectedAt = updatedTask.completionExpectedAt
 					this.task.scheduledAt = updatedTask.scheduledAt
 
-					pollTask(updatedTask.id, this, this.updateTask).then(finishedTask => {
+					pollTask(updatedTask.id, this, true, this.updateTask).then(finishedTask => {
 						console.debug('pollTask.then', finishedTask)
 						if (finishedTask.status === TASK_STATUS_STRING.successful) {
 							this.task.output = finishedTask?.output

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -110,12 +110,14 @@ export default {
 			})
 		},
 		syncSubmit(inputs, taskTypeId, newTaskIdentifier = '') {
+			this.loading = true
 			this.showSyncTaskRunning = true
 			this.isNotifyEnabled = false
 			this.progress = null
 			this.task.completionExpectedAt = null
 			this.task.scheduledAt = null
 			this.task.input = inputs
+			this.task.output = null
 			this.task.type = taskTypeId
 			scheduleTask('assistant', this.task.identifier, taskTypeId, inputs)
 				.then((response) => {

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -219,7 +219,6 @@ export default {
 					const updatedTask = response.data?.ocs?.data?.task
 
 					if (![TASK_STATUS_STRING.scheduled, TASK_STATUS_STRING.running].includes(updatedTask?.status)) {
-						this.selectedTaskTypeId = updatedTask.type
 						this.task.input = updatedTask.input
 						this.task.output = updatedTask.status === TASK_STATUS_STRING.successful ? updatedTask.output : null
 						this.task.id = updatedTask.id

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -129,7 +129,7 @@ export default {
 				return true
 			}
 			// attempt to listen to push notifications to get the intermediate output
-			const pushChannel = 'task_' + pushTaskId
+			const pushChannel = 'taskprocessing:task_id_' + pushTaskId
 			const hasPush = listen(pushChannel, (type, body) => {
 				console.debug('[assistant] received push notification', type, body)
 				if (pushTaskId === this.task.id) {

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -233,6 +233,7 @@ export default {
 						this.task.input = updatedTask.input
 						this.task.output = updatedTask.status === TASK_STATUS_STRING.successful ? updatedTask.output : null
 						this.task.id = updatedTask.id
+						this.task.status = updatedTask.status
 						return
 					}
 

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -70,6 +70,7 @@ export default {
 			progress: null,
 			loading: false,
 			isNotifyEnabled: false,
+			isListeningTo: {},
 		}
 	},
 
@@ -112,6 +113,25 @@ export default {
 				this.task.status = null
 			})
 		},
+		listenToTaskNotifications(pushTaskId) {
+			if (this.isListeningTo[pushTaskId]) {
+				return true
+			}
+			// attempt to listen to push notifications to get the intermediate output
+			const pushChannel = 'task_' + pushTaskId
+			const hasPush = listen(pushChannel, (type, body) => {
+				console.debug('[assistant] received push notification', type, body)
+				if (pushTaskId === this.task.id) {
+					this.task.output = body
+				} else {
+					console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', this.task.id)
+				}
+			})
+			if (hasPush) {
+				this.isListeningTo[pushTaskId] = true
+			}
+			return hasPush
+		},
 		syncSubmit(inputs, taskTypeId, newTaskIdentifier = '') {
 			this.loading = true
 			this.showSyncTaskRunning = true
@@ -130,17 +150,7 @@ export default {
 					this.task.completionExpectedAt = task.completionExpectedAt
 					this.task.scheduledAt = task.scheduledAt
 
-					// attempt to listen to push notifications to get the intermediate output
-					const pushTaskId = task.id
-					const pushChannel = 'task_' + pushTaskId
-					const hasPush = listen(pushChannel, (type, body) => {
-						console.debug('[assistant] received push notification', type, body)
-						if (pushTaskId === this.task.id) {
-							this.task.output = body
-						} else {
-							console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', this.task.id)
-						}
-					})
+					const hasPush = this.listenToTaskNotifications(task.id)
 					console.debug('[assistant] HAS PUSH', hasPush)
 
 					pollTask(task.id, this, !hasPush, this.updateTask).then(finishedTask => {
@@ -217,7 +227,9 @@ export default {
 					this.task.completionExpectedAt = updatedTask.completionExpectedAt
 					this.task.scheduledAt = updatedTask.scheduledAt
 
-					pollTask(updatedTask.id, this, true, this.updateTask).then(finishedTask => {
+					const hasPush = this.listenToTaskNotifications(task.id)
+
+					pollTask(updatedTask.id, this, !hasPush, this.updateTask).then(finishedTask => {
 						console.debug('pollTask.then', finishedTask)
 						if (finishedTask.status === TASK_STATUS_STRING.successful) {
 							this.task.output = finishedTask?.output

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -186,11 +186,16 @@ export default {
 				.then(() => {
 				})
 		},
-		updateTask(task) {
+		updateTask(task, _obj, updateOutput = true) {
 			if (task.status === TASK_STATUS_STRING.running) {
 				this.progress = task.progress
 			}
-			this.task = task
+			this.task = updateOutput
+				? task
+				: {
+					...task,
+					output: this.task.output,
+				}
 		},
 		onSyncSubmit(data) {
 			this.syncSubmit(data.inputs, data.selectedTaskTypeId, this.task.identifier)

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -122,7 +122,7 @@ export default {
 			const hasPush = listen(pushChannel, (type, body) => {
 				console.debug('[assistant] received push notification', type, body)
 				if (pushTaskId === this.task.id) {
-					this.task.output = body
+					this.task.output = body ?? null
 				} else {
 					console.debug('[assistant] ignoring push notification for task', pushTaskId, 'the selected one is', this.task.id)
 				}

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -98,20 +98,31 @@ export default {
 
 	methods: {
 		onBackgroundNotify(enable) {
-			setNotifyReady(this.task.id, enable).then(res => {
-				this.isNotifyEnabled = enable
-			})
+			if (this.task?.id) {
+				setNotifyReady(this.task.id, enable).then(res => {
+					this.isNotifyEnabled = enable
+				})
+			}
 		},
 		onCancel() {
 			cancelTaskPolling()
-			setNotifyReady(this.task.id, false)
-			cancelTask(this.task.id).then(res => {
+			if (this.task?.id) {
+				setNotifyReady(this.task.id, false)
+				cancelTask(this.task.id).then(res => {
+					this.loading = false
+					this.showSyncTaskRunning = false
+					this.task.id = null
+					this.task.output = null
+					this.task.status = null
+				})
+			} else {
+				// if we ever end up in this state, this helps to recover
 				this.loading = false
 				this.showSyncTaskRunning = false
 				this.task.id = null
 				this.task.output = null
 				this.task.status = null
-			})
+			}
 		},
 		listenToTaskNotifications(pushTaskId) {
 			if (this.isListeningTo[pushTaskId]) {

--- a/src/views/AssistantPage.vue
+++ b/src/views/AssistantPage.vue
@@ -107,6 +107,8 @@ export default {
 				this.loading = false
 				this.showSyncTaskRunning = false
 				this.task.id = null
+				this.task.output = null
+				this.task.status = null
 			})
 		},
 		syncSubmit(inputs, taskTypeId, newTaskIdentifier = '') {


### PR DESCRIPTION
Depends on:
* https://github.com/nextcloud/server/pull/60167
* https://github.com/nextcloud/server/pull/60500
* https://github.com/nextcloud/server/pull/61197
* https://github.com/nextcloud/integration_openai/pull/366

This adds the ability to get and display intermediate (streamed) text responses in the chat UI and in the generic form.
We use `@nextcloud/notify_push` if the notify push service is configured and available. If not, we still get intermediate results with the (pre-existing) task status polling.

### Notify push

[Kooha-2026-05-18-13-27-53.webm](https://github.com/user-attachments/assets/46c41b28-b1d4-4dbb-9953-2aca55789630)

[Kooha-2026-05-19-17-04-29.webm](https://github.com/user-attachments/assets/543ae0bb-ec6c-4eb1-9872-af4ed8e58999)


### Polling (fallback)

[Kooha-2026-05-18-13-40-25.webm](https://github.com/user-attachments/assets/3c161833-e404-405a-a9e5-5b87f5d2a59c)

[Kooha-2026-05-19-17-07-20.webm](https://github.com/user-attachments/assets/706595ba-2550-4826-92d1-ab3089b42d76)



