### PR TITLE
feat(file-action): summarize a whole file by sending it to the AI provider

### DIFF
--- a/lib/Listener/FileActionTaskFailedListener.php
+++ b/lib/Listener/FileActionTaskFailedListener.php
@@ -14,6 +14,7 @@ use OCA\Assistant\Service\TaskProcessingService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\TaskProcessing\Events\TaskFailedEvent;
 use Psr\Log\LoggerInterface;
 
@@ -52,6 +53,13 @@ class FileActionTaskFailedListener implements IEventListener {
 			$this->logger->debug('FileActionTaskListener', ['source_file_id' => $sourceFileId]);
 			$userFolder = $this->rootFolder->getUserFolder($task->getUserId());
 			$sourceFile = $userFolder->getFirstNodeById($sourceFileId);
+			if (!$sourceFile instanceof Node) {
+				// the source file was removed while the task was running, there is nothing to point the user at
+				$this->logger->warning('FileActionTaskListener task failed and the source file is gone', [
+					'source_file_id' => $sourceFileId,
+				]);
+				return;
+			}
 			$this->notificationService->sendFileActionNotification(
 				$task->getUserId(), $taskTypeId, $task->getId(),
 				$sourceFileId, $sourceFile->getName(), $userFolder->getRelativePath($sourceFile->getPath()),

--- a/lib/Listener/FileActionTaskSuccessfulListener.php
+++ b/lib/Listener/FileActionTaskSuccessfulListener.php
@@ -15,6 +15,7 @@ use OCA\Assistant\Service\TaskProcessingService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\SystemTag\TagNotFoundException;
 use OCP\TaskProcessing\Events\TaskSuccessfulEvent;
 use OCP\TaskProcessing\TaskTypes\TextToTextSummary;
@@ -57,6 +58,13 @@ class FileActionTaskSuccessfulListener implements IEventListener {
 			$userFolder = $this->rootFolder->getUserFolder($task->getUserId());
 			$sourceFile = $userFolder->getFirstNodeById($sourceFileId);
 			$this->logger->debug('FileActionTaskListener', ['source file id' => $sourceFileId]);
+			if (!$sourceFile instanceof Node) {
+				// the source file was removed while the task was running, there is nowhere to write the result
+				$this->logger->warning('FileActionTaskListener task succeeded but the source file is gone', [
+					'source file id' => $sourceFileId,
+				]);
+				return;
+			}
 			try {
 				$sourceFileParent = $sourceFile->getParent();
 				$this->logger->debug('FileActionTaskListener', ['source file PARENT id' => $sourceFileParent->getId()]);

--- a/lib/Listener/LoadAdditionalScriptsListener.php
+++ b/lib/Listener/LoadAdditionalScriptsListener.php
@@ -8,6 +8,7 @@
 namespace OCA\Assistant\Listener;
 
 use OCA\Assistant\AppInfo\Application;
+use OCA\Assistant\Service\AttachmentService;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
@@ -28,6 +29,7 @@ class LoadAdditionalScriptsListener implements IEventListener {
 		private IAppConfig $appConfig,
 		private IInitialState $initialStateService,
 		private ITaskProcessingManager $taskProcessingManager,
+		private AttachmentService $attachmentService,
 	) {
 	}
 
@@ -46,6 +48,12 @@ class LoadAdditionalScriptsListener implements IEventListener {
 		$this->initialStateService->provideInitialState('stt-available', $sttAvailable);
 		$this->initialStateService->provideInitialState('tts-available', $ttsAvailable);
 		$this->initialStateService->provideInitialState('summarize-available', $summarizeAvailable);
+		// extra mime types the summarize action can handle by sending the file to the provider,
+		// on top of the ones we can extract text from ourselves
+		$this->initialStateService->provideInitialState(
+			'summarize-attachment-mime-types',
+			$summarizeAvailable ? $this->attachmentService->getAttachableMimeTypes(TextToTextSummary::ID) : [],
+		);
 		Util::addInitScript(Application::APP_ID, Application::APP_ID . '-fileActions');
 
 		// New file menu to generate images

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Assistant\Service;
+
+use OCA\Assistant\AppInfo\Application;
+use OCP\Files\File;
+use OCP\IAppConfig;
+use OCP\TaskProcessing\EShapeType;
+use OCP\TaskProcessing\IManager;
+use OCP\TaskProcessing\ShapeDescriptor;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Decides whether a file can be sent to the AI provider as-is (as a task
+ * "input_attachments" file) instead of having its text extracted by Nextcloud
+ * first.
+ *
+ * Sending the file itself lets the model read documents that our own parsers
+ * handle badly or not at all (scanned PDFs, complex layouts) and sidesteps the
+ * 512 kB limit that core puts on Text-shaped task inputs.
+ */
+class AttachmentService {
+
+	/**
+	 * Mime types that are always worth sending to the provider as a file.
+	 *
+	 * Keep this in sync with what the providers can actually turn into a
+	 * document part. Office formats are deliberately absent: they are rejected
+	 * provider side, so they have to keep going through text extraction.
+	 */
+	public const ATTACHABLE_MIME_TYPES = [
+		'application/pdf',
+	];
+
+	/**
+	 * Mime types we can extract losslessly and cheaply ourselves. These are
+	 * only attached when they are too big to fit in a Text input.
+	 */
+	public const EXTRACTABLE_TEXT_MIME_TYPES = [
+		'text/plain',
+		'text/markdown',
+		'text/csv',
+	];
+
+	/**
+	 * Above this size, extracting a text file locally risks blowing the 512 kB
+	 * limit that core enforces on Text-shaped inputs, so attach it instead.
+	 */
+	private const DEFAULT_TEXT_INLINE_THRESHOLD = 262_144;
+
+	/** Mirrors the maximum input file size accepted by the providers. */
+	private const DEFAULT_MAX_ATTACHMENT_SIZE = 50_000_000;
+
+	public function __construct(
+		private IManager $taskProcessingManager,
+		private IAppConfig $appConfig,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Whether the provider currently selected for $taskTypeId accepts files
+	 * alongside the task input.
+	 *
+	 * Optional input shapes come from the provider rather than the task type,
+	 * so this is how a provider advertises that it can handle attachments.
+	 */
+	public function providerSupportsInputAttachments(string $taskTypeId): bool {
+		try {
+			$taskTypes = $this->taskProcessingManager->getAvailableTaskTypes();
+			$shape = $taskTypes[$taskTypeId]['optionalInputShape']['input_attachments'] ?? null;
+			return $shape instanceof ShapeDescriptor
+				&& $shape->getShapeType() === EShapeType::ListOfFiles;
+		} catch (\Throwable $e) {
+			// this is also called while rendering templates, never let it bubble up
+			$this->logger->debug('Could not determine attachment support for ' . $taskTypeId, ['exception' => $e]);
+			return false;
+		}
+	}
+
+	/**
+	 * Whether $file is one we would rather hand to the model directly.
+	 */
+	public function isAttachableFile(File $file): bool {
+		if ($file->getSize() > $this->getMaxAttachmentSize()) {
+			return false;
+		}
+		$mimeType = $file->getMimeType();
+		if (in_array($mimeType, self::ATTACHABLE_MIME_TYPES, true)) {
+			return true;
+		}
+		return in_array($mimeType, self::EXTRACTABLE_TEXT_MIME_TYPES, true)
+			&& $file->getSize() > $this->getTextInlineThreshold();
+	}
+
+	/**
+	 * Whether the file behind $fileId should be attached to a $taskTypeId task
+	 * rather than parsed into text first.
+	 */
+	public function shouldAttachFile(File $file, string $taskTypeId): bool {
+		return $this->providerSupportsInputAttachments($taskTypeId)
+			&& $this->isAttachableFile($file);
+	}
+
+	/**
+	 * The mime types the summarize file action can handle over and above the
+	 * ones we can extract text from.
+	 *
+	 * These end up in a file action `enabled()` check that compares mime types
+	 * exactly, so only concrete types belong here - no wildcards.
+	 *
+	 * @return list<string>
+	 */
+	public function getAttachableMimeTypes(string $taskTypeId): array {
+		if (!$this->providerSupportsInputAttachments($taskTypeId)) {
+			return [];
+		}
+		return self::ATTACHABLE_MIME_TYPES;
+	}
+
+	private function getMaxAttachmentSize(): int {
+		return $this->appConfig->getValueInt(
+			Application::APP_ID,
+			'max_attachment_size',
+			self::DEFAULT_MAX_ATTACHMENT_SIZE,
+			lazy: true,
+		);
+	}
+
+	private function getTextInlineThreshold(): int {
+		return $this->appConfig->getValueInt(
+			Application::APP_ID,
+			'text_inline_threshold',
+			self::DEFAULT_TEXT_INLINE_THRESHOLD,
+			lazy: true,
+		);
+	}
+}

--- a/lib/Service/TaskProcessingService.php
+++ b/lib/Service/TaskProcessingService.php
@@ -33,6 +33,7 @@ class TaskProcessingService {
 		private IRootFolder $rootFolder,
 		private LoggerInterface $logger,
 		private AssistantService $assistantService,
+		private AttachmentService $attachmentService,
 	) {
 	}
 
@@ -88,6 +89,15 @@ class TaskProcessingService {
 		return $file->getContent();
 	}
 
+	/**
+	 * Task types that take the input file itself rather than its text content.
+	 */
+	private function isAudioInputTaskType(string $taskTypeId): bool {
+		return $taskTypeId === AudioToText::ID
+			|| (class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles')
+				&& $taskTypeId === \OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles::ID);
+	}
+
 	public function isFileActionTaskTypeSupported(string $taskTypeId): bool {
 		$authorizedTaskTypes = [AudioToText::ID, TextToTextSummary::ID];
 		if (class_exists('OCP\\TaskProcessing\\TaskTypes\\TextToSpeech')) {
@@ -114,9 +124,7 @@ class TaskProcessingService {
 			throw new Exception('Invalid task type for file action');
 		}
 		try {
-			$input = ($taskTypeId === AudioToText::ID) || (class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles') && $taskTypeId === \OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles::ID)
-				? ['input' => $fileId]
-				: ['input' => $this->assistantService->parseTextFromFile($userId, fileId: $fileId)];
+			$input = $this->buildFileActionInput($userId, $fileId, $taskTypeId);
 		} catch (NotPermittedException|GenericFileException|LockedException|\OCP\Files\NotFoundException|Exception $e) {
 			$this->logger->warning('Assistant runFileAction, impossible to read the file action input file', ['exception' => $e]);
 			throw new Exception('Impossible to read the file action input file');
@@ -139,5 +147,39 @@ class TaskProcessingService {
 			throw new Exception('The task could not be scheduled');
 		}
 		return $taskId;
+	}
+
+	/**
+	 * Build the task input for a file action.
+	 *
+	 * Audio task types consume the file directly. For the others we normally
+	 * extract the text ourselves, but when the provider can take files and the
+	 * file is one our parsers handle badly, we hand it over untouched instead.
+	 *
+	 * The mandatory text input stays empty in that case: the provider builds
+	 * its own instructions around the attachment, and anything we put there
+	 * would be untranslated and fight that prompt.
+	 *
+	 * @return array<string, mixed>
+	 * @throws GenericFileException
+	 * @throws LockedException
+	 * @throws NotPermittedException
+	 * @throws \OCP\Files\NotFoundException
+	 */
+	private function buildFileActionInput(string $userId, int $fileId, string $taskTypeId): array {
+		if ($this->isAudioInputTaskType($taskTypeId)) {
+			return ['input' => $fileId];
+		}
+
+		$file = $this->rootFolder->getUserFolder($userId)->getFirstNodeById($fileId);
+		if ($file instanceof File && $this->attachmentService->shouldAttachFile($file, $taskTypeId)) {
+			$this->logger->debug('Assistant file action: sending the file to the provider as an attachment', [
+				'fileId' => $fileId,
+				'taskTypeId' => $taskTypeId,
+			]);
+			return ['input' => '', 'input_attachments' => [$fileId]];
+		}
+
+		return ['input' => $this->assistantService->parseTextFromFile($userId, fileId: $fileId)];
 	}
 }

--- a/src/files/fileActions.js
+++ b/src/files/fileActions.js
@@ -39,7 +39,7 @@ function registerGroupAction(mimeTypes) {
 	registerFileAction(groupAction)
 }
 
-function registerSummarizeAction() {
+function registerSummarizeAction(mimeTypes) {
 	const summarizeAction = {
 		id: 'assistant-summarize',
 		parent: 'assistant-group',
@@ -51,7 +51,7 @@ function registerSummarizeAction() {
 				&& nodes.length === 1
 				&& !nodes.some(({ permissions }) => (permissions & Permission.READ) === 0)
 				&& nodes.every(({ type }) => type === FileType.File)
-				&& nodes.every(({ mime }) => VALID_TEXT_MIME_TYPES.includes(mime))
+				&& nodes.every(({ mime }) => mimeTypes.includes(mime))
 		},
 		iconSvgInline: () => SummarizeSymbol,
 		order: 0,
@@ -199,24 +199,30 @@ const assistantEnabled = loadState('assistant', 'assistant-enabled', false)
 const summarizeAvailable = loadState('assistant', 'summarize-available', false)
 const sttAvailable = loadState('assistant', 'stt-available', false)
 const ttsAvailable = loadState('assistant', 'tts-available', false)
+// files the AI provider can read itself, so summarizing them does not depend on our text extraction
+const summarizeAttachmentMimeTypes = loadState('assistant', 'summarize-attachment-mime-types', [])
+const summarizeMimeTypes = [...new Set([...VALID_TEXT_MIME_TYPES, ...summarizeAttachmentMimeTypes])]
 
 if (assistantEnabled) {
 	if (summarizeAvailable || sttAvailable || ttsAvailable) {
-		const groupMimeTypes = []
-		if (summarizeAvailable || ttsAvailable) {
-			groupMimeTypes.push(...VALID_TEXT_MIME_TYPES)
+		const groupMimeTypes = new Set()
+		if (summarizeAvailable) {
+			summarizeMimeTypes.forEach((mime) => groupMimeTypes.add(mime))
+		}
+		if (ttsAvailable) {
+			VALID_TEXT_MIME_TYPES.forEach((mime) => groupMimeTypes.add(mime))
 		}
 		if (sttAvailable) {
-			groupMimeTypes.push(...VALID_AUDIO_MIME_TYPES)
+			VALID_AUDIO_MIME_TYPES.forEach((mime) => groupMimeTypes.add(mime))
 		}
-		registerGroupAction(groupMimeTypes)
+		registerGroupAction([...groupMimeTypes])
 	}
 	if (sttAvailable) {
 		registerSttAction()
 		registerSttSubtitlesAction()
 	}
 	if (summarizeAvailable) {
-		registerSummarizeAction()
+		registerSummarizeAction(summarizeMimeTypes)
 	}
 	if (ttsAvailable) {
 		registerTtsAction()

--- a/tests/unit/Service/AttachmentServiceTest.php
+++ b/tests/unit/Service/AttachmentServiceTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Assistant\Tests;
+
+use OCA\Assistant\Service\AttachmentService;
+use OCP\Files\File;
+use OCP\IAppConfig;
+use OCP\TaskProcessing\EShapeType;
+use OCP\TaskProcessing\IManager;
+use OCP\TaskProcessing\ShapeDescriptor;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+class AttachmentServiceTest extends \PHPUnit\Framework\TestCase {
+
+	private const TASK_TYPE_ID = 'core:text2text:summary';
+
+	private IManager&MockObject $taskProcessingManager;
+
+	private function buildService(): AttachmentService {
+		$this->taskProcessingManager = $this->createMock(IManager::class);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		// no admin overrides, always hand back the default
+		$appConfig->method('getValueInt')->willReturnCallback(
+			static fn (string $app, string $key, int $default = 0, bool $lazy = false): int => $default,
+		);
+
+		return new AttachmentService(
+			$this->taskProcessingManager,
+			$appConfig,
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	private function mockFile(string $mimeType, int $size): File&MockObject {
+		$file = $this->createMock(File::class);
+		$file->method('getMimeType')->willReturn($mimeType);
+		$file->method('getSize')->willReturn($size);
+		return $file;
+	}
+
+	/**
+	 * @param ?ShapeDescriptor $shape the input_attachments descriptor the provider advertises, if any
+	 */
+	private function mockAvailableTaskTypes(?ShapeDescriptor $shape): void {
+		$this->taskProcessingManager->method('getAvailableTaskTypes')->willReturn([
+			self::TASK_TYPE_ID => [
+				'optionalInputShape' => $shape === null ? [] : ['input_attachments' => $shape],
+			],
+		]);
+	}
+
+	public function testProviderWithoutAttachmentSlotIsNotSupported(): void {
+		$service = $this->buildService();
+		$this->mockAvailableTaskTypes(null);
+		self::assertFalse($service->providerSupportsInputAttachments(self::TASK_TYPE_ID));
+	}
+
+	public function testProviderAdvertisingListOfFilesIsSupported(): void {
+		$service = $this->buildService();
+		$this->mockAvailableTaskTypes(new ShapeDescriptor('Attachments', 'Files', EShapeType::ListOfFiles));
+		self::assertTrue($service->providerSupportsInputAttachments(self::TASK_TYPE_ID));
+	}
+
+	public function testSlotWithTheWrongShapeTypeIsNotSupported(): void {
+		$service = $this->buildService();
+		// a provider using the same key for something else must not switch the feature on
+		$this->mockAvailableTaskTypes(new ShapeDescriptor('Attachments', 'Files', EShapeType::Text));
+		self::assertFalse($service->providerSupportsInputAttachments(self::TASK_TYPE_ID));
+	}
+
+	public function testUnknownTaskTypeIsNotSupported(): void {
+		$service = $this->buildService();
+		$this->mockAvailableTaskTypes(new ShapeDescriptor('Attachments', 'Files', EShapeType::ListOfFiles));
+		self::assertFalse($service->providerSupportsInputAttachments('core:text2text:chat'));
+	}
+
+	public function testManagerFailureDoesNotBubbleUp(): void {
+		$service = $this->buildService();
+		// this runs while rendering templates, a throw here would break the page
+		$this->taskProcessingManager->method('getAvailableTaskTypes')
+			->willThrowException(new \RuntimeException('boom'));
+		self::assertFalse($service->providerSupportsInputAttachments(self::TASK_TYPE_ID));
+	}
+
+	/**
+	 * @dataProvider attachableFileDataProvider
+	 */
+	public function testIsAttachableFile(string $mimeType, int $size, bool $expected): void {
+		$service = $this->buildService();
+		self::assertSame($expected, $service->isAttachableFile($this->mockFile($mimeType, $size)));
+	}
+
+	public function attachableFileDataProvider(): array {
+		return [
+			// PDFs always go to the provider, our parser is the unreliable part
+			'small pdf' => ['application/pdf', 12_000, true],
+			'large pdf' => ['application/pdf', 20_000_000, true],
+			'oversized pdf' => ['application/pdf', 80_000_000, false],
+			// text extracts fine and cheaply until it no longer fits in a Text input
+			'small markdown' => ['text/markdown', 10_000, false],
+			'large markdown' => ['text/markdown', 1_000_000, true],
+			'small plain text' => ['text/plain', 1_000, false],
+			'large plain text' => ['text/plain', 500_000, true],
+			'large csv' => ['text/csv', 400_000, true],
+			// office formats are rejected provider side, they must keep using text extraction
+			'docx' => ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', 5_000_000, false],
+			'odt' => ['application/vnd.oasis.opendocument.text', 900_000, false],
+			'rtf' => ['text/rtf', 900_000, false],
+			'image' => ['image/jpeg', 900_000, false],
+		];
+	}
+
+	public function testShouldAttachFileRequiresBothProviderSupportAndAnEligibleFile(): void {
+		$service = $this->buildService();
+		$this->mockAvailableTaskTypes(new ShapeDescriptor('Attachments', 'Files', EShapeType::ListOfFiles));
+
+		self::assertTrue($service->shouldAttachFile($this->mockFile('application/pdf', 12_000), self::TASK_TYPE_ID));
+		self::assertFalse($service->shouldAttachFile($this->mockFile('text/markdown', 10_000), self::TASK_TYPE_ID));
+	}
+
+	public function testShouldNotAttachFileWhenTheProviderCannotTakeAttachments(): void {
+		$service = $this->buildService();
+		$this->mockAvailableTaskTypes(null);
+		self::assertFalse($service->shouldAttachFile($this->mockFile('application/pdf', 12_000), self::TASK_TYPE_ID));
+	}
+
+	public function testAttachableMimeTypesAreOnlyAdvertisedWhenTheProviderSupportsThem(): void {
+		$service = $this->buildService();
+		$this->mockAvailableTaskTypes(new ShapeDescriptor('Attachments', 'Files', EShapeType::ListOfFiles));
+		$mimeTypes = $service->getAttachableMimeTypes(self::TASK_TYPE_ID);
+
+		self::assertContains('application/pdf', $mimeTypes);
+		// the file action compares mime types exactly, wildcards would never match
+		foreach ($mimeTypes as $mimeType) {
+			self::assertStringNotContainsString('*', $mimeType);
+		}
+	}
+
+	public function testNoAttachableMimeTypesWithoutProviderSupport(): void {
+		$service = $this->buildService();
+		$this->mockAvailableTaskTypes(null);
+		self::assertSame([], $service->getAttachableMimeTypes(self::TASK_TYPE_ID));
+	}
+}


### PR DESCRIPTION
## Summary

Today the **Summarize** file action never gives the LLM the file. `TaskProcessingService::runFileAction` extracts the text with `AssistantService::parseTextFromFile` and sends that string to `core:text2text:summary`, whose `input` slot is `EShapeType::Text` — capped at **512 kB** by core.

That extraction is the weak link:

- `smalot/pdfparser` returns nothing for scanned PDFs and garbage for complex layouts (cf. #499, where the reporter's own summary was *"the PDF parser is not reliable enough for in-the-wild PDFs"*)
- PhpWord drops tables, headers and footers
- the `default:` branch returns raw bytes as "text" for unsupported binaries
- any file whose extracted text exceeds 512 kB fails validation outright, surfacing as *"Failed to launch the AI file action"*

When the configured provider can accept files, Summarize now hands over the document untouched and lets the model read it.

## How it works

A provider advertises an optional `input_attachments` (`ListOfFiles`) slot. The new `AttachmentService` feature-detects it via `getAvailableTaskTypes()[…]['optionalInputShape']`, exactly like the existing `memories` pattern, and `runFileAction` then sends:

```php
['input' => '', 'input_attachments' => [$fileId]]
```

The mandatory text input stays empty on purpose: the provider builds its own instructions around the attachment, and anything we put there would be untranslated and fight that prompt. Core accepts `''` for a mandatory Text slot, and this matches the convention already used by `MultimodalChatWithToolsProvider`.

**Nothing changes until a provider advertises the slot**, so this is inert on its own.

### Eligibility is deliberately narrow

| Type | Behaviour | Why |
|---|---|---|
| `application/pdf` | always attached | this is the actual pain point |
| `text/plain`, `text/markdown`, `text/csv` | attached only above 256 kB | extraction is lossless and cheap below that; above it, the extracted text risks blowing core's 512 kB Text cap, which fails today |
| doc / docx / odt / rtf | never attached | providers reject these outright; only our own parsers can read them |
| anything > 50 MB | never attached | mirrors the provider-side ceiling, so we fail fast rather than after a 50 MB base64 round-trip |

All three thresholds are readable from app config.

## Also included

A drive-by fix in the two file-action listeners, which both used `getFirstNodeById()` without a null check. That returns `null` when the source file is moved or deleted while the task runs — increasingly likely as tasks get longer.

In `FileActionTaskSuccessfulListener` this was worse than a plain fatal: the null deref happened *inside* the `try`, and the `catch` handler then dereferenced the same node again to send a notification. That second throw escaped the handler and aborted the whole `TaskSuccessfulEvent` dispatch, so unrelated listeners never ran.

## Depends on

nextcloud/integration_openai#419, which adds the `input_attachments` slot to `SummaryProvider` (and fixes document attachments on Mistral). This PR is safe to merge first — without a provider that advertises the slot, behaviour is byte-identical to today.

## Relationship to #602

No overlap. #602 covers chat attachments via `MultimodalChatWithTools`; this covers the Files → Summarize action, which #602 does not touch (no `TaskProcessingService`, no `fileActions.js`). The only shared surface is the initial-state listener.

## Testing

`tests/unit/Service/AttachmentServiceTest.php` — 21 tests covering the capability-detection matrix (slot absent / correct `ListOfFiles` / wrong shape type / manager throwing) and the full eligibility matrix. Passing locally.

Gates run locally: `lint`, `cs:check` (0/98), `psalm` (no errors), `composer run openapi` (`openapi.json` byte-identical — no API surface changed), `eslint`, `npm run build`.

Manual E2E still to do against a live provider: scanned PDF, `Nextcloud Manual.pdf` (#499's reproducer), a 2 MB `.md`, `.docx` still falling back to extraction, and a backend without document support falling back cleanly.

---

_This PR was generated with the help of AI, and reviewed by a Human_