### PR TITLE
Feature/chat message search

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -48,6 +48,7 @@ return [
 		['name' => 'chattyLLM#deleteMessage', 'url' => '/chat/delete_message', 'verb' => 'DELETE'],
 		['name' => 'chattyLLM#getMessages', 'url' => '/chat/messages', 'verb' => 'GET'],
 		['name' => 'chattyLLM#getMessage', 'url' => '/chat/sessions/{sessionId}/messages/{messageId}', 'verb' => 'GET'],
+		['name' => 'chattyLLM#searchMessages', 'url' => '/chat/search', 'verb' => 'GET'],
 		['name' => 'chattyLLM#generateForSession', 'url' => '/chat/generate', 'verb' => 'GET'],
 		['name' => 'chattyLLM#regenerateForSession', 'url' => '/chat/regenerate', 'verb' => 'GET'],
 		['name' => 'chattyLLM#checkSession', 'url' => '/chat/check_session', 'verb' => 'GET'],

--- a/lib/Controller/ChattyLLMController.php
+++ b/lib/Controller/ChattyLLMController.php
@@ -467,6 +467,32 @@ class ChattyLLMController extends OCSController {
 	}
 
 	/**
+	 * Search chat messages
+	 *
+	 * Search through all chat messages for the current user
+	 *
+	 * @param string $query The search query
+	 * @return JSONResponse<Http::STATUS_OK, array{messages: list<AssistantChatMessage>, sessionIds: list<int>}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>
+	 *
+	 * 200: Search results returned successfully
+	 * 401: Not logged in
+	 */
+	#[NoAdminRequired]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['chat_api'])]
+	public function searchMessages(string $query): JSONResponse {
+		try {
+			$result = $this->chatService->searchMessages($this->userId, $query);
+			return new JSONResponse($result);
+		} catch (InternalException $e) {
+			$this->logger->warning('Failed to search chat messages', ['exception' => $e]);
+			return new JSONResponse(['error' => $this->l10n->t('Failed to search chat messages')], Http::STATUS_INTERNAL_SERVER_ERROR);
+		} catch (UnauthorizedException $e) {
+			return new JSONResponse(['error' => $this->l10n->t('User not logged in')], Http::STATUS_UNAUTHORIZED);
+		}
+	}
+
+
+	/**
 	 * Generate a new assistant message
 	 *
 	 * Schedule a task to generate a new message for a session

--- a/lib/Controller/ChattyLLMController.php
+++ b/lib/Controller/ChattyLLMController.php
@@ -480,13 +480,14 @@ class ChattyLLMController extends OCSController {
 	#[NoAdminRequired]
 	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['chat_api'])]
 	public function searchMessages(string $query): JSONResponse {
+
 		try {
 			$result = $this->chatService->searchMessages($this->userId, $query);
 			return new JSONResponse($result);
 		} catch (InternalException $e) {
 			$this->logger->warning('Failed to search chat messages', ['exception' => $e]);
 			return new JSONResponse(['error' => $this->l10n->t('Failed to search chat messages')], Http::STATUS_INTERNAL_SERVER_ERROR);
-		} catch (UnauthorizedException $e) {
+		} catch (\OCA\Assistant\Service\UnauthorizedException $e) {
 			return new JSONResponse(['error' => $this->l10n->t('User not logged in')], Http::STATUS_UNAUTHORIZED);
 		}
 	}

--- a/lib/Db/ChattyLLM/MessageMapper.php
+++ b/lib/Db/ChattyLLM/MessageMapper.php
@@ -191,7 +191,7 @@ class MessageMapper extends QBMapper {
 	 */
 	public function searchMessages(string $userId, string $query, int $limit = 100): array {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select(Message::$columns)
+		$qb->select(array_map(fn ($col) => 'm.' . $col, Message::$columns))
 			->from($this->getTableName(), 'm')
 			->join('m', 'assistant_chat_sns', 's', $qb->expr()->eq('m.session_id', 's.id'))
 			->where($qb->expr()->eq('s.user_id', $qb->createPositionalParameter($userId, IQueryBuilder::PARAM_STR)))

--- a/lib/Db/ChattyLLM/MessageMapper.php
+++ b/lib/Db/ChattyLLM/MessageMapper.php
@@ -190,14 +190,29 @@ class MessageMapper extends QBMapper {
 	 * @throws \OCP\DB\Exception
 	 */
 	public function searchMessages(string $userId, string $query, int $limit = 100): array {
+		// Split the query into individual words on whitespace
+		$words = array_filter(preg_split('/\s+/', trim($query)));
+
+		if (empty($words)) { // A guard for the edge case where the query is empty or consists of all whitespaces
+			return [];
+		}
+
 		$qb = $this->db->getQueryBuilder();
-		$qb->select(array_map(fn ($col) => 'm.' . $col, Message::$columns))
+		$qb->select(array_map(fn ($col) => 'm.' . $col . ' AS ' . $col, Message::$columns))
 			->from($this->getTableName(), 'm')
-			->join('m', 'assistant_chat_sns', 's', $qb->expr()->eq('m.session_id', 's.id'))
-			->where($qb->expr()->eq('s.user_id', $qb->createPositionalParameter($userId, IQueryBuilder::PARAM_STR)))
-			->andWhere($qb->expr()->iLike('m.content', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($query) . '%', IQueryBuilder::PARAM_STR)))
-			->orderBy('m.timestamp', 'DESC')
-			->setMaxResults($limit);
+			->join('m', 'assistant_chat_sns', 's', $qb->expr()->eq('m.session_id', 's.id')) 
+			->where($qb->expr()->eq('s.user_id', $qb->createPositionalParameter($userId, IQueryBuilder::PARAM_STR)));
+
+		// Add a andWhere for each word and then AND them all together on to the query builder
+		foreach ($words as $word) {
+				$qb->andWhere($qb->expr()->iLike(
+					'm.content',
+					$qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($word) . '%', IQueryBuilder::PARAM_STR),
+				));
+			}
+
+			$qb->orderBy('m.timestamp', 'DESC')
+				->setMaxResults($limit);
 
 		return $this->findEntities($qb);
 	}

--- a/lib/Db/ChattyLLM/MessageMapper.php
+++ b/lib/Db/ChattyLLM/MessageMapper.php
@@ -181,4 +181,33 @@ class MessageMapper extends QBMapper {
 
 		$qb->executeStatement();
 	}
+
+	/**
+	 * @param string $userId
+	 * @param string $query
+	 * @param int $limit
+	 * @return list<Message>
+	 * @throws \OCP\DB\Exception
+	 */
+	public function searchMessages(string $userId, string $query, int $limit = 100): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select(Message::$columns)
+			->from($this->getTableName(), 'm')
+			->join('m', 'assistant_chat_sns', 's',
+				$qb->expr()->eq('m.session_id', 's.id')
+			)
+			->where($qb->expr()->eq('s.user_id',
+				$qb->createPositionalParameter($userId, IQueryBuilder::PARAM_STR)
+			))
+			->andWhere($qb->expr()->iLike('m.content',
+				$qb->createPositionalParameter(
+					'%' . $this->db->escapeLikeParameter($query) . '%',
+					IQueryBuilder::PARAM_STR
+				)
+			))
+			->orderBy('m.timestamp', 'DESC')
+			->setMaxResults($limit);
+
+		return $this->findEntities($qb);
+	}
 }

