### PR TITLE
fix: avoid mime_content_type warning on wrapped streams

### DIFF
--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -743,7 +743,8 @@ class AssistantService {
 	 * @throws NotPermittedException
 	 */
 	private function getTargetFileName(File $file): string {
-		$mimeType = $this->detectMimeType($file->fopen('rb'));
+		$head = fread($file->fopen('rb'), 4096);
+		$mimeType = (new \finfo(FILEINFO_MIME_TYPE))->buffer($head);
 		$fileName = $file->getName();
 
 		$mimes = new \Mimey\MimeTypes;
@@ -753,29 +754,6 @@ class AssistantService {
 			return $fileName . '.' . $extension;
 		}
 		return $fileName;
-	}
-
-	/**
-	 * Wraps mime_content_type() to avoid a PHP warning when given a stream
-	 * that does not implement stream_cast() (e.g. Icewind\Streams\CallbackWrapper,
-	 * returned by File::fopen() for some storage backends). The stream is
-	 * drained into a temp file first so mime_content_type() can operate on a
-	 * real path instead of the unsupported stream resource.
-	 *
-	 * @param resource $stream
-	 * @return string|false
-	 */
-	private function detectMimeType($stream) {
-		$tmpFile = tempnam(sys_get_temp_dir(), 'nc_assistant_mime_');
-		$tmpHandle = fopen($tmpFile, 'wb');
-		stream_copy_to_stream($stream, $tmpHandle);
-		fclose($tmpHandle);
-		if (is_resource($stream)) {
-			fclose($stream);
-		}
-		$mimeType = mime_content_type($tmpFile);
-		unlink($tmpFile);
-		return $mimeType;
 	}
 
 	/**
@@ -830,7 +808,8 @@ class AssistantService {
 	 */
 	public function getOutputFilePreviewFile(string $userId, int $taskId, int $fileId, ?int $x = 100, ?int $y = 100): ?array {
 		$taskOutputFile = $this->getTaskOutputFile($userId, $taskId, $fileId);
-		$realMime = $this->detectMimeType($taskOutputFile->fopen('rb'));
+		$head = fread($taskOutputFile->fopen('rb'), 4096);
+		$realMime = (new \finfo(FILEINFO_MIME_TYPE))->buffer($head);
 		return $this->previewService->getFilePreviewFile($taskOutputFile, $x, $y, $realMime ?: null);
 	}
 

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -743,7 +743,7 @@ class AssistantService {
 	 * @throws NotPermittedException
 	 */
 	private function getTargetFileName(File $file): string {
-		$mimeType = mime_content_type($file->fopen('rb'));
+		$mimeType = $this->detectMimeType($file->fopen('rb'));
 		$fileName = $file->getName();
 
 		$mimes = new \Mimey\MimeTypes;
@@ -753,6 +753,29 @@ class AssistantService {
 			return $fileName . '.' . $extension;
 		}
 		return $fileName;
+	}
+
+	/**
+	 * Wraps mime_content_type() to avoid a PHP warning when given a stream
+	 * that does not implement stream_cast() (e.g. Icewind\Streams\CallbackWrapper,
+	 * returned by File::fopen() for some storage backends). The stream is
+	 * drained into a temp file first so mime_content_type() can operate on a
+	 * real path instead of the unsupported stream resource.
+	 *
+	 * @param resource $stream
+	 * @return string|false
+	 */
+	private function detectMimeType($stream) {
+		$tmpFile = tempnam(sys_get_temp_dir(), 'nc_assistant_mime_');
+		$tmpHandle = fopen($tmpFile, 'wb');
+		stream_copy_to_stream($stream, $tmpHandle);
+		fclose($tmpHandle);
+		if (is_resource($stream)) {
+			fclose($stream);
+		}
+		$mimeType = mime_content_type($tmpFile);
+		unlink($tmpFile);
+		return $mimeType;
 	}
 
 	/**
@@ -807,7 +830,7 @@ class AssistantService {
 	 */
 	public function getOutputFilePreviewFile(string $userId, int $taskId, int $fileId, ?int $x = 100, ?int $y = 100): ?array {
 		$taskOutputFile = $this->getTaskOutputFile($userId, $taskId, $fileId);
-		$realMime = mime_content_type($taskOutputFile->fopen('rb'));
+		$realMime = $this->detectMimeType($taskOutputFile->fopen('rb'));
 		return $this->previewService->getFilePreviewFile($taskOutputFile, $x, $y, $realMime ?: null);
 	}
 


### PR DESCRIPTION
mime_content_type() requires stream_cast() support to operate on a stream resource directly. Streams returned by File::fopen() can be wrapped in Icewind\Streams\CallbackWrapper, which does not implement stream_cast(), causing a PHP warning to be logged on every preview/output-file request even though the mime type is still detected correctly.

This drains the stream into a temporary file first, then calls mime_content_type() against the file path instead. No behavior change; only removes log noise.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
