### PR TITLE
Assistant dialog papercuts

### DIFF
--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -21,8 +21,8 @@
 				:is-assignment="mySelectedTaskTypeId === 'assignments'"
 				class="chatty-inputs"
 				@open-chat="onOpenChatFromAssignment" />
-			<div v-else class="container chatty-inputs">
-				<NcAppNavigation>
+			<div v-else ref="container" class="container chatty-inputs">
+				<NcAppNavigation ref="appNav">
 					<NcAppNavigationList>
 						<NcAppNavigationNew :text="t('assistant', 'New task')"
 							variant="secondary"
@@ -204,6 +204,8 @@ import TaskList from './TaskList.vue'
 import TaskTypeSelect from './TaskTypeSelect.vue'
 import TranslateForm from './Translate/TranslateForm.vue'
 
+import navAutoCollapse from '../mixins/navAutoCollapse.js'
+
 import { SHAPE_TYPE_NAMES, MAX_TEXT_INPUT_LENGTH, TASK_STATUS_STRING } from '../constants.js'
 
 import axios from '@nextcloud/axios'
@@ -249,6 +251,7 @@ export default {
 		ChattyLLMInputForm,
 		EditableTextField,
 	},
+	mixins: [navAutoCollapse],
 	provide() {
 		return {
 			providedCurrentTaskId: () => this.selectedTaskId,
@@ -477,6 +480,9 @@ export default {
 		},
 		mySelectedTaskTypeId(newVal) {
 			this.myOutputs = {}
+			// the navigation lives in a conditionally-rendered branch, so
+			// re-attach the resize observer once that branch is in the DOM
+			this.$nextTick(() => this.setupNavObserver())
 		},
 	},
 	mounted() {
@@ -794,13 +800,13 @@ export default {
 		}
 	}
 
-	:deep(.app-navigation--close) {
+	:deep(.app-navigation--closed) {
 		.app-navigation-toggle-wrapper {
 			margin-right: -33px !important;
 		}
 	}
 
-	:deep(.app-navigation--close ~ .session-area) {
+	:deep(.app-navigation--closed ~ .session-area) {
 		.session-area__chat-area, .session-area__input-area {
 			padding-left: 0 !important;
 		}

--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -221,7 +221,7 @@ export default {
 	height: calc(100vh - 32px);
 	max-height: calc(100vh - 32px);
 	height: 80%;
-	width: 70%;
+	width: min(1220px, 90vw);
 	resize: both;
 	overflow: hidden;
 	filter: drop-shadow(0 0 15px rgba(77, 77, 77, 0.5));

--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -8,10 +8,10 @@
 		:closable="false"
 		:dismissable-mask="false"
 		:close-on-escape="false"
-		:draggable="true"
+		:draggable="!isSmallMobile"
 		append-to="self"
 		:base-z-index="isInsideViewer ? 9998 : 5000"
-		class="assistant-modal">
+		:class="['assistant-modal', { 'assistant-modal--fullscreen': isSmallMobile }]">
 		<div ref="modal_content"
 			class="assistant-modal--wrapper">
 			<div class="assistant-modal--content">
@@ -59,6 +59,7 @@ import CloseIcon from 'vue-material-design-icons/Close.vue'
 import PrimeDialog from 'primevue/dialog'
 
 import NcButton from '@nextcloud/vue/components/NcButton'
+import { useIsSmallMobile } from '@nextcloud/vue/composables/useIsMobile'
 
 import AssistantTextProcessingForm from './AssistantTextProcessingForm.vue'
 
@@ -115,6 +116,9 @@ export default {
 		'load-task',
 		'new-task',
 	],
+	setup() {
+		return { isSmallMobile: useIsSmallMobile() }
+	},
 	data() {
 		return {
 			show: true,
@@ -228,6 +232,24 @@ export default {
 	color: var(--color-main-text);
 	background-color: var(--color-main-background);
 	border: 0;
+}
+
+.assistant-modal.p-dialog.assistant-modal--fullscreen,
+.assistant-modal.p-dialog.p-dialog-maximized {
+	inset: 0;
+	width: 100vw;
+	max-width: none;
+	height: 100vh;
+	max-height: none;
+	margin: 0;
+	border-radius: 0;
+	resize: none;
+	filter: none;
+	transform: none;
+}
+
+.assistant-modal.p-dialog.assistant-modal--fullscreen .p-dialog-header .p-dialog-maximize-button {
+	display: none;
 }
 
 .assistant-modal .p-dialog-header {

--- a/src/components/AssistantTextProcessingModal.vue
+++ b/src/components/AssistantTextProcessingModal.vue
@@ -258,7 +258,8 @@ export default {
 	left: 0;
 	right: 0;
 	z-index: 2;
-	min-height: 0;
+	// cover the absolutely-positioned maximize button so the drag strip stays grabbable
+	min-height: calc(var(--default-clickable-area) + 20px);
 	padding: 4px;
 	border: 0;
 	background: transparent;
@@ -267,10 +268,18 @@ export default {
 		cursor: grabbing;
 	}
 	.p-dialog-maximize-button {
+		position: absolute;
+		top: 10px;
+		left: 10px;
+		z-index: 3;
+		margin: 0 !important;
+		color: var(--color-main-text);
+		background-color: var(--color-main-background);
 		border-radius: var(--border-radius-element);
 		width: var(--default-clickable-area);
 		height: var(--default-clickable-area);
 		&:hover {
+			color: var(--color-main-text) !important;
 			background-color: var(--color-background-hover) !important;
 			border: none !important;
 		}

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -3,8 +3,8 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
   -->
 <template>
-	<div class="container">
-		<NcAppNavigation>
+	<div ref="container" class="container">
+		<NcAppNavigation ref="appNav">
 			<NcAppNavigationList>
 				<NcAppNavigationNew v-if="!isAssignment"
 					:text="t('assistant', 'New conversation')"
@@ -260,6 +260,8 @@ import ICAL from 'ical.js'
 import formatRecurrenceRule from './recurrenceRule.js'
 import { getLanguage } from '@nextcloud/l10n'
 
+import navAutoCollapse from '../../mixins/navAutoCollapse.js'
+
 // future: type (text, image, file, etc), attachments, etc support
 
 const getChatURL = (endpoint) => generateOcsUrl('/apps/assistant/chat' + endpoint)
@@ -299,6 +301,8 @@ export default {
 		InputArea,
 		NoSession,
 	},
+
+	mixins: [navAutoCollapse],
 
 	props: {
 		isAssignment: {
@@ -1236,13 +1240,13 @@ export default {
 		}
 	}
 
-	:deep(.app-navigation--close) {
+	:deep(.app-navigation--closed) {
 		.app-navigation-toggle-wrapper {
 			margin-right: -33px !important;
 		}
 	}
 
-	:deep(.app-navigation--close ~ .session-area) {
+	:deep(.app-navigation--closed ~ .session-area) {
 		.session-area__chat-area, .session-area__input-area {
 			padding-left: 0 !important;
 		}

--- a/src/mixins/navAutoCollapse.js
+++ b/src/mixins/navAutoCollapse.js
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// The assistant lives in a resizable/draggable dialog, so the navigation
+// visibility follows the dialog/container width rather than the viewport.
+const NAV_COLLAPSE_BREAKPOINT = 900
+
+/**
+ * Collapses the `NcAppNavigation` sidebar when the surrounding container gets
+ * narrower than NAV_COLLAPSE_BREAKPOINT and reopens it when it grows back.
+ *
+ * Unlike hiding the navigation, this drives the component's built-in open/close
+ * (by clicking its own toggle button) so the toggle stays visible and the
+ * sidebar remains reachable on a narrow dialog.
+ *
+ * The consuming component must set `ref="container"` on the observed element
+ * and `ref="appNav"` on its `<NcAppNavigation>`. If the container is rendered
+ * conditionally, call `setupNavObserver()` again once it appears.
+ */
+export default {
+	data() {
+		return {
+			// null = not evaluated yet, so the first observation always applies
+			navCollapsed: null,
+		}
+	},
+	mounted() {
+		this.setupNavObserver()
+	},
+	beforeUnmount() {
+		this.teardownNavObserver()
+	},
+	methods: {
+		setupNavObserver() {
+			this.teardownNavObserver()
+			const container = this.$refs.container
+			if (!container || typeof ResizeObserver === 'undefined') {
+				return
+			}
+			// reset so a re-setup (e.g. a conditionally rendered container) re-evaluates from scratch
+			this.navCollapsed = null
+			this.navResizeObserver = new ResizeObserver(this.onNavContainerResize)
+			this.navResizeObserver.observe(container)
+		},
+		teardownNavObserver() {
+			this.navResizeObserver?.disconnect()
+			this.navResizeObserver = null
+		},
+		onNavContainerResize(entries) {
+			const width = entries[0]?.contentRect.width
+			if (width === undefined) {
+				return
+			}
+			const shouldCollapse = width < NAV_COLLAPSE_BREAKPOINT
+			if (shouldCollapse === this.navCollapsed) {
+				return
+			}
+			this.navCollapsed = shouldCollapse
+			// defer to the next frame to avoid "ResizeObserver loop" warnings
+			window.requestAnimationFrame(() => this.setNavOpen(!shouldCollapse))
+		},
+		setNavOpen(open) {
+			// We deliberately drive NcAppNavigation through its own toggle button
+			// rather than emit('toggle-navigation') from @nextcloud/event-bus: that
+			// bus is global, so it would also collapse the host app's sidebar when
+			// resizing the assistant modal. NcAppNavigation exposes no `open` prop
+			// and doesn't expose toggleNavigation(), so its toggle button is the
+			// only instance-scoped lever.
+			const toggle = this.$refs.appNav?.$el?.querySelector('button.app-navigation-toggle')
+			if (!toggle) {
+				return
+			}
+			const isOpen = toggle.getAttribute('aria-expanded') === 'true'
+			if (isOpen !== open) {
+				toggle.click()
+			}
+		},
+	},
+}


### PR DESCRIPTION
Fix: #534.

- Collapse task history sidebar below 900px dialog width
- Widen the assistant dialog to `min(1220px, 90vw)`
- Fullscreen on small mobile 
- Fullscreen when maximzed (before it wasn't full height)
- Style and position the maximize/minimize button similarly to the close button

Before 

https://github.com/user-attachments/assets/bec29794-e554-478e-9c15-8620b268e6cb

After

https://github.com/user-attachments/assets/0056b376-59fe-40d2-b464-dea6d246779c