--- a/lib/Db/ChattyLLM/MessageMapper.php
+++ b/lib/Db/ChattyLLM/MessageMapper.php
@@ -193,18 +193,9 @@ class MessageMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select(Message::$columns)
 			->from($this->getTableName(), 'm')
-			->join('m', 'assistant_chat_sns', 's',
-				$qb->expr()->eq('m.session_id', 's.id')
-			)
-			->where($qb->expr()->eq('s.user_id',
-				$qb->createPositionalParameter($userId, IQueryBuilder::PARAM_STR)
-			))
-			->andWhere($qb->expr()->iLike('m.content',
-				$qb->createPositionalParameter(
-					'%' . $this->db->escapeLikeParameter($query) . '%',
-					IQueryBuilder::PARAM_STR
-				)
-			))
+			->join('m', 'assistant_chat_sns', 's', $qb->expr()->eq('m.session_id', 's.id'))
+			->where($qb->expr()->eq('s.user_id', $qb->createPositionalParameter($userId, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->iLike('m.content', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($query) . '%', IQueryBuilder::PARAM_STR)))
 			->orderBy('m.timestamp', 'DESC')
 			->setMaxResults($limit);
 

--- a/lib/Service/ChatService.php
+++ b/lib/Service/ChatService.php
@@ -169,6 +169,31 @@ class ChatService {
 	}
 
 	/**
+	 * @return array{messages: list<array<string,mixed>>, sessionIds: list<int>}
+	 * @throws UnauthorizedException
+	 * @throws InternalException
+	 */
+	public function searchMessages(?string $userId, string $query): array {
+		if ($userId === null) {
+			throw new UnauthorizedException($this->l10n->t('Unauthorized'));
+		}
+		if (trim($query) === '') {
+			return ['messages' => [], 'sessionIds' => []];
+		}
+		try {
+			$messages = $this->messageMapper->searchMessages($userId, $query);
+		} catch (Exception $e) {
+			throw new InternalException(previous: $e);
+		}
+		$sessionIds = array_values(array_unique(
+			array_map(fn(Message $m) => $m->getSessionId(), $messages)
+		));
+		return [
+			'messages' => array_map(fn(Message $m) => $m->jsonSerialize(), $messages),
+			'sessionIds' => $sessionIds,
+		];
+	}
+	/**
 	 * @throws BadRequestException
 	 * @throws InternalException
 	 * @throws NotFoundException

--- a/lib/Service/ChatService.php
+++ b/lib/Service/ChatService.php
@@ -177,6 +177,7 @@ class ChatService {
 		if ($userId === null) {
 			throw new UnauthorizedException($this->l10n->t('Unauthorized'));
 		}
+		// For empty queries return two empty lists right away
 		if (trim($query) === '') {
 			return ['messages' => [], 'sessionIds' => []];
 		}
@@ -189,7 +190,7 @@ class ChatService {
 			array_map(fn(Message $m) => $m->getSessionId(), $messages)
 		));
 		return [
-			'messages' => array_map(fn(Message $m) => $m->jsonSerialize(), $messages),
+			'messages' => array_map(fn(Message $m) => $m->jsonSerialize(), $messages), // convert Message objects into plain arrays
 			'sessionIds' => $sessionIds,
 		];
 	}

--- a/lib/Service/ChatService.php
+++ b/lib/Service/ChatService.php
@@ -187,10 +187,10 @@ class ChatService {
 			throw new InternalException(previous: $e);
 		}
 		$sessionIds = array_values(array_unique(
-			array_map(fn(Message $m) => $m->getSessionId(), $messages)
+			array_map(fn (Message $m) => $m->getSessionId(), $messages)
 		));
 		return [
-			'messages' => array_map(fn(Message $m) => $m->jsonSerialize(), $messages), // convert Message objects into plain arrays
+			'messages' => array_map(fn (Message $m) => $m->jsonSerialize(), $messages), // convert Message objects into plain arrays
 			'sessionIds' => $sessionIds,
 		];
 	}

--- a/lib/Service/ChatService.php
+++ b/lib/Service/ChatService.php
@@ -169,7 +169,7 @@ class ChatService {
 	}
 
 	/**
-	 * @return array{messages: list<array<string,mixed>>, sessionIds: list<int>}
+	 * @return array{messages: list<array{id: int, session_id: int, role: string, content: string, timestamp: int, ocp_task_id: int, sources: string, attachments: list<array{type: string, fileId: int}>}>, sessionIds: list<int>}
 	 * @throws UnauthorizedException
 	 * @throws InternalException
 	 */
@@ -187,10 +187,12 @@ class ChatService {
 			throw new InternalException(previous: $e);
 		}
 		$sessionIds = array_values(array_unique(
-			array_map(fn (Message $m) => $m->getSessionId(), $messages)
+			array_map(fn (Message $m) => $m->getSessionId(), $messages) // Extract the session id from each message, remove duplicates, re-index the array
 		));
+		/** @var list<array{id: int, session_id: int, role: string, content: string, timestamp: int, ocp_task_id: int, sources: string, attachments: list<array{type: string, fileId: int}>}> $serializedMessages */
+		$serializedMessages = array_map(fn (Message $m) => $m->jsonSerialize(), $messages);
 		return [
-			'messages' => array_map(fn (Message $m) => $m->jsonSerialize(), $messages), // convert Message objects into plain arrays
+			'messages' => $serializedMessages,
 			'sessionIds' => $sessionIds,
 		];
 	}

