### PR TITLE
feat: add core:audio2text:subtitles task type, register file action

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -128,6 +128,24 @@ class Capabilities implements IPublicCapability {
 					'icon' => $this->urlGenerator->imagePath(Application::APP_ID, 'client_integration/speech_to_text.svg'),
 				];
 				$capabilities['client_integration'][Application::APP_ID]['context-menu'][] = $endpoint;
+
+				if (class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles')) {
+					$url = $this->urlGenerator->linkToOCSRouteAbsolute(Application::APP_ID . '.assistantApi.runFileAction', [
+						'apiVersion' => 'v1',
+						'fileId' => '123456789',
+						'taskTypeId' => \OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles::ID,
+					]);
+					$url = str_replace($this->urlGenerator->getBaseUrl(), '', $url);
+					$url = str_replace('123456789', '{fileId}', $url);
+					$endpoint = [
+						'name' => $this->l->t('Generate subtitles using AI'),
+						'url' => $url,
+						'method' => 'POST',
+						'mimetype_filters' => 'audio/, video/',
+						'icon' => $this->urlGenerator->imagePath(Application::APP_ID, 'client_integration/speech_to_text.svg'),
+					];
+					$capabilities['client_integration'][Application::APP_ID]['context-menu'][] = $endpoint;
+				}
 			}
 
 			if ($ttsAvailable) {

--- a/lib/Controller/AssistantApiController.php
+++ b/lib/Controller/AssistantApiController.php
@@ -432,6 +432,10 @@ class AssistantApiController extends OCSController {
 			$message = $this->l10n->t('Assistant task submitted successfully');
 			if ($taskTypeId === AudioToText::ID) {
 				$message = $this->l10n->t('Transcription task submitted successfully');
+			} elseif (class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles')) {
+				if ($taskTypeId === \OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles::ID) {
+					$message = $this->l10n->t('Subtitles task submitted successfully');
+				}
 			} elseif ($taskTypeId === TextToTextSummary::ID) {
 				$message = $this->l10n->t('Summarization task submitted successfully');
 			} elseif (class_exists('OCP\\TaskProcessing\\TaskTypes\\TextToSpeech')) {

--- a/lib/Listener/FileActionTaskSuccessfulListener.php
+++ b/lib/Listener/FileActionTaskSuccessfulListener.php
@@ -75,6 +75,18 @@ class FileActionTaskSuccessfulListener implements IEventListener {
 					}
 					$targetFileName = $sourceFile->getName() . ' - text to speech.' . $extension;
 					$targetFile = $sourceFileParent->newFile($targetFileName, $speechFile->fopen('rb'));
+				} elseif (
+					class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles')
+					&& $taskTypeId === \OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles::ID
+				) {
+					$subtitlesFileId = (int)$task->getOutput()['output'];
+					$subtitlesFile = $this->taskProcessingService->getOutputFile($subtitlesFileId);
+					$mimeType = mime_content_type($subtitlesFile->fopen('rb'));
+					$mimeType = $mimeType ?: 'text/plain';
+					$mimes = new \Mimey\MimeTypes;
+					$extension = $mimes->getExtension($mimeType);
+					$targetFileName = $sourceFile->getName() . ' - subtitles.' . $extension;
+					$targetFile = $sourceFileParent->newFile($targetFileName, $subtitlesFile->fopen('rb'));
 				} else {
 					$textResult = $task->getOutput()['output'];
 					$suffix = $taskTypeId === TextToTextSummary::ID ? 'summarized' : 'transcribed';

--- a/lib/Migration/Version030500Date20260715083046.php
+++ b/lib/Migration/Version030500Date20260715083046.php
@@ -105,6 +105,6 @@ class Version030500Date20260715083046 extends SimpleMigrationStep {
 		}
 
 		$userIds = array_unique(array_merge($userIdsChat, $userIdsAssignments));
-		return $userIds;
+		return array_values($userIds);
 	}
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -93,6 +93,9 @@ class Notifier implements INotifier {
 					$taskTypeName = $l->t('AI image generation');
 				} elseif ($params['taskTypeId'] === AudioToText::ID) {
 					$taskTypeName = $l->t('AI audio transcription');
+				} elseif (class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles')
+					&& $params['taskTypeId'] === \OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles::ID) {
+					$taskTypeName = $l->t('AI subtitles generation');
 				} elseif ($params['taskTypeId'] === 'copywriter') {
 					// TODO adjust that when we have copywriter back on its feet
 					// Catch the custom copywriter task type built on top of the FreePrompt task type.
@@ -196,6 +199,9 @@ class Notifier implements INotifier {
 					case AudioToText::ID:
 						$message = $l->t('{sourceFile} has been transcribed in {targetFile}');
 						break;
+					case class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles') ? \OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles::ID : 'nope':
+						$message = $l->t('{sourceFile} has been subtitled in {targetFile}');
+						break;
 					case class_exists('OCP\\TaskProcessing\\TaskTypes\\TextToSpeech') ? \OCP\TaskProcessing\TaskTypes\TextToSpeech::ID : 'nope':
 						$message = $l->t('{sourceFile} has been converted to audio in {targetFile}');
 						break;
@@ -245,6 +251,9 @@ class Notifier implements INotifier {
 						break;
 					case AudioToText::ID:
 						$message = $l->t('Transcription of {sourceFile} has failed');
+						break;
+					case class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles') ? \OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles::ID : 'nope':
+						$message = $l->t('Subtitling of {sourceFile} has failed');
 						break;
 					case class_exists('OCP\\TaskProcessing\\TaskTypes\\TextToSpeech') ? \OCP\TaskProcessing\TaskTypes\TextToSpeech::ID : 'nope':
 						$message = $l->t('The text-to-speech process for {sourceFile} has failed');

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -69,13 +69,14 @@ class AssistantService {
 		'context_chat:context_chat' => 3,
 		'legacy:TextProcessing:OCA\ContextChat\TextProcessing\ContextChatTaskType' => 3,
 		'context_chat:context_chat_search' => 4,
-		AudioToText::ID => 5,
-		TextToTextTranslate::ID => 6,
-		ContextWrite::ID => 7,
-		TextToImage::ID => 8,
-		TextToTextSummary::ID => 9,
-		TextToTextHeadline::ID => 10,
-		TextToTextTopics::ID => 11,
+		AudioToText::ID => 10,
+		'core:audio2text:subtitles' => 11,
+		TextToTextTranslate::ID => 20,
+		ContextWrite::ID => 21,
+		TextToImage::ID => 22,
+		TextToTextSummary::ID => 23,
+		TextToTextHeadline::ID => 24,
+		TextToTextTopics::ID => 25,
 	];
 
 	public array $informationSources;

--- a/lib/Service/TaskProcessingService.php
+++ b/lib/Service/TaskProcessingService.php
@@ -93,6 +93,9 @@ class TaskProcessingService {
 		if (class_exists('OCP\\TaskProcessing\\TaskTypes\\TextToSpeech')) {
 			$authorizedTaskTypes[] = \OCP\TaskProcessing\TaskTypes\TextToSpeech::ID;
 		}
+		if (class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles')) {
+			$authorizedTaskTypes[] = \OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles::ID;
+		}
 		return in_array($taskTypeId, $authorizedTaskTypes, true);
 	}
 
@@ -111,7 +114,7 @@ class TaskProcessingService {
 			throw new Exception('Invalid task type for file action');
 		}
 		try {
-			$input = $taskTypeId === AudioToText::ID
+			$input = ($taskTypeId === AudioToText::ID) || (class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles') && $taskTypeId === \OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles::ID)
 				? ['input' => $fileId]
 				: ['input' => $this->assistantService->parseTextFromFile($userId, fileId: $fileId)];
 		} catch (NotPermittedException|GenericFileException|LockedException|\OCP\Files\NotFoundException|Exception $e) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -37,6 +37,7 @@
 				<referencedClass name="Symfony\Component\Console\Input\InputInterface" />
 				<referencedClass name="Symfony\Component\Console\Output\OutputInterface" />
 				<referencedClass name="OC\User\NoUserException" />
+				<referencedClass name="OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles" />
 			</errorLevel>
 		</UndefinedClass>
 		<UndefinedDocblockClass>

--- a/src/components/fields/FileDisplay.vue
+++ b/src/components/fields/FileDisplay.vue
@@ -79,7 +79,9 @@ export default {
 
 	mounted() {
 		console.debug('CURRENT TASK', this.myCurrentTaskId)
-		this.getFileInfo()
+		if (!this.isOutput) {
+			this.getFileInfo()
+		}
 	},
 
 	methods: {

--- a/src/files/fileActions.js
+++ b/src/files/fileActions.js
@@ -10,7 +10,7 @@ import CreationSvgIcon from '@mdi/svg/svg/creation.svg?raw'
 import SummarizeSymbol from '@material-symbols/svg-700/outlined/summarize.svg?raw'
 import TTSSymbol from '@material-symbols/svg-700/outlined/text_to_speech.svg?raw'
 import STTSymbol from '@material-symbols/svg-700/outlined/speech_to_text.svg?raw'
-import { VALID_AUDIO_MIME_TYPES, VALID_TEXT_MIME_TYPES } from '../constants.js'
+import { VALID_AUDIO_MIME_TYPES, VALID_TEXT_MIME_TYPES, VALID_VIDEO_MIME_TYPES } from '../constants.js'
 
 const actionIgnoreLists = [
 	'trashbin',
@@ -156,6 +156,45 @@ function registerSttAction() {
 	registerFileAction(sttAction)
 }
 
+function registerSttSubtitlesAction() {
+	const sttSubtitlesAction = {
+		id: 'assistant-stt-subtitles',
+		parent: 'assistant-group',
+		displayName: ({ nodes }) => {
+			return t('assistant', 'Generate subtitles using AI')
+		},
+		enabled({ nodes, view }) {
+			return !actionIgnoreLists.includes(view.id)
+				&& nodes.length === 1
+				&& !nodes.some(({ permissions }) => (permissions & Permission.READ) === 0)
+				&& nodes.every(({ type }) => type === FileType.File)
+				&& nodes.every(({ mime }) => VALID_AUDIO_MIME_TYPES.includes(mime) || VALID_VIDEO_MIME_TYPES.includes(mime))
+		},
+		iconSvgInline: () => STTSymbol,
+		order: 0,
+		async exec({ nodes }) {
+			const node = nodes[0]
+			const { default: axios } = await import('@nextcloud/axios')
+			const { generateOcsUrl } = await import('@nextcloud/router')
+			const { showError, showSuccess } = await import('@nextcloud/dialogs')
+			const url = generateOcsUrl('/apps/assistant/api/v1/file-action/{fileId}/core:audio2text:subtitles', { fileId: node.fileid })
+			try {
+				await axios.post(url)
+				showSuccess(
+					t('assistant', 'AI subtitles task submitted successfully.') + '\n'
+						+ t('assistant', 'You will be notified when it is ready.') + '\n'
+						+ t('assistant', 'It can also be checked in the Assistant in the "Work with audio -> Generate subtitles" menu.'),
+				)
+			} catch (error) {
+				console.error(error)
+				showError(t('assistant', 'Failed to launch the AI file action'))
+			}
+			return null
+		},
+	}
+	registerFileAction(sttSubtitlesAction)
+}
+
 const assistantEnabled = loadState('assistant', 'assistant-enabled', false)
 const summarizeAvailable = loadState('assistant', 'summarize-available', false)
 const sttAvailable = loadState('assistant', 'stt-available', false)
@@ -174,6 +213,7 @@ if (assistantEnabled) {
 	}
 	if (sttAvailable) {
 		registerSttAction()
+		registerSttSubtitlesAction()
 	}
 	if (summarizeAvailable) {
 		registerSummarizeAction()


### PR DESCRIPTION
Registers a file action and adds support for the new `core:audio2text:subtitles` task type. The `OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles` class is imported conditionally to maintain compatibility with NC versions older than 35.

## To Fix

- [x] ~~This does not seem to have any adverse affect on the tasks themselves, but when opening finished subtitles tasks, the browser currently reports a few errors in the console such as `GET https://nextcloud.local/ocs/v2.php/apps/assistant/api/v1/file/104/info` returning a 404 status.~~ (done)

## Limitations

Currently, the **Save this media** button for output files automatically appends the `.srt` extension for `.srt` files, but not for `.vtt` files. This seems to be a limitation of the PHP Mimey package as it doesn't recognize the `text/vtt` MIME type.

By contrast, the **Download this media** button automatically appends the `.vtt` extension for `.vtt` files, but not for `.srt` files for me. Since the browser/OS looks to be doing the MIME type to extension conversion at that point, I'm not sure if there's anything we can do there.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
