### PR TITLE
Fix: correctly order messages when getting the system prompt one

### DIFF
--- a/lib/Db/ChattyLLM/MessageMapper.php
+++ b/lib/Db/ChattyLLM/MessageMapper.php
@@ -27,17 +27,22 @@ class MessageMapper extends QBMapper {
 	/**
 	 * @param integer $sessionId
 	 * @param integer $n
+	 * @param string|null $role
 	 * @return Message
 	 * @throws \OCP\DB\Exception
 	 * @throws \RuntimeException
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 */
-	public function getFirstNMessages(int $sessionId, int $n = 1): Message {
+	public function getFirstNMessages(int $sessionId, int $n = 1, ?string $role = null): Message {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select(Message::$columns)
 			->from($this->getTableName())
-			->where($qb->expr()->eq('session_id', $qb->createPositionalParameter($sessionId, IQueryBuilder::PARAM_INT)))
+			->where($qb->expr()->eq('session_id', $qb->createPositionalParameter($sessionId, IQueryBuilder::PARAM_INT)));
+		if ($role !== null) {
+			$qb->andWhere($qb->expr()->eq('role', $qb->createPositionalParameter($role, IQueryBuilder::PARAM_STR)));
+		}
+		$qb->orderBy('timestamp', 'ASC')
 			->setMaxResults($n);
 
 		return $this->findEntity($qb);

--- a/lib/Service/ChatService.php
+++ b/lib/Service/ChatService.php
@@ -415,14 +415,12 @@ class ChatService {
 			// classic chat
 			$systemPrompt = '';
 			try {
-				$firstMessage = $this->messageMapper->getFirstNMessages($sessionId, 1);
+				$firstMessage = $this->messageMapper->getFirstNMessages($sessionId, 1, Message::ROLE_SYSTEM);
+				$systemPrompt = $firstMessage->getContent();
 			} catch (DoesNotExistException $e) {
-				throw new NotFoundException($this->l10n->t('No message found in this session'), previous: $e);
+				$this->logger->info('No system message found in the session', ['exception' => $e, 'sessionId' => $sessionId]);
 			} catch (MultipleObjectsReturnedException|Exception $e) {
 				throw new InternalException(previous: $e);
-			}
-			if ($firstMessage->getRole() === Message::ROLE_SYSTEM) {
-				$systemPrompt = $firstMessage->getContent();
 			}
 			try {
 				$history = $this->getRawLastMessages($sessionId);


### PR DESCRIPTION
closes #625

And improve the related query by applying a role filter.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