--- a/openapi.json
+++ b/openapi.json
@@ -4292,6 +4292,137 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/assistant/chat/search": {
+            "get": {
+                "operationId": "chattyllm-search-messages",
+                "summary": "Search chat messages",
+                "description": "Search through all chat messages for the current user",
+                "tags": [
+                    "chat_api"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "description": "The search query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Search results returned successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "messages",
+                                        "sessionIds"
+                                    ],
+                                    "properties": {
+                                        "messages": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/ChatMessage"
+                                            }
+                                        },
+                                        "sessionIds": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "integer",
+                                                "format": "int64"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "ocs"
+                                            ],
+                                            "properties": {
+                                                "ocs": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "meta",
+                                                        "data"
+                                                    ],
+                                                    "properties": {
+                                                        "meta": {
+                                                            "$ref": "#/components/schemas/OCSMeta"
+                                                        },
+                                                        "data": {}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/assistant/chat/generate": {
             "get": {
                 "operationId": "chattyllm-generate-for-session",

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -13,6 +13,9 @@
 						<PlusIcon :size="20" />
 					</template>
 				</NcAppNavigationNew>
+				<NcAppNavigationSearch
+					v-model="searchQuery"
+					:placeholder="t('assistant', 'Search messages…')" />
 				<div v-if="sessions == null" class="unloaded-sessions">
 					<NcLoadingIcon :size="30" />
 					{{ t('assistant', 'Loading conversations…') }}
@@ -20,8 +23,11 @@
 				<div v-else-if="sessions != null && sessions.length === 0" class="unloaded-sessions">
 					{{ t('assistant', 'No conversations yet') }}
 				</div>
+				<div v-else-if="searchResults !== null && filteredSessions.length === 0" class="unloaded-sessions">
+					{{ t('assistant', 'No conversations match your search') }}
+				</div>
 				<NcAppNavigationItem
-					v-for="session in sessions"
+					v-for="session in filteredSessions"
 					v-else
 					:key="'conversation' + session.id"
 					:active="session.id === active?.id"
@@ -204,6 +210,7 @@ import NcAppNavigationNew from '@nextcloud/vue/components/NcAppNavigationNew'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
+import NcAppNavigationSearch from '@nextcloud/vue/components/NcAppNavigationSearch'
 
 import ConversationBox from './ConversationBox.vue'
 import EditableTextField from './EditableTextField.vue'
@@ -221,6 +228,7 @@ import { SHAPE_TYPE_NAMES, TASK_STATUS_INT } from '../../constants.js'
 // future: type (text, image, file, etc), attachments, etc support
 
 const getChatURL = (endpoint) => generateOcsUrl('/apps/assistant/chat' + endpoint)
+
 const Roles = {
 	HUMAN: 'human',
 	ASSISTANT: 'assistant',
@@ -247,6 +255,7 @@ export default {
 		NcAppNavigationItem,
 		NcAppNavigationList,
 		NcAppNavigationNew,
+		NcAppNavigationSearch,
 		NcButton,
 		NcLoadingIcon,
 		NcDialog,
@@ -279,6 +288,7 @@ export default {
 				newSession: false,
 				messageDelete: false,
 				sessionDelete: false,
+				search: false,
 			},
 			msgCursor: 0,
 			msgLimit: 20,
@@ -303,6 +313,9 @@ export default {
 					message: t('assisant', 'Which actions can you do for me?'),
 				},
 			],
+			searchQuery: '',
+			searchResults: null,
+			searchDebounceTimer: null,
 		}
 	},
 
@@ -314,6 +327,13 @@ export default {
 			const session = this.sessions.find(s => s.id === this.sessionIdToDelete)
 			const sessionTitle = this.getSessionTitle(session)?.trim()
 			return t('assistant', 'Are you sure you want to delete "{sessionTitle}"?', { sessionTitle })
+		},
+
+		filteredSessions() {
+			if (!this.sessions || this.searchResults === null) {
+				return this.sessions
+			}
+			return this.sessions.filter(s => this.searchResults.sessionIds.includes(s.id))
 		},
 	},
 
