### PR TITLE
Add UI for Context Chat Multi: batch question input and output

### DIFF
--- a/src/components/AssistantFormInputs.vue
+++ b/src/components/AssistantFormInputs.vue
@@ -7,6 +7,11 @@
 		:inputs="inputs"
 		:task-type="selectedTaskType"
 		@update:inputs="$emit('update:inputs', $event)" />
+	<ContextChatMultiInputForm v-else-if="selectedTaskTypeId === 'context_chat:context_chat_multi'"
+		:inputs="inputs"
+		:task-type="selectedTaskType"
+		@update:inputs="$emit('update:inputs', $event)" />
+
 	<div v-else class="assistant-inputs">
 		<div class="input-container">
 			<TaskTypeFields
@@ -29,12 +34,14 @@
 <script>
 import ContextChatInputForm from './ContextChat/ContextChatInputForm.vue'
 import TaskTypeFields from './fields/TaskTypeFields.vue'
+import ContextChatMultiInputForm from './ContextChat/ContextChatMultiInputForm.vue'
 
 export default {
 	name: 'AssistantFormInputs',
 	components: {
 		ContextChatInputForm,
 		TaskTypeFields,
+		ContextChatMultiInputForm,
 	},
 	props: {
 		inputs: {

--- a/src/components/AssistantFormOutputs.vue
+++ b/src/components/AssistantFormOutputs.vue
@@ -12,6 +12,10 @@
 			class="output-fields"
 			:output-shape="selectedTaskType.outputShape"
 			:output="outputs" />
+		<ContextChatMultiOutputForm v-else-if="selectedTaskTypeId === 'context_chat:context_chat_multi'"
+			class="output-fields"
+			:output-shape="selectedTaskType.outputShape"
+			:output="outputs" />
 		<TaskTypeFields v-else
 			class="output-fields"
 			:is-output="true"
@@ -44,6 +48,7 @@ import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import ContextChatOutputForm from './ContextChat/ContextChatOutputForm.vue'
 import ContextChatSearchOutputForm from './ContextChat/ContextChatSearchOutputForm.vue'
 import TaskTypeFields from './fields/TaskTypeFields.vue'
+import ContextChatMultiOutputForm from './ContextChat/ContextChatMultiOutputForm.vue'
 
 export default {
 	name: 'AssistantFormOutputs',
@@ -53,6 +58,7 @@ export default {
 		ContextChatSearchOutputForm,
 		TaskTypeFields,
 		NcNoteCard,
+		ContextChatMultiOutputForm,
 	},
 
 	props: {

--- a/src/components/ContextChat/ContextChatMultiInputForm.vue
+++ b/src/components/ContextChat/ContextChatMultiInputForm.vue
@@ -288,7 +288,7 @@ export default {
 			this.onTaskTypeChange()
 		},
 		inputs(newValue) {
-			if (Object.keys(newValue).length === 0) {
+			if (!newValue.questions) {
 				this.onInputsReset()
 			}
 		},

--- a/src/components/ContextChat/ContextChatMultiInputForm.vue
+++ b/src/components/ContextChat/ContextChatMultiInputForm.vue
@@ -46,7 +46,7 @@
 				</template>
 			</NcButton>
 			<NcNoteCard v-if="atMaxQuestions" type="warning">
-				{{ t('assistant', 'You can ask up to {max} questions at once.', { max: MAX_QUESTIONS }) }}
+				{{ t('assistant', 'You can ask up to {max} questions at once.', { max: taskType.inputShapeDefaults?.maxQuestions ?? 20 }) }}
 			</NcNoteCard>
 		</div>
 		<NcCheckboxRadioSwitch v-model="sccEnabled" @update:model-value="onUpdateSccEnabled">
@@ -181,11 +181,6 @@ const _ScopeType = Object.freeze({
 	PROVIDER: 'provider',
 })
 
-// Keep in sync with MAX_MULTI_QUESTIONS in
-// context_chat_backend/controller.py and task_fetcher.py — any question
-// beyond this count is silently dropped by the backend, so the UI must
-// not let the person add more than this.
-const MAX_QUESTIONS = 20
 
 const _tStrings = {
 	[_ScopeType.SOURCE]: t('assistant', 'Select Files/Folders'),
@@ -264,8 +259,6 @@ export default {
 		return {
 			ScopeType: _ScopeType,
 			tStrings: _tStrings,
-			MAX_QUESTIONS,
-
 			providerOptions: [],
 			providersLoading: false,
 			defaultProviderKey: 'files__default',
@@ -277,7 +270,7 @@ export default {
 
 	computed: {
 		atMaxQuestions() {
-			return (this.inputs.questions?.length ?? 0) >= MAX_QUESTIONS
+			return (this.inputs.questions?.length ?? 0) >= (this.taskType.inputShapeDefaults?.maxQuestions ?? 20)
 		},
 		scopeListMetaArray() {
 			if (!this.inputs.scopeListMeta) {

--- a/src/components/ContextChat/ContextChatMultiInputForm.vue
+++ b/src/components/ContextChat/ContextChatMultiInputForm.vue
@@ -181,7 +181,6 @@ const _ScopeType = Object.freeze({
 	PROVIDER: 'provider',
 })
 
-
 const _tStrings = {
 	[_ScopeType.SOURCE]: t('assistant', 'Select Files/Folders'),
 	[_ScopeType.PROVIDER]: t('assistant', 'Select Providers'),

--- a/src/components/ContextChat/ContextChatMultiInputForm.vue
+++ b/src/components/ContextChat/ContextChatMultiInputForm.vue
@@ -38,11 +38,16 @@
 			<NcButton
 				class="more-button"
 				variant="secondary"
+				:disabled="atMaxQuestions"
+				:title="atMaxQuestions ? t('assistant', 'Maximum number of questions reached') : ''"
 				@click="onAddQuestion">
 				<template #icon>
 					<PlusIcon />
 				</template>
 			</NcButton>
+			<NcNoteCard v-if="atMaxQuestions" type="warning">
+				{{ t('assistant', 'You can ask up to {max} questions at once.', { max: MAX_QUESTIONS }) }}
+			</NcNoteCard>
 		</div>
 		<NcCheckboxRadioSwitch v-model="sccEnabled" @update:model-value="onUpdateSccEnabled">
 			{{ t('assistant', 'Selective context') }}
@@ -178,6 +183,12 @@ const _ScopeType = Object.freeze({
 	PROVIDER: 'provider',
 })
 
+// Keep in sync with MAX_MULTI_QUESTIONS in
+// context_chat_backend/controller.py and task_fetcher.py — any question
+// beyond this count is silently dropped by the backend, so the UI must
+// not let the person add more than this.
+const MAX_QUESTIONS = 20
+
 const _tStrings = {
 	[_ScopeType.SOURCE]: t('assistant', 'Select Files/Folders'),
 	[_ScopeType.PROVIDER]: t('assistant', 'Select Providers'),
@@ -255,6 +266,7 @@ export default {
 		return {
 			ScopeType: _ScopeType,
 			tStrings: _tStrings,
+			MAX_QUESTIONS,
 
 			providerOptions: [],
 			providersLoading: false,
@@ -266,6 +278,9 @@ export default {
 	},
 
 	computed: {
+		atMaxQuestions() {
+			return (this.inputs.questions?.length ?? 0) >= MAX_QUESTIONS
+		},
 		scopeListMetaArray() {
 			if (!this.inputs.scopeListMeta) {
 				return []
@@ -379,6 +394,9 @@ export default {
 			this.onInputsChanged({ questions: newQuestions })
 		},
 		onAddQuestion() {
+			if (this.atMaxQuestions) {
+				return
+			}
 			const newQuestions = [...(this.inputs.questions ?? []), '']
 			this.onInputsChanged({ questions: newQuestions })
 		},

--- a/src/components/ContextChat/ContextChatMultiInputForm.vue
+++ b/src/components/ContextChat/ContextChatMultiInputForm.vue
@@ -175,8 +175,6 @@ import { getFilePickerBuilder, showError } from '@nextcloud/dialogs'
 import { generateUrl } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
 
-// Kept identical to ContextChatInputForm.vue's ScopeType so the two
-// components stay compatible with the same backend scope contract.
 const _ScopeType = Object.freeze({
 	NONE: 'none',
 	SOURCE: 'source',
@@ -336,6 +334,7 @@ export default {
 			return this.scopeListMetaArray.some((item) => item.id === scopeId)
 		},
 		chooseDialogCallback(nodes) {
+			console.debug('nodes:', nodes)
 			const addedScopeListMeta = []
 			for (const node of nodes) {
 				const scopeId = `${this.defaultProviderKey}: ${node.fileid}`
@@ -385,8 +384,8 @@ export default {
 		},
 		onDeleteQuestion(i) {
 			const questions = this.inputs.questions ?? []
-			// always keep at least one (possibly empty) question field visible
-			if (questions.length <= 1) {
+			// always keep at least two (possibly empty) question field visible
+			if (questions.length <= 2) {
 				return
 			}
 			const newQuestions = questions.slice()

--- a/src/components/ContextChat/ContextChatMultiInputForm.vue
+++ b/src/components/ContextChat/ContextChatMultiInputForm.vue
@@ -1,0 +1,525 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="cc-input-form">
+		<NcNoteCard v-if="!indexingComplete" type="warning">
+			{{ t('assistant', 'Context Chat has not finished indexing all your documents yet, it may not be able to answer your questions, yet.') }}
+		</NcNoteCard>
+		<div class="questions-field">
+			<label :title="taskType.inputShape?.questions?.name">
+				{{ taskType.inputShape?.questions?.description }}
+			</label>
+			<div class="questions-field--items">
+				<div v-for="(question, i) in inputs.questions"
+					:key="'question-' + i"
+					class="questions-field--items--item">
+					<TextInput
+						:id="'context_chat_multi_question-input-' + i"
+						class="text-input"
+						:value="question ?? ''"
+						:is-output="false"
+						:show-choose-button="false"
+						:placeholder="taskType.inputShape?.questions?.description"
+						:title="taskType.inputShape?.questions?.name"
+						@update:value="onQuestionChanged(i, $event)" />
+					<NcButton
+						class="delete-button"
+						variant="secondary"
+						:disabled="inputs.questions?.length <= 1"
+						@click="onDeleteQuestion(i)">
+						<template #icon>
+							<TrashCanOutlineIcon />
+						</template>
+					</NcButton>
+				</div>
+			</div>
+			<NcButton
+				class="more-button"
+				variant="secondary"
+				@click="onAddQuestion">
+				<template #icon>
+					<PlusIcon />
+				</template>
+			</NcButton>
+		</div>
+		<NcCheckboxRadioSwitch v-model="sccEnabled" @update:model-value="onUpdateSccEnabled">
+			{{ t('assistant', 'Selective context') }}
+		</NcCheckboxRadioSwitch>
+		<div v-if="sccEnabled" class="line spaced">
+			<div class="radios">
+				<NcCheckboxRadioSwitch
+					type="radio"
+					:model-value="inputs.scopeType"
+					:value="ScopeType.SOURCE"
+					:button-variant="true"
+					button-variant-grouped="horizontal"
+					name="scopeType"
+					@update:model-value="onScopeTypeChanged(ScopeType.SOURCE)">
+					{{ tStrings[ScopeType.SOURCE] }}
+				</NcCheckboxRadioSwitch>
+				<NcCheckboxRadioSwitch
+					type="radio"
+					:model-value="inputs.scopeType"
+					:value="ScopeType.PROVIDER"
+					:button-variant="true"
+					button-variant-grouped="horizontal"
+					name="scopeType"
+					@update:model-value="onScopeTypeChanged(ScopeType.PROVIDER)">
+					{{ tStrings[ScopeType.PROVIDER] }}
+				</NcCheckboxRadioSwitch>
+			</div>
+			<NcButton
+				variant="secondary"
+				:disabled="scopeListMetaArray.length === 0"
+				@click="onInputsChanged({ scopeListMeta: '[]'})">
+				<template #icon>
+					<PlaylistRemoveIcon />
+				</template>
+				{{ tStrings['Clear Selection'] }}
+			</NcButton>
+		</div>
+		<div v-if="sccEnabled" class="selector-form">
+			<div v-if="inputs.scopeType === ScopeType.SOURCE" class="sources-form">
+				<NcButton
+					variant="secondary"
+					@click="onChooseSourceClicked">
+					<template #icon>
+						<FileDocumentOutlineIcon />
+					</template>
+					{{ tStrings['Choose Files/Folders'] }}
+				</NcButton>
+				<NcSelect v-if="scopeListMetaArray.length > 0"
+					:model-value="scopeListMetaArray"
+					class="line"
+					:placeholder="tStrings[ScopeType.SOURCE]"
+					:multiple="true"
+					:close-on-select="false"
+					:dropdown-should-open="() => false"
+					:label-outside="true"
+					:no-wrap="false"
+					@update:model-value="onScopeListChange">
+					<template #selected-option="option">
+						<NcAvatar
+							:size="24"
+							:url="getFilePreviewUrl(option.type === 'file' ? option.id : null)"
+							:display-name="option.label" />
+						<span class="multiselect-name">
+							{{ option.label }}
+						</span>
+					</template>
+				</NcSelect>
+			</div>
+			<div v-else class="providers-form">
+				<NcSelect
+					:model-value="scopeListMetaArray"
+					:placeholder="tStrings[ScopeType.PROVIDER]"
+					:multiple="true"
+					:close-on-select="false"
+					:no-wrap="false"
+					:loading="providersLoading"
+					:label-outside="true"
+					:append-to-body="false"
+					:options="providerOptions"
+					@update:model-value="onScopeListChange">
+					<template #option="option">
+						<div class="select-option">
+							<NcAvatar
+								:size="24"
+								:url="option.icon"
+								:display-name="option.label" />
+							<span class="multiselect-name">
+								{{ option.label }}
+							</span>
+						</div>
+					</template>
+					<template #selected-option="option">
+						<div class="select-option">
+							<NcAvatar
+								:size="24"
+								:url="option.icon"
+								:display-name="option.label" />
+							<span class="multiselect-name">
+								{{ option.label }}
+							</span>
+						</div>
+					</template>
+				</NcSelect>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
+import PlaylistRemoveIcon from 'vue-material-design-icons/PlaylistRemove.vue'
+import PlusIcon from 'vue-material-design-icons/Plus.vue'
+import TrashCanOutlineIcon from 'vue-material-design-icons/TrashCanOutline.vue'
+
+import NcAvatar from '@nextcloud/vue/components/NcAvatar'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+import NcSelect from '@nextcloud/vue/components/NcSelect'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+
+import TextInput from '../fields/TextInput.vue'
+
+import axios from '@nextcloud/axios'
+import { getFilePickerBuilder, showError } from '@nextcloud/dialogs'
+import { generateUrl } from '@nextcloud/router'
+import { loadState } from '@nextcloud/initial-state'
+
+// Kept identical to ContextChatInputForm.vue's ScopeType so the two
+// components stay compatible with the same backend scope contract.
+const _ScopeType = Object.freeze({
+	NONE: 'none',
+	SOURCE: 'source',
+	PROVIDER: 'provider',
+})
+
+const _tStrings = {
+	[_ScopeType.SOURCE]: t('assistant', 'Select Files/Folders'),
+	[_ScopeType.PROVIDER]: t('assistant', 'Select Providers'),
+	'Choose Files/Folders': t('assistant', 'Choose Files/Folders'),
+	Choose: t('assistant', 'Choose'),
+	'Clear Selection': t('assistant', 'Clear Selection'),
+}
+
+const SUPPORTED_MIMETYPES = [
+	'text/plain',
+	'text/markdown',
+	'application/json',
+	'application/pdf',
+	'text/csv',
+	'application/epub+zip',
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+	'application/vnd.ms-powerpoint',
+	'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+	'application/vnd.oasis.opendocument.spreadsheet',
+	'application/vnd.ms-excel.sheet.macroEnabled.12',
+	'application/vnd.oasis.opendocument.text',
+	'text/rtf',
+	'text/x-rst',
+	'application/xml',
+	'message/rfc822',
+	'application/vnd.ms-outlook',
+	'text/org',
+	// folders
+	'httpd/unix-directory',
+]
+
+const picker = (callback) => getFilePickerBuilder(_tStrings[_ScopeType.SOURCE])
+	.setMimeTypeFilter(SUPPORTED_MIMETYPES)
+	.setMultiSelect(true)
+	.allowDirectories(true)
+	.addButton({
+		id: 'choose-ff',
+		label: _tStrings.Choose,
+		variant: 'primary',
+		callback,
+	})
+	.build()
+
+export default {
+	name: 'ContextChatMultiInputForm',
+
+	components: {
+		TextInput,
+		FileDocumentOutlineIcon,
+		NcAvatar,
+		NcButton,
+		NcCheckboxRadioSwitch,
+		NcSelect,
+		PlaylistRemoveIcon,
+		PlusIcon,
+		TrashCanOutlineIcon,
+		NcNoteCard,
+	},
+
+	props: {
+		inputs: {
+			type: Object,
+			required: true,
+		},
+		taskType: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	emits: ['update:inputs'],
+
+	data() {
+		return {
+			ScopeType: _ScopeType,
+			tStrings: _tStrings,
+
+			providerOptions: [],
+			providersLoading: false,
+			defaultProviderKey: 'files__default',
+
+			sccEnabled: !!this.inputs.scopeType && this.inputs.scopeType !== _ScopeType.NONE && !!this.inputs.scopeList,
+			indexingComplete: loadState('assistant', 'contextChatIndexingComplete', false),
+		}
+	},
+
+	computed: {
+		scopeListMetaArray() {
+			if (!this.inputs.scopeListMeta) {
+				return []
+			}
+			try {
+				return JSON.parse(this.inputs.scopeListMeta)
+			} catch (error) {
+				console.error('failed to parse scopeListMeta', error)
+				return []
+			}
+		},
+	},
+	watch: {
+		taskType(newValue) {
+			this.onTaskTypeChange()
+		},
+		inputs(newValue) {
+			if (Object.keys(newValue).length === 0) {
+				this.onInputsReset()
+			}
+		},
+	},
+
+	mounted() {
+		const defaultProviderUrl = generateUrl('/apps/context_chat/default-provider-key')
+		axios.get(defaultProviderUrl)
+			.then((response) => {
+				this.defaultProviderKey = response.data
+					? response.data
+					: this.defaultProviderKey
+			})
+			.catch((error) => {
+				console.error('Error fetching default provider key:', error)
+				showError(t('assistant', 'Error fetching default provider key'))
+			})
+
+		// initialize each input if necessary
+		this.$nextTick(() => {
+			this.$emit('update:inputs', {
+				questions: this.inputs.questions?.length > 0 ? this.inputs.questions : [''],
+				scopeType: this.inputs.scopeType ?? _ScopeType.NONE,
+				scopeList: this.inputs.scopeList ?? [],
+				scopeListMeta: this.inputs.scopeListMeta ?? '[]',
+			})
+		})
+	},
+
+	methods: {
+		onChooseSourceClicked() {
+			picker(this.chooseDialogCallback).pick()
+		},
+		isScopePresent(scopeId) {
+			return this.scopeListMetaArray.some((item) => item.id === scopeId)
+		},
+		chooseDialogCallback(nodes) {
+			const addedScopeListMeta = []
+			for (const node of nodes) {
+				const scopeId = `${this.defaultProviderKey}: ${node.fileid}`
+				if (node.path && !this.isScopePresent(scopeId)) {
+					addedScopeListMeta.push({
+						id: scopeId,
+						type: node.type,
+						label: (node.path?.substring(0, 100) + (node.path.length > 100 ? '...' : '')) || node.name,
+						isNoUser: true,
+					})
+				}
+			}
+
+			const newScopeListMetaArray = this.scopeListMetaArray.concat(addedScopeListMeta)
+			this.onInputsChanged({
+				scopeListMeta: JSON.stringify(newScopeListMetaArray),
+				scopeList: newScopeListMetaArray.map(item => item.id),
+			})
+		},
+		fetchProviders() {
+			this.providersLoading = true
+			axios.get(generateUrl('/apps/context_chat/providers'))
+				.then((response) => {
+					this.providerOptions = response.data
+				})
+				.catch((error) => {
+					console.error('Error fetching providers:', error)
+					showError(t('assistant', 'Error fetching providers'))
+				})
+				.finally(() => {
+					this.providersLoading = false
+				})
+		},
+		getFilePreviewUrl(fileId) {
+			if (fileId == null) {
+				return generateUrl('/apps/theming/img/core/filetypes/folder.svg')
+			}
+			return generateUrl(
+				'/apps/assistant/preview?id={fileId}&x=24&y=24',
+				{ fileId: fileId.substring(`${this.defaultProviderKey}: `.length) },
+			)
+		},
+		onQuestionChanged(i, value) {
+			const newQuestions = (this.inputs.questions ?? []).slice()
+			newQuestions[i] = value
+			this.onInputsChanged({ questions: newQuestions })
+		},
+		onDeleteQuestion(i) {
+			const questions = this.inputs.questions ?? []
+			// always keep at least one (possibly empty) question field visible
+			if (questions.length <= 1) {
+				return
+			}
+			const newQuestions = questions.slice()
+			newQuestions.splice(i, 1)
+			this.onInputsChanged({ questions: newQuestions })
+		},
+		onAddQuestion() {
+			const newQuestions = [...(this.inputs.questions ?? []), '']
+			this.onInputsChanged({ questions: newQuestions })
+		},
+		onUpdateSccEnabled(enabled) {
+			this.$emit('update:inputs', {
+				questions: this.inputs.questions,
+				scopeType: enabled ? _ScopeType.SOURCE : _ScopeType.NONE,
+				scopeList: [],
+				scopeListMeta: '[]',
+			})
+		},
+		onScopeTypeChanged(value) {
+			if (value === this.ScopeType.PROVIDER && this.providerOptions.length === 0) {
+				this.fetchProviders()
+			}
+
+			this.onInputsChanged({
+				scopeType: value,
+				scopeList: [],
+				scopeListMeta: '[]',
+			})
+		},
+		onScopeListChange(value) {
+			try {
+				this.onInputsChanged({ scopeList: value.map(v => v.id), scopeListMeta: JSON.stringify(value) })
+			} catch (error) {
+				console.error('Failed to change scopeListMeta', error)
+			}
+		},
+		onInputsChanged(changedInputs) {
+			this.$emit('update:inputs', {
+				...this.inputs,
+				...changedInputs,
+			})
+		},
+		onTaskTypeChange() {
+			this.reinitializeInputs()
+		},
+		onInputsReset() {
+			this.reinitializeInputs()
+		},
+		reinitializeInputs() {
+			this.$emit('update:inputs', {
+				questions: [''],
+				scopeType: _ScopeType.NONE,
+				scopeList: [],
+				scopeListMeta: '[]',
+			})
+			this.sccEnabled = false
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.cc-input-form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+
+	.line {
+		display: flex;
+		flex-direction: row;
+		align-items: start;
+		margin-top: 8px;
+		width: 100%;
+	}
+
+	.spaced {
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.radios {
+		display: flex;
+
+		:deep(.checkbox-radio-switch__text) {
+			flex: unset !important;
+		}
+	}
+
+	.selector-form {
+		margin-top: 16px;
+		:deep(.avatardiv) {
+			border-radius: 50%;
+
+			&> img {
+				border-radius: 0 !important;
+			}
+		}
+
+		.providers-form {
+			.v-select {
+				min-width: 400px;
+			}
+
+			:deep(.avatardiv > img) {
+				filter: var(--background-invert-if-dark) !important;
+			}
+		}
+
+		.sources-form {
+			min-width: 400px;
+
+			:deep(.vs__actions) {
+				display: none !important;
+			}
+		}
+	}
+
+	.select-option {
+		display: flex;
+		align-items: center;
+	}
+
+	.multiselect-name {
+		margin-left: 8px;
+	}
+}
+
+// Mirrors ListOfTextsField.vue's structure/naming, since this replaces
+// that generic component for the questions field specifically.
+.questions-field {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+
+	&--items {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+
+		&--item {
+			display: flex;
+			gap: 4px;
+			align-items: end;
+
+			.text-input {
+				flex-grow: 1;
+			}
+		}
+	}
+}
+</style>

--- a/src/components/ContextChat/ContextChatMultiInputForm.vue
+++ b/src/components/ContextChat/ContextChatMultiInputForm.vue
@@ -27,7 +27,7 @@
 					<NcButton
 						class="delete-button"
 						variant="secondary"
-						:disabled="inputs.questions?.length <= 1"
+						:disabled="inputs.questions?.length <= 2"
 						@click="onDeleteQuestion(i)">
 						<template #icon>
 							<TrashCanOutlineIcon />
@@ -318,7 +318,7 @@ export default {
 		// initialize each input if necessary
 		this.$nextTick(() => {
 			this.$emit('update:inputs', {
-				questions: this.inputs.questions?.length > 0 ? this.inputs.questions : [''],
+				questions: this.inputs.questions?.length > 0 ? this.inputs.questions : ['', ''],
 				scopeType: this.inputs.scopeType ?? _ScopeType.NONE,
 				scopeList: this.inputs.scopeList ?? [],
 				scopeListMeta: this.inputs.scopeListMeta ?? '[]',
@@ -439,7 +439,7 @@ export default {
 		},
 		reinitializeInputs() {
 			this.$emit('update:inputs', {
-				questions: [''],
+				questions: ['', ''],
 				scopeType: _ScopeType.NONE,
 				scopeList: [],
 				scopeListMeta: '[]',

--- a/src/components/ContextChat/ContextChatMultiOutputForm.vue
+++ b/src/components/ContextChat/ContextChatMultiOutputForm.vue
@@ -1,0 +1,171 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="cc-multi-output">
+		<div v-for="(block, i) in qaBlocks"
+			:key="'qa-block-' + i"
+			class="cc-multi-output__block">
+			<p class="cc-multi-output__block__question">
+				{{ block.question }}
+			</p>
+			<TextInput
+				:id="'context_chat_multi_answer-' + i"
+				class="cc-multi-output__block__answer"
+				:value="block.answer"
+				:is-output="true"
+				:show-choose-button="false" />
+			<div class="cc-multi-output__block__sources">
+				<label for="v-select" class="cc-multi-output__block__sources__label">
+					{{ outputShape.sources.description }}
+				</label>
+				<NcSelect
+					:model-value="block.sources"
+					:placeholder="t('assistant', 'No sources referenced')"
+					:multiple="true"
+					:close-on-select="false"
+					:no-wrap="false"
+					:label-outside="true"
+					:append-to-body="false"
+					:dropdown-should-open="() => false">
+					<template #option="option">
+						<a class="select-option" :href="option.url" target="_blank">
+							<NcAvatar
+								:size="24"
+								:url="option.icon"
+								:display-name="option.label" />
+							<span class="multiselect-name">
+								{{ option.label }}
+							</span>
+						</a>
+					</template>
+					<template #selected-option="option">
+						<a class="select-option" :href="option.url" target="_blank">
+							<NcAvatar
+								:size="24"
+								:url="option.icon"
+								:display-name="option.label" />
+							<span class="multiselect-name">
+								{{ option.label }}
+							</span>
+						</a>
+					</template>
+				</NcSelect>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import NcAvatar from '@nextcloud/vue/components/NcAvatar'
+import NcSelect from '@nextcloud/vue/components/NcSelect'
+
+import TextInput from '../fields/TextInput.vue'
+
+export default {
+	name: 'ContextChatMultiOutputForm',
+
+	components: {
+		NcAvatar,
+		NcSelect,
+		TextInput,
+	},
+
+	props: {
+		outputShape: {
+			type: Object,
+			required: true,
+		},
+		output: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	computed: {
+		// questions/answers/sources are three parallel lists (same order,
+		// same length, as declared in the backend's output_shape): each
+		// sources[i] entry is a JSON-encoded array of the sources used for
+		// questions[i]/answers[i]. Zip them into one block per question.
+		qaBlocks() {
+			const questions = this.output?.questions ?? []
+			const answers = this.output?.answers ?? []
+			const rawSources = this.output?.sources ?? []
+			return questions.map((question, i) => {
+				let sources = []
+				try {
+					sources = rawSources[i] ? JSON.parse(rawSources[i]) : []
+				} catch (e) {
+					console.error('Failed to parse sources for question', i, e)
+				}
+				return {
+					question,
+					answer: answers[i] ?? '',
+					sources,
+				}
+			})
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.cc-multi-output {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	width: 100%;
+
+	&__block {
+		display: flex;
+		flex-direction: column;
+		align-items: start;
+		gap: 8px;
+		width: 100%;
+
+		&__question {
+			font-weight: bold;
+			margin: 0;
+		}
+
+		&__answer {
+			width: 100%;
+		}
+
+		&__sources {
+			display: flex;
+			flex-direction: column;
+
+			:deep(.v-select) {
+				min-width: 400px !important;
+
+				> div {
+					border: 2px solid var(--color-primary-element) !important;
+				}
+
+				.avatardiv {
+					border-radius: 50%;
+
+					&> img {
+						border-radius: 0 !important;
+					}
+				}
+
+				.vs__actions {
+					display: none !important;
+				}
+			}
+
+			.select-option {
+				display: flex;
+				align-items: center;
+			}
+
+			.multiselect-name {
+				margin-left: 8px;
+			}
+		}
+	}
+}
+</style>

--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -181,6 +181,13 @@ export default {
 					const nbGeneratedImages = this.task.output?.length ?? 0
 					return n('assistant', '{n} image generated', '{n} images generated', nbGeneratedImages, { n: nbGeneratedImages })
 				}
+				if (this.task.type === 'context_chat:context_chat_multi') {
+					const questions = this.task.input.questions ?? []
+					const extraCount = questions.length - 1
+					return extraCount > 0
+						? n('assistant', '+{extraCount} more question', '+{extraCount} more questions', extraCount, { extraCount })
+						: ''
+				}
 				return this.textOutputPreview
 			} else if (this.task.status === TASK_STATUS_STRING.scheduled) {
 				if (this.isText2Image) {
@@ -203,6 +210,10 @@ export default {
 			return statusTitles[this.task.status] ?? t('assistant', 'Unknown status')
 		},
 		textInputPreview() {
+			if (this.task.type === 'context_chat:context_chat_multi') {
+				const questions = this.task.input.questions ?? []
+				return questions.length > 0 ? questions[0] : ''
+			}
 			const textInputs = []
 			Object.keys(this.taskType.inputShape).forEach(key => {
 				const field = this.taskType.inputShape[key]


### PR DESCRIPTION
UI implementation for #637.

## Problem

Context Chat currently answers one question per task. For workflows that need answers to a fixed batch of related questions against the same knowledge base, this means submitting each question as a separate task and manually reassembling the results.

## Solution

Adds the Assistant UI for the new "Context Chat Multi" task type (backend: nextcloud/context_chat_backend#351). Users can add/remove question fields (currently capped at 20, read from the backend's configured limit rather than hardcoded), and the output shows one block per question with its answer and sources, reusing existing output components where possible.

## Changes

- `src/components/ContextChat/ContextChatMultiInputForm.vue`: new input form, add/remove question fields, starts with the 2-question minimum
- `src/components/ContextChat/ContextChatMultiOutputForm.vue`: new output form, one block per question (question, answer, sources)
- `src/components/AssistantFormInputs.vue` / `AssistantFormOutputs.vue`: register the new components for the Multi task type
- `src/components/TaskListItem.vue`: show the first question and remaining count in the task list sidebar for Multi tasks

## Testing

Tested end-to-end on a real Nextcloud instance with the companion backend branch: submitted a batch of questions against real indexed documents and confirmed the UI returns correctly answered, source-attributed results for each question.

## Companion PR

This is the UI half of the feature. Backend: nextcloud/context_chat_backend#351

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
