### PR TITLE
feat: allow the data folder name to be set server-wide

### DIFF
--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -24,6 +24,7 @@ use OCP\Files\GenericFileException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotPermittedException;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ITempManager;
@@ -91,6 +92,7 @@ class AssistantService {
 		private IL10N $l10n,
 		private ITempManager $tempManager,
 		private IConfig $config,
+		private IAppConfig $appConfig,
 		private IShareManager $shareManager,
 		private SystemTagService $systemTagService,
 	) {
@@ -522,7 +524,7 @@ class AssistantService {
 	public function getAssistantDataFolder(string $userId): Folder {
 		$userFolder = $this->rootFolder->getUserFolder($userId);
 
-		$defaultFolderName = $this->config->getAppValue(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME) ?: Application::ASSISTANT_DATA_FOLDER_NAME;
+		$defaultFolderName = $this->appConfig->getValueString(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME, lazy: true) ?: Application::ASSISTANT_DATA_FOLDER_NAME;
 		$dataFolderName = $this->config->getUserValue($userId, Application::APP_ID, 'data_folder', $defaultFolderName) ?: $defaultFolderName;
 		if ($userFolder->nodeExists($dataFolderName)) {
 			$dataFolderNode = $userFolder->get($dataFolderName);
@@ -531,7 +533,7 @@ class AssistantService {
 			}
 		}
 		// it does not exist or is not a folder or does not have write permissions: we create one
-		$dataFolder = $this->createAssistantDataFolder($userId, $defaultFolderName);
+		$dataFolder = $this->createAssistantDataFolder($userId, $dataFolderName);
 		$dataFolderName = $dataFolder->getName();
 		$this->config->setUserValue($userId, Application::APP_ID, 'data_folder', $dataFolderName);
 		return $dataFolder;

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -522,7 +522,8 @@ class AssistantService {
 	public function getAssistantDataFolder(string $userId): Folder {
 		$userFolder = $this->rootFolder->getUserFolder($userId);
 
-		$dataFolderName = $this->config->getUserValue($userId, Application::APP_ID, 'data_folder', Application::ASSISTANT_DATA_FOLDER_NAME) ?: Application::ASSISTANT_DATA_FOLDER_NAME;
+		$defaultFolderName = $this->config->getAppValue(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME) ?: Application::ASSISTANT_DATA_FOLDER_NAME;
+		$dataFolderName = $this->config->getUserValue($userId, Application::APP_ID, 'data_folder', $defaultFolderName) ?: $defaultFolderName;
 		if ($userFolder->nodeExists($dataFolderName)) {
 			$dataFolderNode = $userFolder->get($dataFolderName);
 			if ($dataFolderNode instanceof Folder && $dataFolderNode->isCreatable()) {
@@ -530,7 +531,7 @@ class AssistantService {
 			}
 		}
 		// it does not exist or is not a folder or does not have write permissions: we create one
-		$dataFolder = $this->createAssistantDataFolder($userId);
+		$dataFolder = $this->createAssistantDataFolder($userId, $defaultFolderName);
 		$dataFolderName = $dataFolder->getName();
 		$this->config->setUserValue($userId, Application::APP_ID, 'data_folder', $dataFolderName);
 		return $dataFolder;
@@ -538,17 +539,18 @@ class AssistantService {
 
 	/**
 	 * @param string $userId
+	 * @param string $baseName
 	 * @param int $try
 	 * @return Folder
 	 * @throws NoUserException
 	 * @throws NotPermittedException
 	 */
-	private function createAssistantDataFolder(string $userId, int $try = 0): Folder {
+	private function createAssistantDataFolder(string $userId, string $baseName, int $try = 0): Folder {
 		$userFolder = $this->rootFolder->getUserFolder($userId);
 		if ($try === 0) {
-			$folderPath = Application::ASSISTANT_DATA_FOLDER_NAME;
+			$folderPath = $baseName;
 		} else {
-			$folderPath = Application::ASSISTANT_DATA_FOLDER_NAME . ' ' . $try;
+			$folderPath = $baseName . ' ' . $try;
 		}
 
 		if ($userFolder->nodeExists($folderPath)) {
@@ -556,7 +558,7 @@ class AssistantService {
 				// give up
 				throw new RuntimeException('Could not create the assistant data folder');
 			}
-			return $this->createAssistantDataFolder($userId, $try + 1);
+			return $this->createAssistantDataFolder($userId, $baseName, $try + 1);
 		}
 
 		return $userFolder->newFolder($folderPath);

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -528,9 +528,14 @@ class AssistantService {
 		if ($defaultFolderName === '') {
 			$defaultFolderName = Application::ASSISTANT_DATA_FOLDER_NAME;
 		}
-		$dataFolderName = $this->config->getUserValue($userId, Application::APP_ID, 'data_folder', $defaultFolderName);
+		$dataFolderName = $this->config->getUserValue($userId, Application::APP_ID, 'data_folder', '');
 		if ($dataFolderName === '') {
-			$dataFolderName = $defaultFolderName;
+			// No folder stored for this user. If they already have one under the built-in
+			// name, from before an administrator set a default, keep using it: applying the
+			// default here would start a second folder and leave their existing output behind.
+			$dataFolderName = $userFolder->nodeExists(Application::ASSISTANT_DATA_FOLDER_NAME)
+				? Application::ASSISTANT_DATA_FOLDER_NAME
+				: $defaultFolderName;
 		}
 		if ($userFolder->nodeExists($dataFolderName)) {
 			$dataFolderNode = $userFolder->get($dataFolderName);

--- a/lib/Service/AssistantService.php
+++ b/lib/Service/AssistantService.php
@@ -524,8 +524,14 @@ class AssistantService {
 	public function getAssistantDataFolder(string $userId): Folder {
 		$userFolder = $this->rootFolder->getUserFolder($userId);
 
-		$defaultFolderName = $this->appConfig->getValueString(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME, lazy: true) ?: Application::ASSISTANT_DATA_FOLDER_NAME;
-		$dataFolderName = $this->config->getUserValue($userId, Application::APP_ID, 'data_folder', $defaultFolderName) ?: $defaultFolderName;
+		$defaultFolderName = $this->appConfig->getValueString(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME, lazy: true);
+		if ($defaultFolderName === '') {
+			$defaultFolderName = Application::ASSISTANT_DATA_FOLDER_NAME;
+		}
+		$dataFolderName = $this->config->getUserValue($userId, Application::APP_ID, 'data_folder', $defaultFolderName);
+		if ($dataFolderName === '') {
+			$dataFolderName = $defaultFolderName;
+		}
 		if ($userFolder->nodeExists($dataFolderName)) {
 			$dataFolderNode = $userFolder->get($dataFolderName);
 			if ($dataFolderNode instanceof Folder && $dataFolderNode->isCreatable()) {

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -56,6 +56,7 @@ class Admin implements ISettings {
 		$chattyLLMUserInstructions = $this->appConfig->getValueString(Application::APP_ID, 'chat_user_instructions', Application::CHAT_USER_INSTRUCTIONS, lazy: true) ?: Application::CHAT_USER_INSTRUCTIONS;
 		$chattyLLMUserInstructionsTitle = $this->appConfig->getValueString(Application::APP_ID, 'chat_user_instructions_title', Application::CHAT_USER_INSTRUCTIONS_TITLE, lazy: true) ?: Application::CHAT_USER_INSTRUCTIONS_TITLE;
 		$chattyLLMLastNMessages = (int)$this->appConfig->getValueString(Application::APP_ID, 'chat_last_n_messages', '10', lazy: true);
+		$defaultDataFolder = $this->appConfig->getValueString(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME, lazy: true) ?: Application::ASSISTANT_DATA_FOLDER_NAME;
 
 		$globalSkillsConfig = $this->agentSkillsService->getGlobalSkillsConfig();
 
@@ -73,6 +74,7 @@ class Admin implements ISettings {
 			'chat_user_instructions' => $chattyLLMUserInstructions,
 			'chat_user_instructions_title' => $chattyLLMUserInstructionsTitle,
 			'chat_last_n_messages' => $chattyLLMLastNMessages,
+			'default_data_folder' => $defaultDataFolder,
 			'context_agent_available' => $contextAgentAvailable,
 			'global_skills_admin_uid' => $globalSkillsConfig['admin_uid'],
 			'global_skills_path' => $globalSkillsConfig['path'],

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -56,7 +56,10 @@ class Admin implements ISettings {
 		$chattyLLMUserInstructions = $this->appConfig->getValueString(Application::APP_ID, 'chat_user_instructions', Application::CHAT_USER_INSTRUCTIONS, lazy: true) ?: Application::CHAT_USER_INSTRUCTIONS;
 		$chattyLLMUserInstructionsTitle = $this->appConfig->getValueString(Application::APP_ID, 'chat_user_instructions_title', Application::CHAT_USER_INSTRUCTIONS_TITLE, lazy: true) ?: Application::CHAT_USER_INSTRUCTIONS_TITLE;
 		$chattyLLMLastNMessages = (int)$this->appConfig->getValueString(Application::APP_ID, 'chat_last_n_messages', '10', lazy: true);
-		$defaultDataFolder = $this->appConfig->getValueString(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME, lazy: true) ?: Application::ASSISTANT_DATA_FOLDER_NAME;
+		$defaultDataFolder = $this->appConfig->getValueString(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME, lazy: true);
+		if ($defaultDataFolder === '') {
+			$defaultDataFolder = Application::ASSISTANT_DATA_FOLDER_NAME;
+		}
 
 		$globalSkillsConfig = $this->agentSkillsService->getGlobalSkillsConfig();
 

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -48,7 +48,10 @@ class Personal implements ISettings {
 			|| (class_exists('OCP\\TaskProcessing\\TaskTypes\\ContextAgentAudioInteraction') && array_key_exists(\OCP\TaskProcessing\TaskTypes\ContextAgentAudioInteraction::ID, $availableTaskTypes));
 		$autoplayAudioChat = $this->config->getUserValue($this->userId, Application::APP_ID, 'autoplay_audio_chat', '1') === '1';
 		$dataFolder = $this->config->getUserValue($this->userId, Application::APP_ID, 'data_folder', '');
-		$defaultDataFolder = $this->appConfig->getValueString(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME, lazy: true) ?: Application::ASSISTANT_DATA_FOLDER_NAME;
+		$defaultDataFolder = $this->appConfig->getValueString(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME, lazy: true);
+		if ($defaultDataFolder === '') {
+			$defaultDataFolder = Application::ASSISTANT_DATA_FOLDER_NAME;
+		}
 
 		$assistantAvailable = $taskProcessingAvailable && $this->appConfig->getValueString(Application::APP_ID, 'assistant_enabled', '1', lazy: true) === '1';
 		$assistantEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'assistant_enabled', '1') === '1';

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -47,6 +47,8 @@ class Personal implements ISettings {
 		$audioChatAvailable = (class_exists('OCP\\TaskProcessing\\TaskTypes\\AudioToAudioChat') && array_key_exists(\OCP\TaskProcessing\TaskTypes\AudioToAudioChat::ID, $availableTaskTypes))
 			|| (class_exists('OCP\\TaskProcessing\\TaskTypes\\ContextAgentAudioInteraction') && array_key_exists(\OCP\TaskProcessing\TaskTypes\ContextAgentAudioInteraction::ID, $availableTaskTypes));
 		$autoplayAudioChat = $this->config->getUserValue($this->userId, Application::APP_ID, 'autoplay_audio_chat', '1') === '1';
+		$dataFolder = $this->config->getUserValue($this->userId, Application::APP_ID, 'data_folder', '');
+		$defaultDataFolder = $this->appConfig->getValueString(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME, lazy: true) ?: Application::ASSISTANT_DATA_FOLDER_NAME;
 
 		$assistantAvailable = $taskProcessingAvailable && $this->appConfig->getValueString(Application::APP_ID, 'assistant_enabled', '1', lazy: true) === '1';
 		$assistantEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'assistant_enabled', '1') === '1';
@@ -77,6 +79,8 @@ class Personal implements ISettings {
 			'speech_to_text_picker_enabled' => $speechToTextPickerEnabled,
 			'audio_chat_available' => $audioChatAvailable,
 			'autoplay_audio_chat' => $autoplayAudioChat,
+			'data_folder' => $dataFolder,
+			'default_data_folder' => $defaultDataFolder,
 		];
 		$this->initialStateService->provideInitialState('config', $userConfig);
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -292,9 +292,13 @@ export default {
 			this.saveOptions({ [key]: this.state[key] ? '1' : '0' })
 		},
 		delayedValueUpdate(newValue, key) {
+			// delay() shares one timer, so a second edit within the delay cancels the
+			// first callback: queue the value now rather than when the timer fires
+			this.optionsToSave[key] = newValue
 			delay(() => {
-				this.optionsToSave[key] = newValue
-				this.saveOptions(this.optionsToSave)
+				const values = { ...this.optionsToSave }
+				this.optionsToSave = {}
+				this.saveOptions(values)
 			}, 2000)
 		},
 		async onPickGlobalSkillsFolder() {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -118,6 +118,19 @@
 					</div>
 				</NcNoteCard>
 			</div>
+			<div class="data-folder">
+				<h4>
+					{{ t('assistant', 'Data folder') }}
+				</h4>
+				<NcNoteCard type="info">
+					{{ t('assistant', 'Name of the folder the assistant creates in the files of each user to store generated content. Users can override this in their personal settings. Changing it does not rename folders that already exist.') }}
+				</NcNoteCard>
+				<NcTextField id="default_data_folder"
+					v-model="state.default_data_folder"
+					class="text-field"
+					:label="t('assistant', 'Default data folder name')"
+					@update:model-value="delayedValueUpdate(state.default_data_folder, 'default_data_folder')" />
+			</div>
 			<div class="chat-with-ai">
 				<h4>
 					{{ t('assistant', 'Chat with AI') }}

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -58,6 +58,16 @@
 					{{ taskNames.join(', ') }}
 				</div>
 			</div>
+			<div class="data-folder">
+				<h3>{{ t('assistant', 'Data folder') }}</h3>
+				<p>{{ t('assistant', 'Where the assistant stores content it generates for you. Leave empty to use the name your administrator has set. Changing it does not move files that are already there.') }}</p>
+				<NcTextField id="data_folder"
+					v-model="state.data_folder"
+					class="data-folder__field"
+					:label="t('assistant', 'Folder name')"
+					:placeholder="state.default_data_folder"
+					@update:model-value="delayedValueUpdate(state.data_folder, 'data_folder')" />
+			</div>
 			<div v-if="rememberedConversations.length > 0">
 				<h3>{{ t('assistant', 'Remembered conversations') }}</h3>
 				<p>{{ t('assistant', 'The following conversations are remembered by the Assistant Chat and will be taken into account for every new conversation:') }}</p>
@@ -84,10 +94,12 @@ import NcFormBox from '@nextcloud/vue/components/NcFormBox'
 import NcFormBoxSwitch from '@nextcloud/vue/components/NcFormBoxSwitch'
 import NcFormBoxButton from '@nextcloud/vue/components/NcFormBoxButton'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
 
 import MemoryIcon from 'vue-material-design-icons/Memory.vue'
 
 import { loadState } from '@nextcloud/initial-state'
+import { delay } from '../utils.js'
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import { showSuccess, showError } from '@nextcloud/dialogs'
@@ -102,6 +114,7 @@ export default {
 		NcFormBoxSwitch,
 		NcFormBoxButton,
 		NcNoteCard,
+		NcTextField,
 		MemoryIcon,
 	},
 
@@ -112,6 +125,7 @@ export default {
 			state: loadState('assistant', 'config'),
 			providers: loadState('assistant', 'availableProviders'),
 			rememberedConversations: loadState('assistant', 'rememberedSessions'),
+			optionsToSave: {},
 		}
 	},
 
@@ -130,6 +144,12 @@ export default {
 	},
 
 	methods: {
+		delayedValueUpdate(newValue, key) {
+			delay(() => {
+				this.optionsToSave[key] = newValue
+				this.saveOptions(this.optionsToSave)
+			}, 2000)
+		},
 		onCheckboxChanged(newValue, key) {
 			this.state[key] = newValue
 			this.saveOptions({ [key]: this.state[key] ? '1' : '0' })

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -145,9 +145,13 @@ export default {
 
 	methods: {
 		delayedValueUpdate(newValue, key) {
+			// delay() shares one timer, so a second edit within the delay cancels the
+			// first callback: queue the value now rather than when the timer fires
+			this.optionsToSave[key] = newValue
 			delay(() => {
-				this.optionsToSave[key] = newValue
-				this.saveOptions(this.optionsToSave)
+				const values = { ...this.optionsToSave }
+				this.optionsToSave = {}
+				this.saveOptions(values)
 			}, 2000)
 		},
 		onCheckboxChanged(newValue, key) {


### PR DESCRIPTION
Fixes #631

### Summary

`Application::ASSISTANT_DATA_FOLDER_NAME` is a class constant, so a server whose users do not work in English has no supported way to give new accounts a localized name for the folder the assistant creates in their files.

The per-user `data_folder` setting does not fill the gap. When the configured folder does not exist yet, `getAssistantDataFolder()` falls through to `createAssistantDataFolder()`, which reads the constant rather than the configured name, and the caller then writes the created name back over the preference:

```php
$dataFolder = $this->createAssistantDataFolder($userId);
$dataFolderName = $dataFolder->getName();
$this->config->setUserValue($userId, Application::APP_ID, 'data_folder', $dataFolderName);
```

So `occ user:setting <uid> assistant data_folder Something` on a user who has not used the assistant yet creates `Assistant` and silently reverts the setting.

### What this changes

Resolve the default from an app config value, keeping the constant as the last resort, and pass the resolved name down so the creation path uses it:

```php
$defaultFolderName = $this->config->getAppValue(Application::APP_ID, 'default_data_folder', Application::ASSISTANT_DATA_FOLDER_NAME) ?: Application::ASSISTANT_DATA_FOLDER_NAME;
$dataFolderName = $this->config->getUserValue($userId, Application::APP_ID, 'data_folder', $defaultFolderName) ?: $defaultFolderName;
```

`createAssistantDataFolder()` now takes the base name instead of reading the constant, keeping its existing " 1", " 2" collision suffixes.

An administrator can then run:

```
occ config:app:set assistant default_data_folder --value="Bilge8"
```

This is the same shape Talk uses for its attachment folder (`default_attachment_folder` in `spreed/lib/Config.php`): an app-level default behind the per-user value.

### Behaviour

- A server that sets no app config behaves exactly as before.
- Users who already have a folder keep it, because the per-user value still wins and is written on first use.
- The per-user setting now works for a folder that does not exist yet, which it did not before.

### Testing

Running on Nextcloud 34 with the equivalent change against the bundled version, on a server with several thousand accounts. New accounts get the configured folder name, existing accounts keep theirs, and unsetting the app config restores the previous behaviour.

`php-cs-fixer` and `psalm` are clean for the changed file.