@@ -391,6 +411,17 @@ export default {
 				this.loading.llmRunning = false
 				this.loading.titleGeneration = false
 			}
+		},
+
+		searchQuery(newVal) {
+			clearTimeout(this.searchDebounceTimer)
+			if (!newVal.trim()) {
+				this.searchResults = null
+				return
+			}
+			this.searchDebounceTimer = setTimeout(() => {
+				this.performSearch(newVal.trim())
+			}, 350)
 		},
 	},
 
@@ -912,6 +943,20 @@ export default {
 			}
 			const url = generateUrl('/apps/assistant/config')
 			return axios.put(url, req)
+		},
+
+		async performSearch(query) {
+			this.loading.search = true
+			try {
+				const response = await axios.get(getChatURL('/search'), { params: { query } })
+				this.searchResults = response.data
+			} catch (error) {
+				console.error('Search error:', error)
+				showError(error?.response?.data?.error ?? t('assistant', 'Error searching messages'))
+				this.searchResults = null
+			} finally {
+				this.loading.search = false
+			}
 		},
 	},
 }

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -415,6 +415,7 @@ export default {
 		},
 
 		searchQuery(newVal) {
+			console.debug('[search] searchQuery changed to:', JSON.stringify(newVal))
 			clearTimeout(this.searchDebounceTimer)
 			if (!newVal.trim()) {
 				this.searchResults = null

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -127,6 +127,7 @@
 						:loading="loading"
 						:slow-pickup="slowPickup"
 						:search-query="searchQuery"
+						:matching-message-ids="matchingMessageIds"
 						@regenerate="runRegenerationTask"
 						@delete="deleteMessage" />
 					<div v-if="messages != null && messages.length > 0 && !loading.llmGeneration && !loading.newHumanMessage && messages[messages.length - 1]?.role === 'human'" class="session-area__chat-area__active-session__utility-button">
@@ -335,6 +336,10 @@ export default {
 				return this.sessions
 			}
 			return this.sessions.filter(s => this.searchResults.sessionIds.includes(s.id))
+		},
+
+		matchingMessageIds() {
+			return new Set(this.searchResults?.messages?.map(m => m.id) ?? [])
 		},
 	},
 

--- a/src/components/ChattyLLM/ChattyLLMInputForm.vue
+++ b/src/components/ChattyLLM/ChattyLLMInputForm.vue
@@ -126,6 +126,7 @@
 					<ConversationBox :messages="messages"
 						:loading="loading"
 						:slow-pickup="slowPickup"
