### PR TITLE
fix(assistant): use extended markdown for all NcRichText (renders tables)

### DIFF
--- a/src/components/ChattyLLM/Message.vue
+++ b/src/components/ChattyLLM/Message.vue
@@ -46,7 +46,7 @@
 							<div class="reasoningcontent_popover_inner">
 								<h6>{{ t('assistant', 'Reasoning content') }}</h6>
 								<NcRichText :text="message.reasoning"
-									:use-markdown="true"
+									:use-extended-markdown="true"
 									:autolink="true" />
 							</div>
 						</template>
@@ -92,7 +92,6 @@
 		</div>
 		<NcRichText class="message__content"
 			:text="streaming ? streamedMessageContent : message.content"
-			:use-markdown="true"
 			:use-extended-markdown="true"
 			:reference-limit="1"
 			:references="references"

--- a/src/components/ChattyLLM/Message.vue
+++ b/src/components/ChattyLLM/Message.vue
@@ -93,6 +93,7 @@
 		<NcRichText class="message__content"
 			:text="streaming ? streamedMessageContent : message.content"
 			:use-markdown="true"
+			:use-extended-markdown="true"
 			:reference-limit="1"
 			:references="references"
 			:autolink="true" />

--- a/src/components/ContextChat/ContextChatSource.vue
+++ b/src/components/ContextChat/ContextChatSource.vue
@@ -5,7 +5,7 @@
 <template>
 	<NcRichText
 		:text="text"
-		:use-markdown="true"
+		:use-extended-markdown="true"
 		:reference-limit="1"
 		:references="references"
 		:autolink="true" />

--- a/src/components/fields/TextInput.vue
+++ b/src/components/fields/TextInput.vue
@@ -16,7 +16,7 @@
 			:class="{ streaming: isOutput && streaming() }"
 			:title="t('assistant', 'Double-click to edit')"
 			:text="value ?? ''"
-			:use-markdown="true"
+			:use-extended-markdown="true"
 			:autolink="true"
 			@dblclick="enterEditMode" />
 		<NcRichContenteditable


### PR DESCRIPTION
Chat messages are rendered in markdown mode, not extended markdown, so tables aren't rendered. I'm not sure if this is what others want, but AI often outputs tables and, in my opinion, users expect those tables to render correctly. At least that's what I'd like to see, so if others agree, I propose switching to extended markdown. This complements #540 (which left tables out) and also addresses #497. Tested on NC 33 / Assistant 3.5.0. I verified that both a Markdown table and a code block (with syntax highlighting) now render correctly.

Disclosure: I used AI assistance (Claude Code) to locate the relevant prop and prepare this change; I reviewed and tested it myself.

Update (per review): dropped the now-redundant use-markdown and switched all NcRichText usages to use-extended-markdown for uniformity, so this also covers the reasoning content, the "Work with text" output, and ContextChatSource (finishing the tables part #540 left out).

Proof that after this change it correctly renders tables and code blocks:

<img width="1239" height="529" alt="image" src="https://github.com/user-attachments/assets/d43e9747-325d-4209-98b2-76f9c41ab543" />
<img width="461" height="273" alt="image" src="https://github.com/user-attachments/assets/0194dda9-d506-408f-bd47-8c6f5c903afd" />