### PR TITLE
Add improve button to text outputs to allow for iteration

### DIFF
--- a/src/components/AssistantFormOutputs.vue
+++ b/src/components/AssistantFormOutputs.vue
@@ -21,8 +21,10 @@
 			:optional-shape-options="selectedTaskType.optionalOutputShapeEnumValues ?? null"
 			:values="outputs"
 			:show-advanced="showAdvanced"
+			:can-improve-output="canImproveOutput"
 			@update:values="$emit('update:outputs', $event)"
-			@update:show-advanced="$emit('update:show-advanced', $event)" />
+			@update:show-advanced="$emit('update:show-advanced', $event)"
+			@improve="$emit('improve', $event)" />
 		<NcNoteCard v-if="outputEqualsInput"
 			class="warning-note"
 			type="warning">
@@ -70,11 +72,16 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		canImproveOutput: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	emits: [
 		'update:outputs',
 		'update:show-advanced',
+		'improve',
 	],
 
 	computed: {

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -123,7 +123,9 @@
 							v-model:show-advanced="showAdvanced"
 							v-model:outputs="myOutputs"
 							:inputs="myInputs"
-							:selected-task-type="selectedTaskType" />
+							:selected-task-type="selectedTaskType"
+							:can-improve-output="canImproveOutput"
+							@improve="onImprove" />
 					</div>
 					<div class="footer">
 						<div class="footer--action-buttons">
@@ -254,24 +256,6 @@ export default {
 		return {
 			providedCurrentTaskId: () => this.selectedTaskId,
 			streaming: () => this.streaming,
-			improveOutput: (content) => {
-				if (!this.showImproveWithNewInstructionsButton) {
-					return
-				}
-				this.$emit('new-task')
-				this.mySelectedTaskTypeId = TEXT2TEXT_IMPROVE_TASK_TYPE_ID
-				this.$nextTick(() => {
-					this.$refs?.assistantFormInputs?.setDefaultValues(true)
-					this.$nextTick(() => {
-						this.myInputs = {
-							...this.myInputs,
-							input: content,
-						}
-						saveLastSelectedTaskType(this.mySelectedTaskTypeId)
-					})
-				})
-			},
-			canImproveOutput: () => this.showImproveWithNewInstructionsButton,
 		}
 	},
 	props: {
@@ -479,7 +463,7 @@ export default {
 		actionButtonsToShow() {
 			return this.hasOutput ? this.actionButtons : []
 		},
-		contextWriteTaskType() {
+		improveTaskType() {
 			const taskType = this.taskTypes.find(tt => tt.id === TEXT2TEXT_IMPROVE_TASK_TYPE_ID)
 			if (taskType === undefined) {
 				return null
@@ -489,9 +473,9 @@ export default {
 			}
 			return taskType
 		},
-		showImproveWithNewInstructionsButton() {
+		canImproveOutput() {
 			return this.hasOutput
-				&& this.contextWriteTaskType !== null
+				&& this.improveTaskType !== null
 		},
 		showRunningEmptyContent() {
 			return this.showSyncTaskRunning && this.myOutputs === null
@@ -517,6 +501,23 @@ export default {
 		console.debug('[assistant] form\'s myoutputs', this.myOutputs)
 	},
 	methods: {
+		onImprove(content) {
+			if (!this.canImproveOutput) {
+				return
+			}
+			this.$emit('new-task')
+			this.mySelectedTaskTypeId = TEXT2TEXT_IMPROVE_TASK_TYPE_ID
+			this.$nextTick(() => {
+				this.$refs?.assistantFormInputs?.setDefaultValues(true)
+				this.$nextTick(() => {
+					this.myInputs = {
+						...this.myInputs,
+						input: content,
+					}
+					saveLastSelectedTaskType(this.mySelectedTaskTypeId)
+				})
+			})
+		},
 		// Parse the file if a fileId is passed as initial value to a text field
 		parseTextFileInputs(taskType) {
 			if (taskType === undefined || taskType === null) {

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -215,6 +215,7 @@ import { saveLastSelectedTaskType } from '../assistant.js'
 
 const TEXT2TEXT_TASK_TYPE_ID = 'core:text2text'
 const CHAT_TASK_TYPE_ID = 'chatty-llm'
+const TEXT2TEXT_IMPROVE_TASK_TYPE_ID = 'core:text2text:improve'
 
 export default {
 	name: 'AssistantTextProcessingForm',
@@ -253,6 +254,24 @@ export default {
 		return {
 			providedCurrentTaskId: () => this.selectedTaskId,
 			streaming: () => this.streaming,
+			improveOutput: (content) => {
+				if (!this.showImproveWithNewInstructionsButton) {
+					return
+				}
+				this.$emit('new-task')
+				this.mySelectedTaskTypeId = TEXT2TEXT_IMPROVE_TASK_TYPE_ID
+				this.$nextTick(() => {
+					this.$refs?.assistantFormInputs?.setDefaultValues(true)
+					this.$nextTick(() => {
+						this.myInputs = {
+							...this.myInputs,
+							input: content,
+						}
+						saveLastSelectedTaskType(this.mySelectedTaskTypeId)
+					})
+				})
+			},
+			canImproveOutput: () => this.showImproveWithNewInstructionsButton,
 		}
 	},
 	props: {
@@ -459,6 +478,20 @@ export default {
 		},
 		actionButtonsToShow() {
 			return this.hasOutput ? this.actionButtons : []
+		},
+		contextWriteTaskType() {
+			const taskType = this.taskTypes.find(tt => tt.id === TEXT2TEXT_IMPROVE_TASK_TYPE_ID)
+			if (taskType === undefined) {
+				return null
+			}
+			if (this.taskTypeIdList !== null && !this.taskTypeIdList.includes(TEXT2TEXT_IMPROVE_TASK_TYPE_ID)) {
+				return null
+			}
+			return taskType
+		},
+		showImproveWithNewInstructionsButton() {
+			return this.hasOutput
+				&& this.contextWriteTaskType !== null
 		},
 		showRunningEmptyContent() {
 			return this.showSyncTaskRunning && this.myOutputs === null

--- a/src/components/AssistantTextProcessingForm.vue
+++ b/src/components/AssistantTextProcessingForm.vue
@@ -514,7 +514,6 @@ export default {
 						...this.myInputs,
 						input: content,
 					}
-					saveLastSelectedTaskType(this.mySelectedTaskTypeId)
 				})
 			})
 		},

--- a/src/components/fields/TaskTypeField.vue
+++ b/src/components/fields/TaskTypeField.vue
@@ -10,8 +10,10 @@
 		:field="field"
 		:options="options ?? undefined"
 		:is-output="isOutput"
+		:can-improve-output="isTextField ? canImproveOutput : false"
 		@submit="$emit('submit', $event)"
-		@update:value="$emit('update:value', $event)" />
+		@update:value="$emit('update:value', $event)"
+		@improve="$emit('improve', $event)" />
 </template>
 
 <script>
@@ -56,11 +58,16 @@ export default {
 			type: [Object, Array, null],
 			default: null,
 		},
+		canImproveOutput: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	emits: [
 		'submit',
 		'update:value',
+		'improve',
 	],
 
 	data() {
@@ -90,6 +97,9 @@ export default {
 				return false
 			}
 			return (this.defaults && this.defaults[this.fieldKey] && parseInt(this.defaults[this.fieldKey]) < 10)
+		},
+		isTextField() {
+			return this.field.type === SHAPE_TYPE_NAMES.Text
 		},
 		component() {
 			if (this.field.type === SHAPE_TYPE_NAMES.Text) {

--- a/src/components/fields/TaskTypeFields.vue
+++ b/src/components/fields/TaskTypeFields.vue
@@ -12,8 +12,10 @@
 			:options="getInputFieldOptions(field, key)"
 			:is-output="isOutput"
 			:defaults="defaults"
+			:can-improve-output="canImproveOutput"
 			@submit="onSubmit"
-			@update:value="onValueChange(key, $event)" />
+			@update:value="onValueChange(key, $event)"
+			@improve="$emit('improve', $event)" />
 		<!--NcButton v-if="hasOptionalShape"
 			@click="$emit('update:show-advanced', !showAdvanced)">
 			<template #icon>
@@ -32,7 +34,9 @@
 				:options="getOptionalInputFieldOptions(field, key)"
 				:is-output="isOutput"
 				:defaults="optionalDefaults"
-				@update:value="onValueChange(key, $event)" />
+				:can-improve-output="canImproveOutput"
+				@update:value="onValueChange(key, $event)"
+				@improve="$emit('improve', $event)" />
 		</div>
 	</div>
 </template>
@@ -84,11 +88,16 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		canImproveOutput: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	emits: [
 		'submit',
 		'update:values',
+		'improve',
 	],
 
 	data() {

--- a/src/components/fields/TextField.vue
+++ b/src/components/fields/TextField.vue
@@ -11,8 +11,10 @@
 		:label="field.description"
 		:placeholder="field.placeholder ?? field.description"
 		:title="field.name"
+		:can-improve-output="canImproveOutput"
 		@submit="onSubmit"
-		@update:value="onUpdateValue" />
+		@update:value="onUpdateValue"
+		@improve="$emit('improve', $event)" />
 </template>
 
 <script>
@@ -42,11 +44,16 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		canImproveOutput: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	emits: [
 		'submit',
 		'update:value',
+		'improve',
 	],
 
 	data() {

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -24,12 +24,12 @@
 			@update:model-value="$emit('update:value', $event)" />
 		<div v-if="isOutput && hasValue"
 			class="output-buttons">
-			<NcButton v-if="!streaming() && canImproveOutput()"
+			<NcButton v-if="!streaming() && canImproveOutput"
 				class="improve-button"
 				variant="secondary"
 				:title="t('assistant', 'Improve with new instructions')"
-				@click="improveOutput(formattedValue)">
-				{{ t('assistant', 'Improve') }}
+				@click="$emit('improve', formattedValue)">
+				{{ t('assistant', 'Improve this text') }}
 			</NcButton>
 			<NcButton
 				class="copy-button"
@@ -105,7 +105,7 @@ export default {
 		isMobile,
 	],
 
-	inject: ['streaming', 'improveOutput', 'canImproveOutput'],
+	inject: ['streaming'],
 
 	props: {
 		id: {
@@ -136,11 +136,16 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+		canImproveOutput: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	emits: [
 		'submit',
 		'update:value',
+		'improve',
 	],
 
 	data() {

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -30,7 +30,7 @@
 				:title="t('assistant', 'Improve with new instructions')"
 				@click="$emit('improve', formattedValue)">
 				<template #icon>
-					<WrenchOutlineIcon />
+					<WrenchOutlineIcon size="20" />
 				</template>
 				{{ t('assistant', 'Improve this text') }}
 			</NcButton>
@@ -40,9 +40,9 @@
 				:title="t('assistant', 'Copy output')"
 				@click="onCopy">
 				<template #icon>
-					<NcLoadingIcon v-if="streaming()" />
-					<ClipboardCheckOutlineIcon v-else-if="copied" />
-					<ContentCopyIcon v-else />
+					<NcLoadingIcon v-if="streaming()" size="20" />
+					<ClipboardCheckOutlineIcon v-else-if="copied" size="20" />
+					<ContentCopyIcon v-else size="20" />
 				</template>
 				<span v-if="streaming()">
 					{{ t('assistant', 'Getting results...') }}

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -29,6 +29,9 @@
 				variant="secondary"
 				:title="t('assistant', 'Improve with new instructions')"
 				@click="$emit('improve', formattedValue)">
+				<template #icon>
+					<WrenchOutlineIcon />
+				</template>
 				{{ t('assistant', 'Improve this text') }}
 			</NcButton>
 			<NcButton
@@ -64,6 +67,7 @@
 <script>
 import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
 import ClipboardCheckOutlineIcon from 'vue-material-design-icons/ClipboardCheckOutline.vue'
+import WrenchOutlineIcon from 'vue-material-design-icons/WrenchOutline.vue'
 import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 
 import NcButton from '@nextcloud/vue/components/NcButton'
@@ -99,6 +103,7 @@ export default {
 		FileDocumentOutlineIcon,
 		ClipboardCheckOutlineIcon,
 		ContentCopyIcon,
+		WrenchOutlineIcon,
 	},
 
 	mixins: [

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -22,23 +22,33 @@
 			:title="title"
 			@submit="hasValue && $emit('submit', $event)"
 			@update:model-value="$emit('update:value', $event)" />
-		<NcButton v-if="isOutput && hasValue"
-			class="copy-button"
-			variant="secondary"
-			:title="t('assistant', 'Copy output')"
-			@click="onCopy">
-			<template #icon>
-				<NcLoadingIcon v-if="streaming()" />
-				<ClipboardCheckOutlineIcon v-else-if="copied" />
-				<ContentCopyIcon v-else />
-			</template>
-			<span v-if="streaming()">
-				{{ t('assistant', 'Getting results...') }}
-			</span>
-			<span v-else>
-				{{ t('assistant', 'Copy') }}
-			</span>
-		</NcButton>
+		<div v-if="isOutput && hasValue"
+			class="output-buttons">
+			<NcButton v-if="!streaming() && canImproveOutput()"
+				class="improve-button"
+				variant="secondary"
+				:title="t('assistant', 'Improve with new instructions')"
+				@click="improveOutput(formattedValue)">
+				{{ t('assistant', 'Improve') }}
+			</NcButton>
+			<NcButton
+				class="copy-button"
+				variant="secondary"
+				:title="t('assistant', 'Copy output')"
+				@click="onCopy">
+				<template #icon>
+					<NcLoadingIcon v-if="streaming()" />
+					<ClipboardCheckOutlineIcon v-else-if="copied" />
+					<ContentCopyIcon v-else />
+				</template>
+				<span v-if="streaming()">
+					{{ t('assistant', 'Getting results...') }}
+				</span>
+				<span v-else>
+					{{ t('assistant', 'Copy') }}
+				</span>
+			</NcButton>
+		</div>
 		<NcButton v-if="!isOutput && !hasValue && showChooseButton"
 			class="choose-file-button"
 			variant="secondary"
@@ -95,9 +105,7 @@ export default {
 		isMobile,
 	],
 
-	inject: [
-		'streaming',
-	],
+	inject: ['streaming', 'improveOutput', 'canImproveOutput'],
 
 	props: {
 		id: {
@@ -230,21 +238,28 @@ body[dir="rtl"] .choose-file-button {
 	right: unset;
 }
 
+body[dir="rtl"] .output-buttons {
+	left: 4px;
+	right: unset;
+}
+
 .text-input {
 	position: relative;
 
-	.copy-button,
+	.output-buttons,
 	.choose-file-button {
 		position: absolute !important;
 	}
 
-	.choose-file-button {
-		bottom: 2px;
-	}
-
-	.copy-button {
+	.output-buttons {
 		bottom: 4px;
 		right: 4px;
+		display: flex;
+		gap: 4px;
+	}
+
+	.choose-file-button {
+		bottom: 2px;
 	}
 
 	.rich-contenteditable__input {


### PR DESCRIPTION
Example in generate text:
<img width="1208" height="456" alt="image" src="https://github.com/user-attachments/assets/83772a53-da06-40b9-bf27-850a1e8ded4b" />


It is on _all_ text output fields right now. If you can think of some it shouldn't be on feel free to mention that.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