+						:search-query="searchQuery"
 						@regenerate="runRegenerationTask"
 						@delete="deleteMessage" />
 					<div v-if="messages != null && messages.length > 0 && !loading.llmGeneration && !loading.newHumanMessage && messages[messages.length - 1]?.role === 'human'" class="session-area__chat-area__active-session__utility-button">

--- a/src/components/ChattyLLM/ConversationBox.vue
+++ b/src/components/ChattyLLM/ConversationBox.vue
@@ -29,6 +29,7 @@
 				:regenerate-loading="loading.llmGeneration && message.id === regenerateFromId"
 				:new-message-loading="loading.newHumanMessage && idx === (messages.length - 1)"
 				:information-source-names="informationSourceNames"
+				:search-query="searchQuery"
 				@regenerate="regenerate(message.id)"
 				@delete="deleteMessage(message.id)" />
 			<LoadingPlaceholder v-if="loading.llmGeneration" :slow-pickup="slowPickup" />
@@ -82,6 +83,10 @@ export default {
 		slowPickup: {
 			type: Boolean,
 			default: false,
+		},
+		searchQuery: {
+			type: String,
+			default: '',
 		},
 	},
 

--- a/src/components/ChattyLLM/ConversationBox.vue
+++ b/src/components/ChattyLLM/ConversationBox.vue
@@ -29,7 +29,7 @@
 				:regenerate-loading="loading.llmGeneration && message.id === regenerateFromId"
 				:new-message-loading="loading.newHumanMessage && idx === (messages.length - 1)"
 				:information-source-names="informationSourceNames"
-				:search-query="searchQuery"
+				:search-query="matchingMessageIds.has(message.id) ? searchQuery : ''"
 				@regenerate="regenerate(message.id)"
 				@delete="deleteMessage(message.id)" />
 			<LoadingPlaceholder v-if="loading.llmGeneration" :slow-pickup="slowPickup" />
@@ -87,6 +87,10 @@ export default {
 		searchQuery: {
 			type: String,
 			default: '',
+		},
+		matchingMessageIds: {
+			type: Set,
+			default: () => new Set(),
 		},
 	},
 

--- a/src/components/ChattyLLM/Message.vue
+++ b/src/components/ChattyLLM/Message.vue
@@ -55,16 +55,13 @@
 			</div>
 			<NcDateTime class="message__header__timestamp" :timestamp="new Date((message?.timestamp ?? 0) * 1000)" :ignore-seconds="true" />
 		</div>
-		<NcRichText v-if="!searchQuery"
+		<NcRichText
 			class="message__content"
 			:text="message.content"
 			:use-markdown="true"
 			:reference-limit="1"
 			:references="references"
 			:autolink="true" />
-		<div v-else
-			class="message__content message__content--highlighted"
-			v-html="highlightedContent" />
 		<AudioDisplay v-for="a in audioAttachments"
 			:key="a.type + '-' + a.file_id"
 			class="message__content"
@@ -179,16 +176,15 @@ export default {
 		audioAttachments() {
 			return this.message.attachments?.filter(a => a.type === SHAPE_TYPE_NAMES.Audio) ?? []
 		},
-		highlightedContent() {
+		displayContent() {
 			if (!this.searchQuery || !this.message.content) {
 				return this.message.content
 			}
-			const escapeHtml = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 			const regexEscaped = this.searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-			const parts = this.message.content.split(new RegExp(`(${regexEscaped})`, 'gi'))
-			return parts.map((part, i) =>
-				i % 2 === 1 ? `<mark>${escapeHtml(part)}</mark>` : escapeHtml(part),
-			).join('')
+			return this.message.content.replace(
+				new RegExp(`(${regexEscaped})`, 'gi'),
+				'**$1**',
+			)
 		},
 	},
 
@@ -273,18 +269,6 @@ export default {
 
 		:deep(.widget-default), :deep(.widget-custom) {
 			width: auto !important;
-		}
-
-		&--highlighted {
-			white-space: pre-wrap;
-			word-wrap: break-word;
-
-			:deep(mark) {
-				background-color: var(--color-warning);
-				color: var(--color-main-text);
-				border-radius: 2px;
-				padding: 0 2px;
-			}
 		}
 	}
 }

--- a/src/components/ChattyLLM/Message.vue
+++ b/src/components/ChattyLLM/Message.vue
@@ -55,12 +55,16 @@
 			</div>
 			<NcDateTime class="message__header__timestamp" :timestamp="new Date((message?.timestamp ?? 0) * 1000)" :ignore-seconds="true" />
 		</div>
-		<NcRichText class="message__content"
+		<NcRichText v-if="!searchQuery"
+			class="message__content"
 			:text="message.content"
 			:use-markdown="true"
 			:reference-limit="1"
 			:references="references"
 			:autolink="true" />
