### PR TITLE
Make the text input larger by default

### DIFF
--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -248,7 +248,7 @@ body[dir="rtl"] .choose-file-button {
 	}
 
 	.rich-contenteditable__input {
-		min-height: calc(var(--default-clickable-area) + 4px);
+		min-height: calc(var(--default-clickable-area) * 3 + 4px);
 		padding-top: 5px !important;
 		padding-bottom: 4px !important;
 	}


### PR DESCRIPTION
This is to invite users to put in more text.
<img width="1244" height="1544" alt="image" src="https://github.com/user-attachments/assets/2e41c5a5-a7f8-4412-b76f-b2c5a30a516e" />

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
