### PR TITLE
Fix(z-index): correctly set the z-index 

### DIFF
--- a/src/assistant.js
+++ b/src/assistant.js
@@ -81,6 +81,7 @@ export async function openAssistantForm({
 			if (isInsideViewer) {
 				// so the assistant modal is opened on top of the current viewer
 				document.querySelector('body').append(modalMountPoint)
+				modalMountPoint.classList.add('insideViewer')
 			} else {
 				// so the viewer can be later opened on top of the assistant
 				document.querySelector('body').insertBefore(modalMountPoint, content.nextSibling)
@@ -547,6 +548,7 @@ export async function openAssistantTask(
 		if (isInsideViewer) {
 			// so the assistant modal is opened on top of the current viewer
 			document.querySelector('body').append(modalMountPoint)
+			modalMountPoint.classList.add('insideViewer')
 		} else {
 			// so the viewer can be later opened on top of the assistant
 			document.querySelector('body').insertBefore(modalMountPoint, content.nextSibling)

--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -204,6 +204,13 @@ export default {
 </script>
 
 <style lang="scss">
+.p-dialog-mask {
+	z-index: 5000 !important;
+}
+#assistantTextProcessingModal.insideViewer .p-dialog-mask {
+	z-index: 9998 !important;
+}
+
 .assistant-modal.p-dialog {
 	position: relative;
 	max-width: 100%;


### PR DESCRIPTION
depending on if we are in the viewer or not, this makes the file picker always appear on top of the assistant dialog