+		<div v-else
+			class="message__content message__content--highlighted"
+			v-html="highlightedContent" />
 		<AudioDisplay v-for="a in audioAttachments"
 			:key="a.type + '-' + a.file_id"
 			class="message__content"
@@ -139,6 +143,10 @@ export default {
 			type: Object,
 			default: null,
 		},
+		searchQuery: {
+			type: String,
+			default: '',
+		},
 	},
 
 	emits: ['delete', 'regenerate'],
@@ -170,6 +178,17 @@ export default {
 		},
 		audioAttachments() {
 			return this.message.attachments?.filter(a => a.type === SHAPE_TYPE_NAMES.Audio) ?? []
+		},
+		highlightedContent() {
+			if (!this.searchQuery || !this.message.content) {
+				return this.message.content
+			}
+			const escapeHtml = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+			const regexEscaped = this.searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+			const parts = this.message.content.split(new RegExp(`(${regexEscaped})`, 'gi'))
+			return parts.map((part, i) =>
+				i % 2 === 1 ? `<mark>${escapeHtml(part)}</mark>` : escapeHtml(part),
+			).join('')
 		},
 	},
 
@@ -254,6 +273,18 @@ export default {
 
 		:deep(.widget-default), :deep(.widget-custom) {
 			width: auto !important;
+		}
+
+		&--highlighted {
+			white-space: pre-wrap;
+			word-wrap: break-word;
+
+			:deep(mark) {
+				background-color: var(--color-warning);
+				color: var(--color-main-text);
+				border-radius: 2px;
+				padding: 0 2px;
+			}
 		}
 	}
 }

--- a/tests/unit/Service/ChatServiceSearchTest.php
+++ b/tests/unit/Service/ChatServiceSearchTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Assistant\Tests;
+
+use OCA\Assistant\Db\ChattyLLM\Message;
+use OCA\Assistant\Db\ChattyLLM\MessageMapper;
+use OCA\Assistant\Db\ChattyLLM\SessionMapper;
+use OCA\Assistant\Service\ChatService;
+use OCA\Assistant\Service\SessionSummaryService;
+use OCA\Assistant\Service\UnauthorizedException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use OCP\IL10N;
+use OCP\IUserManager;
+use OCP\TaskProcessing\IManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class ChatServiceSearchTest extends TestCase {
+
+    private ChatService $service;
+    private MessageMapper $messageMapper;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        // Mock all ChatService dependencies
+        $this->messageMapper = $this->createMock(MessageMapper::class);
+
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $this->service = new ChatService(
+            $this->createMock(IUserManager::class),
+            $this->createMock(IAppConfig::class),
+            $l10n,
+            $this->createMock(SessionMapper::class),
+            $this->messageMapper,
+            $this->createMock(SessionSummaryService::class),
+            $this->createMock(IManager::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(ITimeFactory::class),
+        );
+    }
+
+    public function testSearchMessagesUserIdNull(): void {
+        // UserId = null should throw an error
+        $this->expectException(UnauthorizedException::class);
+        $this->service->searchMessages(null, 'hello');
+    }
+
+    public function testSearchMessagesBlankQuery(): void {
+        // A blank query should not hit the database but return empty
+        $this->messageMapper->expects($this->never())
+            ->method('searchMessages');
+
+        $result = $this->service->searchMessages('user1', '   ');
+
+        $this->assertSame([], $result['messages']);
+        $this->assertSame([], $result['sessionIds']);
+    }
+
+    public function testSearchMessagesSameSession(): void {
+        // Two messages from the same session
+        $msg1 = new Message();
+        $msg1->setSessionId(1);
+        $msg1->setRole(Message::ROLE_HUMAN);
+        $msg1->setContent('hello assistant');
+        $msg1->setTimestamp(1000);
+        $msg1->setSources('[]');
+        $msg1->setAttachments('[]');
+
+        $msg2 = new Message();
+        $msg2->setSessionId(1);
+        $msg2->setRole(Message::ROLE_ASSISTANT);
+        $msg2->setContent('hello human');
+        $msg2->setTimestamp(1001);
+        $msg2->setSources('[]');
+        $msg2->setAttachments('[]');
+
+        $this->messageMapper->expects($this->once())
+            ->method('searchMessages')
+            ->with('user1', 'hello')
+            ->willReturn([$msg1, $msg2]);
+
+        $result = $this->service->searchMessages('user1', 'hello');
+
+        // Two messages returned
+        $this->assertCount(2, $result['messages']);
+        // Check that the messages have the same session ID
+        $this->assertSame([1], $result['sessionIds']);
+    }
+
+    public function testSearchMessagesDifferentSession(): void {
+        $msg1 = new Message();
+        $msg1->setSessionId(2);
+        $msg1->setRole(Message::ROLE_HUMAN);
+        $msg1->setContent('hello from session 2');
+        $msg1->setTimestamp(1000);
+        $msg1->setSources('[]');
+        $msg1->setAttachments('[]');
+
+        $msg2 = new Message();
+        $msg2->setSessionId(3);
+        $msg2->setRole(Message::ROLE_HUMAN);
+        $msg2->setContent('hello from session 3');
+        $msg2->setTimestamp(1001);
+        $msg2->setSources('[]');
+        $msg2->setAttachments('[]');
+
+        $this->messageMapper->expects($this->once())
+            ->method('searchMessages')
+            ->with('user1', 'hello')
+            ->willReturn([$msg1, $msg2]);
+
+        $result = $this->service->searchMessages('user1', 'hello');
+
+        $this->assertCount(2, $result['messages']);
+
+        // Check that the messages have different session IDs
+        $this->assertSame([2, 3], $result['sessionIds']);
+    }
+}

--- a/tests/unit/Service/ChatServiceSearchTest.php
+++ b/tests/unit/Service/ChatServiceSearchTest.php
@@ -25,106 +25,106 @@ use Psr\Log\LoggerInterface;
 
 class ChatServiceSearchTest extends TestCase {
 
-    private ChatService $service;
-    private MessageMapper $messageMapper;
+	private ChatService $service;
+	private MessageMapper $messageMapper;
 
-    protected function setUp(): void {
-        parent::setUp();
+	protected function setUp(): void {
+		parent::setUp();
 
-        // Mock all ChatService dependencies
-        $this->messageMapper = $this->createMock(MessageMapper::class);
+		// Mock all ChatService dependencies
+		$this->messageMapper = $this->createMock(MessageMapper::class);
 
-        $l10n = $this->createMock(IL10N::class);
-        $l10n->method('t')->willReturnArgument(0);
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
 
-        $this->service = new ChatService(
-            $this->createMock(IUserManager::class),
-            $this->createMock(IAppConfig::class),
-            $l10n,
-            $this->createMock(SessionMapper::class),
-            $this->messageMapper,
-            $this->createMock(SessionSummaryService::class),
-            $this->createMock(IManager::class),
-            $this->createMock(LoggerInterface::class),
-            $this->createMock(ITimeFactory::class),
-        );
-    }
+		$this->service = new ChatService(
+			$this->createMock(IUserManager::class),
+			$this->createMock(IAppConfig::class),
+			$l10n,
+			$this->createMock(SessionMapper::class),
+			$this->messageMapper,
+			$this->createMock(SessionSummaryService::class),
+			$this->createMock(IManager::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(ITimeFactory::class),
+		);
+	}
 
-    public function testSearchMessagesUserIdNull(): void {
-        // UserId = null should throw an error
-        $this->expectException(UnauthorizedException::class);
-        $this->service->searchMessages(null, 'hello');
-    }
+	public function testSearchMessagesUserIdNull(): void {
+		// UserId = null should throw an error
+		$this->expectException(UnauthorizedException::class);
+		$this->service->searchMessages(null, 'hello');
+	}
 
-    public function testSearchMessagesBlankQuery(): void {
-        // A blank query should not hit the database but return empty
-        $this->messageMapper->expects($this->never())
-            ->method('searchMessages');
+	public function testSearchMessagesBlankQuery(): void {
+		// A blank query should not hit the database but return empty
+		$this->messageMapper->expects($this->never())
+			->method('searchMessages');
 
-        $result = $this->service->searchMessages('user1', '   ');
+		$result = $this->service->searchMessages('user1', '   ');
 
-        $this->assertSame([], $result['messages']);
-        $this->assertSame([], $result['sessionIds']);
-    }
+		$this->assertSame([], $result['messages']);
+		$this->assertSame([], $result['sessionIds']);
+	}
 
-    public function testSearchMessagesSameSession(): void {
-        // Two messages from the same session
-        $msg1 = new Message();
-        $msg1->setSessionId(1);
-        $msg1->setRole(Message::ROLE_HUMAN);
-        $msg1->setContent('hello assistant');
-        $msg1->setTimestamp(1000);
-        $msg1->setSources('[]');
-        $msg1->setAttachments('[]');
+	public function testSearchMessagesSameSession(): void {
+		// Two messages from the same session
+		$msg1 = new Message();
+		$msg1->setSessionId(1);
+		$msg1->setRole(Message::ROLE_HUMAN);
+		$msg1->setContent('hello assistant');
+		$msg1->setTimestamp(1000);
+		$msg1->setSources('[]');
+		$msg1->setAttachments('[]');
 
-        $msg2 = new Message();
-        $msg2->setSessionId(1);
-        $msg2->setRole(Message::ROLE_ASSISTANT);
-        $msg2->setContent('hello human');
-        $msg2->setTimestamp(1001);
-        $msg2->setSources('[]');
-        $msg2->setAttachments('[]');
+		$msg2 = new Message();
+		$msg2->setSessionId(1);
+		$msg2->setRole(Message::ROLE_ASSISTANT);
+		$msg2->setContent('hello human');
+		$msg2->setTimestamp(1001);
+		$msg2->setSources('[]');
+		$msg2->setAttachments('[]');
 
-        $this->messageMapper->expects($this->once())
-            ->method('searchMessages')
-            ->with('user1', 'hello')
-            ->willReturn([$msg1, $msg2]);
+		$this->messageMapper->expects($this->once())
+			->method('searchMessages')
+			->with('user1', 'hello')
+			->willReturn([$msg1, $msg2]);
 
-        $result = $this->service->searchMessages('user1', 'hello');
+		$result = $this->service->searchMessages('user1', 'hello');
 
-        // Two messages returned
-        $this->assertCount(2, $result['messages']);
-        // Check that the messages have the same session ID
-        $this->assertSame([1], $result['sessionIds']);
-    }
+		// Two messages returned
+		$this->assertCount(2, $result['messages']);
+		// Check that the messages have the same session ID
+		$this->assertSame([1], $result['sessionIds']);
+	}
 
-    public function testSearchMessagesDifferentSession(): void {
-        $msg1 = new Message();
-        $msg1->setSessionId(2);
-        $msg1->setRole(Message::ROLE_HUMAN);
-        $msg1->setContent('hello from session 2');
-        $msg1->setTimestamp(1000);
-        $msg1->setSources('[]');
-        $msg1->setAttachments('[]');
+	public function testSearchMessagesDifferentSession(): void {
+		$msg1 = new Message();
+		$msg1->setSessionId(2);
+		$msg1->setRole(Message::ROLE_HUMAN);
+		$msg1->setContent('hello from session 2');
+		$msg1->setTimestamp(1000);
+		$msg1->setSources('[]');
+		$msg1->setAttachments('[]');
 
-        $msg2 = new Message();
-        $msg2->setSessionId(3);
-        $msg2->setRole(Message::ROLE_HUMAN);
-        $msg2->setContent('hello from session 3');
-        $msg2->setTimestamp(1001);
-        $msg2->setSources('[]');
-        $msg2->setAttachments('[]');
+		$msg2 = new Message();
+		$msg2->setSessionId(3);
+		$msg2->setRole(Message::ROLE_HUMAN);
+		$msg2->setContent('hello from session 3');
+		$msg2->setTimestamp(1001);
+		$msg2->setSources('[]');
+		$msg2->setAttachments('[]');
 
-        $this->messageMapper->expects($this->once())
-            ->method('searchMessages')
-            ->with('user1', 'hello')
-            ->willReturn([$msg1, $msg2]);
+		$this->messageMapper->expects($this->once())
+			->method('searchMessages')
+			->with('user1', 'hello')
+			->willReturn([$msg1, $msg2]);
 
-        $result = $this->service->searchMessages('user1', 'hello');
+		$result = $this->service->searchMessages('user1', 'hello');
 
-        $this->assertCount(2, $result['messages']);
+		$this->assertCount(2, $result['messages']);
 
-        // Check that the messages have different session IDs
-        $this->assertSame([2, 3], $result['sessionIds']);
-    }
+		// Check that the messages have different session IDs
+		$this->assertSame([2, 3], $result['sessionIds']);
+	}
 }


### PR DESCRIPTION
Added for backend:
- ``MessageMapper::searchMessages()`` a method to query messages across all sessions from a user sessions. It uses case-insensitive LIKE '%query%' search. The messages table is joined against the sessions table to ensure user scoping with the user id. A limitation here is that search does not use a database index on the content column, so a full table scan is performed. On large instances with a lot of message this can become slow.
- ``ChatService::searchMessages()`` a method to orchestrate the search. It returns matching messages with their session IDs
- ``ChattyLLMController::searchMessages()``  new GET /chat/search?query= OCS endpoint
- Route registered in ``appinfo/routes.php``
- Unit tests for the service layer covering empty query, null user, deduplication of session IDs, and multiple session results

Added for frontend:
- ``searchMessages()``an api helper to call GET /chat/search?query= endpoint
- Search input field (imported from ``@nextcloud/vue/components/NcAppNavigationSearch``) in the chat sidebar
- Debounced querying at a 350 ms rate and a clear button
- Session list filters to show only conversations containing matching messages when a search is active
- An info message in the sidebar with "No conversations match your search" for when the query returns no results
- ``searchQuery`` is passed as a prop through ``ChattyLLMInputForm.vue`` to ``ConversationBox.vue`` to ``Message.vue``
- Text matching the search query is highlighted in yellow via ``highlightedContent`` that is computed (+styled) in ``Message.vue``